### PR TITLE
fix(platform): avoid bluetooth polling process leak

### DIFF
--- a/platform/src/daemon/PlatformServer.cpp
+++ b/platform/src/daemon/PlatformServer.cpp
@@ -805,9 +805,26 @@ void PlatformServer::runNetworkRefresh(QLocalSocket *socket,
 void PlatformServer::runBluetoothList(QLocalSocket *socket, const QJsonObject &request)
 {
     const QPointer<QLocalSocket> guardedSocket(socket);
+
+    // bluetoothctl waits for BlueZ activation when no controller exists. On
+    // controller-less desktops that means every periodic status refresh leaves
+    // another process and three pipe descriptors behind indefinitely. Avoid
+    // spawning it at all in the common no-hardware case; --timeout below is a
+    // second guard for unavailable or wedged BlueZ daemons.
+    const QDir bluetoothClass(QStringLiteral("/sys/class/bluetooth"));
+    if (!bluetoothClass.exists()
+        || bluetoothClass.entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty()) {
+        respond(guardedSocket.data(), request, true,
+                QJsonObject{{QStringLiteral("available"), false},
+                            {QStringLiteral("powered"), false},
+                            {QStringLiteral("devices"), QJsonArray{}}});
+        return;
+    }
+
     auto *show = new QProcess(this);
     show->setProgram(QStringLiteral("bluetoothctl"));
-    show->setArguments({QStringLiteral("show")});
+    show->setArguments({QStringLiteral("--timeout"), QStringLiteral("2"),
+                        QStringLiteral("show")});
     connect(show, &QProcess::finished, this,
             [this, guardedSocket, request, show](int showExit, QProcess::ExitStatus) {
         const QByteArray controller = show->readAllStandardOutput();
@@ -819,7 +836,8 @@ void PlatformServer::runBluetoothList(QLocalSocket *socket, const QJsonObject &r
         }
         auto *devices = new QProcess(this);
         devices->setProgram(QStringLiteral("bluetoothctl"));
-        devices->setArguments({QStringLiteral("devices")});
+        devices->setArguments({QStringLiteral("--timeout"), QStringLiteral("2"),
+                               QStringLiteral("devices")});
         connect(devices, &QProcess::finished, this,
                 [this, guardedSocket, request, controller, devices](int devicesExit,
                                                                        QProcess::ExitStatus) {


### PR DESCRIPTION
## Summary
- skip bluetoothctl polling when no Bluetooth controller exists
- add a two-second bluetoothctl timeout for unavailable or wedged BlueZ
- return a normal unavailable snapshot instead of accumulating child processes

## Reproduction
On a desktop without /sys/class/bluetooth, the three-second control-center refresh spawned one bluetoothctl show process per interval. The processes never exited, eventually reaching 1015 open file descriptors and causing QProcess pipe creation failures.

## Validation
- built KOS successfully with KWin plugin builds disabled
- verified the running daemon dropped from 1015 to 26 file descriptors
- observed multiple refresh intervals with no bluetoothctl children
- platform contract tests and Go data-service tests pass