### PR TITLE
fix(deskcenter): stay above Plasma desktop surface

### DIFF
--- a/packaging/systemd/kos-shell.service.in
+++ b/packaging/systemd/kos-shell.service.in
@@ -9,6 +9,10 @@ After=kos-data.service
 # platform daemon and shell from starting too early and aborting on
 # "could not connect to display" (SIGABRT, then a 2s restart loop).
 After=plasma-kwin_wayland.service
+# DeskCenter shares the desktop with Plasma's wallpaper/file surface. Starting
+# after plasmashell keeps their initial stacking deterministic; DeskCenter also
+# uses the Bottom layer so later Plasma restarts cannot hide it again.
+After=plasma-plasmashell.service
 PartOf=graphical-session.target
 
 [Service]

--- a/shell/desktop/modules/deskcenter/DeskCenterWindow.qml
+++ b/shell/desktop/modules/deskcenter/DeskCenterWindow.qml
@@ -13,16 +13,17 @@ import qs.desktop.modules.common
 import qs.desktop.modules.dock
 import qs.desktop.modules.weather
 
-// iPadOS-inspired desktop widgets. This is a Background layer: normal and
-// maximised application windows are always painted and interacted with above
-// it, and it reserves no usable desktop area.
+// iPadOS-inspired desktop widgets. Keep this in the Bottom layer so Plasma's
+// desktop surface cannot cover it when plasmashell starts after KOS. Normal and
+// maximised application windows remain above it, and it reserves no usable
+// desktop area.
 PanelWindow {
     id: root
 
     color: "transparent"
     exclusionMode: ExclusionMode.Ignore
     exclusiveZone: 0
-    WlrLayershell.layer: WlrLayer.Background
+    WlrLayershell.layer: WlrLayer.Bottom
     // A desktop needs shortcuts only after the user explicitly clicks it.
     // OnDemand keeps active applications' Ctrl+C/V untouched otherwise.
     WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand


### PR DESCRIPTION
## Summary
- place DeskCenter on the Wayland Bottom layer
- order kos-shell after plasma-plasmashell during login
- keep normal application windows above DeskCenter

## Problem
DeskCenter used the Background layer. When KOS started before plasmashell, Plasma could cover the widget and desktop-file surface after login, leaving only the Dock visible.

## Validation
- reproduced the missing widget surface after session startup
- verified the clock, weather, metrics, calendar, activity and desktop files are visible after applying the layer change
- qmllint completes without errors; existing repository warnings remain