### PR TITLE
feat(settings): show live integration status

### DIFF
--- a/apps/settings/CMakeLists.txt
+++ b/apps/settings/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Core Gui Qml Quick)
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core DBus Gui Qml Quick)
 
 qt_add_executable(kos-settings
     src/main.cpp
@@ -13,6 +13,7 @@ qt_add_executable(kos-settings
 
 target_link_libraries(kos-settings PRIVATE
     Qt6::Core
+    Qt6::DBus
     Qt6::Gui
     Qt6::Qml
     Qt6::Quick

--- a/apps/settings/main.qml
+++ b/apps/settings/main.qml
@@ -78,6 +78,10 @@ ApplicationWindow {
         {
             subtitle: "启动台",
             groups: []
+        },
+        {
+            subtitle: "接入状态",
+            groups: []
         }
     ]
 
@@ -199,6 +203,209 @@ ApplicationWindow {
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
         }
+    }
+
+    component IntegrationStatusPage: ColumnLayout {
+        id: integrationPage
+
+        Layout.fillWidth: true
+        spacing: 8
+        property var bridge: (typeof settingsBridge !== "undefined")
+            ? settingsBridge : null
+        property var snapshot: ({})
+        property string errorText: ""
+
+        function refresh() {
+            if (!bridge) {
+                errorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            snapshot = bridge.integrationSnapshot()
+            errorText = bridge.lastError || ""
+        }
+
+        function notificationState() {
+            const provider = snapshot.notificationProvider || "none"
+            if (provider === "kos")
+                return { label: "KOS 已接管", color: "#30d158",
+                    detail: "通知将显示在 KOS 通知中心" }
+            if (provider === "plasma")
+                return { label: "Plasma 接管", color: "#ff9f0a",
+                    detail: "KOS 正在等待 org.freedesktop.Notifications 所有权" }
+            if (provider === "other")
+                return { label: "其他程序接管", color: "#ff9f0a",
+                    detail: snapshot.notificationCommand || snapshot.notificationOwner || "未知通知服务" }
+            return { label: "未注册", color: "#ff453a",
+                detail: "当前没有可用的桌面通知服务" }
+        }
+
+        function statusRow(icon, tint, title, ready, readyLabel, detail) {
+            return { icon: icon, tint: tint, title: title,
+                label: ready ? readyLabel : "未连接",
+                color: ready ? "#30d158" : "#ff453a", detail: detail }
+        }
+
+        readonly property var notification: notificationState()
+        readonly property var rows: [
+            statusRow("K", "#0a84ff", "KOS Shell", !!snapshot.shellReady,
+                "运行中", "设置页与 Quickshell IPC 通道"),
+            statusRow("↔", "#5ac8fa", "平台桥接", !!snapshot.platformConnected,
+                "已连接", "窗口、网络、音频与系统操作"),
+            statusRow("D", "#34c759", "数据服务", !!snapshot.dataConnected,
+                "已连接", "系统指标、活动记录与桌面文件"),
+            statusRow("▦", "#af52de", "桌面组件", !!snapshot.desktopWidgetsVisible,
+                "已显示", snapshot.desktopFilesReady
+                    ? "时钟、天气、资源卡片与桌面文件已就绪"
+                    : "组件层已显示，桌面文件仍在同步"),
+            { icon: "N", tint: "#ff9500", title: "通知接管",
+                label: notification.label, color: notification.color,
+                detail: notification.detail },
+            statusRow("G", "#64d2ff", "Glass 特效", !!snapshot.glassLoaded,
+                "已加载", "KWin 模糊与液态玻璃效果"),
+            statusRow("A", "#ff375f", "Dock 窗口动画",
+                !!snapshot.dockAnimationLoaded, "已加载", "KWin Dock 缩放／Genie 动画"),
+            statusRow("I", "#bf5af2", "桌面输入桥接",
+                !!snapshot.contextMenuInputLoaded, "已加载", "全局点击与菜单收起事件")
+        ]
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 13
+            Layout.rightMargin: 13
+
+            Text {
+                Layout.fillWidth: true
+                text: snapshot.updatedAt
+                    ? "最后检查 " + snapshot.updatedAt : "正在读取实时状态…"
+                color: theme.secondaryText
+                font.pixelSize: 12
+            }
+
+            Rectangle {
+                implicitWidth: 72
+                implicitHeight: 30
+                radius: 15
+                color: refreshPointer.containsMouse
+                    ? theme.sidebarHover : theme.card
+                border.width: 1
+                border.color: theme.floatingBorder
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "刷新"
+                    color: theme.primaryText
+                    font.pixelSize: 12
+                    font.weight: Font.DemiBold
+                }
+                MouseArea {
+                    id: refreshPointer
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: integrationPage.refresh()
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: statusColumn.implicitHeight + 8
+            radius: 24
+            color: theme.card
+
+            Column {
+                id: statusColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: 4
+
+                Repeater {
+                    model: integrationPage.rows
+
+                    delegate: Item {
+                        required property var modelData
+                        required property int index
+                        width: statusColumn.width
+                        height: 62
+
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 10
+                            anchors.rightMargin: 12
+                            spacing: 11
+
+                            SettingIcon {
+                                symbol: modelData.icon
+                                tint: modelData.tint
+                            }
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 2
+                                Text {
+                                    text: modelData.title
+                                    color: theme.primaryText
+                                    font.pixelSize: 14
+                                    font.weight: Font.DemiBold
+                                }
+                                Text {
+                                    Layout.fillWidth: true
+                                    text: modelData.detail
+                                    color: theme.secondaryText
+                                    font.pixelSize: 11
+                                    elide: Text.ElideRight
+                                }
+                            }
+                            Rectangle {
+                                implicitWidth: statusLabel.implicitWidth + 18
+                                implicitHeight: 24
+                                radius: 12
+                                color: theme.dark
+                                    ? Qt.rgba(1, 1, 1, 0.09)
+                                    : Qt.rgba(0, 0, 0, 0.055)
+                                Text {
+                                    id: statusLabel
+                                    anchors.centerIn: parent
+                                    text: modelData.label
+                                    color: modelData.color
+                                    font.pixelSize: 11
+                                    font.weight: Font.DemiBold
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.leftMargin: 49
+                            anchors.bottom: parent.bottom
+                            height: 1
+                            color: theme.separator
+                            visible: index < integrationPage.rows.length - 1
+                        }
+                    }
+                }
+            }
+        }
+
+        Text {
+            Layout.fillWidth: true
+            Layout.leftMargin: 13
+            Layout.rightMargin: 13
+            visible: errorText.length > 0
+            text: errorText
+            color: "#ff453a"
+            font.pixelSize: 12
+            wrapMode: Text.Wrap
+        }
+
+        Timer {
+            interval: 5000
+            repeat: true
+            running: integrationPage.visible
+            onTriggered: integrationPage.refresh()
+        }
+        Component.onCompleted: refresh()
     }
 
     component DockSettingsPage: ColumnLayout {
@@ -2872,6 +3079,15 @@ ApplicationWindow {
                     navTint: "#ff9500"
                 }
 
+                SidebarEntry {
+                    Layout.fillWidth: true
+                    Layout.topMargin: 1
+                    pageIndex: 5
+                    label: "接入状态"
+                    navSymbol: "✓"
+                    navTint: "#30d158"
+                }
+
                 Item {
                     Layout.fillHeight: true
                 }
@@ -2914,7 +3130,7 @@ ApplicationWindow {
                         Layout.bottomMargin: 18
                     }
                     Repeater {
-                        model: (window.currentPage >= 0 && window.currentPage <= 4)
+                        model: (window.currentPage >= 0 && window.currentPage <= 5)
                             ? [] : window.contentByPage[window.currentPage].groups
                         delegate: ColumnLayout {
                             required property var modelData
@@ -2947,6 +3163,10 @@ ApplicationWindow {
 
                     LauncherSettingsPage {
                         visible: window.currentPage === 4
+                    }
+
+                    IntegrationStatusPage {
+                        visible: window.currentPage === 5
                     }
 
                     DockSettingsPage {

--- a/apps/settings/src/main.cpp
+++ b/apps/settings/src/main.cpp
@@ -1,5 +1,11 @@
 #include <QGuiApplication>
+#include <QDateTime>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusInterface>
+#include <QDBusReply>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -157,6 +163,62 @@ public:
         return accepted;
     }
 
+    Q_INVOKABLE QVariantMap integrationSnapshot() {
+        QVariantMap result = integrationSnapshotFromReply(
+            callIntegration({QStringLiteral("snapshot")}));
+
+        const QDBusConnection sessionBus = QDBusConnection::sessionBus();
+        auto *busInterface = sessionBus.interface();
+        QString notificationProvider = QStringLiteral("none");
+        QString notificationOwner;
+        uint notificationPid = 0;
+        if (busInterface) {
+            const QDBusReply<QString> ownerReply = busInterface->serviceOwner(
+                QStringLiteral("org.freedesktop.Notifications"));
+            if (ownerReply.isValid() && !ownerReply.value().isEmpty()) {
+                notificationOwner = ownerReply.value();
+                const QDBusReply<uint> pidReply = busInterface->servicePid(notificationOwner);
+                if (pidReply.isValid())
+                    notificationPid = pidReply.value();
+
+                QFile commandLine(QStringLiteral("/proc/%1/cmdline").arg(notificationPid));
+                QString command;
+                if (commandLine.open(QIODevice::ReadOnly)) {
+                    QByteArray raw = commandLine.readAll();
+                    raw.replace('\0', ' ');
+                    command = QString::fromLocal8Bit(raw).trimmed();
+                }
+                if (command.contains(QStringLiteral("plasmashell"))) {
+                    notificationProvider = QStringLiteral("plasma");
+                } else if (command.contains(QStringLiteral("/qs"))
+                           || command.contains(QStringLiteral("quickshell"))) {
+                    notificationProvider = QStringLiteral("kos");
+                } else {
+                    notificationProvider = QStringLiteral("other");
+                }
+                result.insert(QStringLiteral("notificationCommand"), command);
+            }
+        }
+        result.insert(QStringLiteral("notificationProvider"), notificationProvider);
+        result.insert(QStringLiteral("notificationOwner"), notificationOwner);
+        result.insert(QStringLiteral("notificationPid"), notificationPid);
+
+        QDBusInterface effects(QStringLiteral("org.kde.KWin"), QStringLiteral("/Effects"),
+                               QStringLiteral("org.kde.kwin.Effects"), sessionBus);
+        const QStringList loadedEffects = effects.isValid()
+            ? effects.property("loadedEffects").toStringList() : QStringList{};
+        result.insert(QStringLiteral("kwinAvailable"), effects.isValid());
+        result.insert(QStringLiteral("glassLoaded"),
+                      loadedEffects.contains(QStringLiteral("glass")));
+        result.insert(QStringLiteral("dockAnimationLoaded"),
+                      loadedEffects.contains(QStringLiteral("kos_dock_window_animation")));
+        result.insert(QStringLiteral("contextMenuInputLoaded"),
+                      loadedEffects.contains(QStringLiteral("kos_context_menu_input")));
+        result.insert(QStringLiteral("updatedAt"),
+                      QDateTime::currentDateTime().toString(QStringLiteral("HH:mm:ss")));
+        return result;
+    }
+
 signals:
     void lastErrorChanged();
 
@@ -279,6 +341,20 @@ private:
         };
     }
 
+    QVariantMap integrationSnapshotFromReply(const QString &payload) {
+        if (payload.isEmpty())
+            return {{QStringLiteral("shellReady"), false}};
+
+        QJsonParseError parseError;
+        const QJsonDocument document = QJsonDocument::fromJson(payload.toUtf8(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+            setLastError(QStringLiteral("桌面环境返回了无效的接入状态"));
+            return {{QStringLiteral("shellReady"), false}};
+        }
+        setLastError({});
+        return document.object().toVariantMap();
+    }
+
     QString callDock(const QStringList &arguments) {
         return callShell(QStringLiteral("dock-settings"), arguments,
                          QStringLiteral("Dock 设置请求失败"));
@@ -292,6 +368,11 @@ private:
     QString callLauncher(const QStringList &arguments) {
         return callShell(QStringLiteral("applauncher-settings"), arguments,
                          QStringLiteral("启动台设置请求失败"));
+    }
+
+    QString callIntegration(const QStringList &arguments) {
+        return callShell(QStringLiteral("integration-status"), arguments,
+                         QStringLiteral("接入状态请求失败"));
     }
 
     static QString shellDirectory() {

--- a/shell/desktop/DesktopEnvironment.qml
+++ b/shell/desktop/DesktopEnvironment.qml
@@ -234,6 +234,25 @@ Item {
         }
     }
 
+    // Read-only health snapshot for the standalone Settings app. Keep these
+    // values sourced from the live Shell connections so the UI reports what
+    // is actually connected, not merely which units were installed.
+    IpcHandler {
+        target: "integration-status"
+
+        function snapshot(): string {
+            return JSON.stringify({
+                shellReady: true,
+                platformConnected: PlatformClient.socket.connected,
+                dataConnected: DataClient.socket.connected,
+                outputAvailable: ScreenLifecycle.outputAvailable,
+                desktopWidgetsVisible: ScreenLifecycle.outputAvailable
+                    && ScreenLifecycle.activeScreen !== null,
+                desktopFilesReady: DesktopFilesService.ready,
+            })
+        }
+    }
+
     // The KWin effect observes pointer presses at compositor scope and routes
     // them through WindowService's existing local bridge. Keep the policy here
     // so individual desktop, Dock, and tray surfaces need no outside-click


### PR DESCRIPTION
## Summary
- add a read-only integration-status IPC endpoint backed by live Shell connections
- add a Settings page for Shell, platform, data, DeskCenter and KWin effect status
- report the current org.freedesktop.Notifications provider explicitly
- refresh automatically every five seconds and on demand

## Motivation
Installed components were otherwise hard to distinguish from active integrations. In particular, KOS silently waits when Plasma owns the notification service, so users could not tell whether KOS notifications had taken over.

## Validation
- built kos-settings and kos-platform successfully
- opened the installed Settings page against a live KOS session
- verified live statuses for both sockets, DeskCenter, Glass, Dock animation and input bridge
- verified Plasma notification ownership is shown as Plasma managed
- qmllint completes without errors; existing repository warnings remain