### PR TITLE
fix(lifecycle): preserve dock-launched apps on restart

### DIFF
--- a/packaging/systemd/kos-shell.service.in
+++ b/packaging/systemd/kos-shell.service.in
@@ -13,13 +13,12 @@ PartOf=graphical-session.target
 
 [Service]
 Type=simple
-# `KillMode=mixed`: on stop, SIGTERM only the main qs process (which exits
-# promptly). Without this, systemd's default KillMode=control-group SIGTERMs
-# every process in the cgroup — including desktop apps the shell launched via
-# QProcess::startDetached() (which only fork+setsid and do NOT leave the
-# launching cgroup), so a restart would hang 90s waiting for Electron apps to
-# die and then SIGKILL them. mixed keeps launched apps alive across restarts.
-KillMode=mixed
+# Detached processes keep the launching cgroup even after fork+setsid. Use
+# process mode so restarting the Shell signals only the main qs process and
+# leaves applications launched from the Dock alive. mixed is insufficient: it
+# sends SIGTERM only to qs first, but then SIGKILLs every remaining cgroup
+# process as soon as qs exits.
+KillMode=process
 # The installed shell must be stable: `sync`/`install` overwrite the config
 # directory it watches. Disable the file watcher so a copy in progress can
 # never trigger a hot-reload of half-written QML (which crashes quickshell).


### PR DESCRIPTION
## Summary
- change kos-shell from KillMode=mixed to KillMode=process
- document why detached Dock applications remain in the Shell cgroup
- ensure Shell restarts signal only the qs main process

## Problem
QProcess startDetached changes the process session but not its systemd cgroup. KillMode=mixed sends SIGTERM only to qs initially, then SIGKILLs every remaining process as soon as qs exits. As a result, kosctl start and service restarts can terminate browsers and other applications launched from the Dock.

## Validation
- reproduced with Chrome Canary under kos-shell.service
- observed Chrome receive a new PID after a Shell restart with KillMode=mixed
- reloaded the unit with KillMode=process and verified the live systemd property
- systemd-analyze user verification passes