### PR TITLE
修复：恢复启动台应用编辑器的文本光标反馈

### DIFF
--- a/shell/desktop/modules/applauncher/AppLauncherWindow.qml
+++ b/shell/desktop/modules/applauncher/AppLauncherWindow.qml
@@ -2274,9 +2274,14 @@ PanelWindow {
                                         color: AppLauncherService.dockForegroundColor
                                         selectionColor: Qt.rgba(1, 1, 1, 0.30)
                                         selectedTextColor: AppLauncherService.dockForegroundColor
+                                        selectByMouse: true
                                         text: root.editorName
                                         onTextEdited: root.editorName = text
                                         Keys.onReturnPressed: root.saveApplicationEditor()
+
+                                        HoverHandler {
+                                            cursorShape: Qt.IBeamCursor
+                                        }
                                     }
                                 }
 
@@ -2303,8 +2308,13 @@ PanelWindow {
                                         color: AppLauncherService.dockForegroundColor
                                         selectionColor: Qt.rgba(1, 1, 1, 0.30)
                                         selectedTextColor: AppLauncherService.dockForegroundColor
+                                        selectByMouse: true
                                         text: root.editorIcon
                                         onTextEdited: root.editorIcon = text
+
+                                        HoverHandler {
+                                            cursorShape: Qt.IBeamCursor
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
## 问题

在“启动台 → 右键应用 → 编辑应用”中，显示名称和图标路径两个输入框在鼠标悬浮时仍显示普通箭头光标，而不是切换到编辑状态。这与项目现有文本输入控件的交互不一致，容易让用户误以为输入框没有进入编辑状态。

## 修改

- 为两个编辑输入框添加 I-Beam 文本光标反馈
- 启用 `selectByMouse`，支持鼠标定位和拖选文本
- 仅修复应用编辑器输入交互，不包含启动台 Glass 局部重绘问题

## 验证

- `git diff --check`
- `python3 platform/tests/test_contract.py`
- `go test ./...`（`services/data-service`）
- `node shell/desktop/modules/dock/test_adaptive.mjs`
- `node shell/desktop/modules/dock/test_autohide.mjs`
- `node shell/desktop/modules/common/test_appearance_config.mjs`
- `qmllint` 未发现语法错误；仍有项目现存的 Quickshell 自定义模块解析警告