### PR TITLE
修复：消除启动台玻璃区域的鼠标方块残影

### DIFF
--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -12,6 +12,7 @@
 #include "settings.h"
 
 #include "core/pixelgrid.h"
+#include "cursor.h"
 #ifndef GLASS_X11
 #include "core/region.h"
 #endif
@@ -207,6 +208,62 @@ BlurEffect::BlurEffect()
 
     connect(effects, &EffectsHandler::windowAdded, this, &BlurEffect::slotWindowAdded);
     connect(effects, &EffectsHandler::windowDeleted, this, &BlurEffect::slotWindowDeleted);
+#if defined(GLASS_KWIN_67) && !defined(GLASS_X11)
+    connect(effects, &EffectsHandler::mouseChanged, this,
+            [this](const QPointF &pos, const QPointF &oldPos,
+                   Qt::MouseButtons, Qt::MouseButtons,
+                   Qt::KeyboardModifiers, Qt::KeyboardModifiers) {
+        Cursor *cursor = Cursors::self() ? Cursors::self()->mouse() : nullptr;
+        RectF currentCursor = cursor ? cursor->geometry() : RectF(pos.x() - 32, pos.y() - 32, 64, 64);
+        if (currentCursor.isEmpty()) {
+            currentCursor = RectF(pos.x() - 32, pos.y() - 32, 64, 64);
+        }
+        const RectF oldCursor = currentCursor.translated(oldPos - pos);
+        const RectF cursorDamage = currentCursor.united(oldCursor).marginsAdded(QMarginsF(2, 2, 2, 2));
+
+        const auto isQuickshell = [](const QString &value) {
+            return value.contains(QLatin1String("quickshell"), Qt::CaseInsensitive);
+        };
+        QList<LogicalOutput *> affectedOutputs;
+        for (const auto &[window, blurData] : m_windows) {
+            Q_UNUSED(blurData)
+            if (!window->screen() || window->isDock()) {
+                continue;
+            }
+            if (!isQuickshell(window->window()->resourceClass())
+                && !isQuickshell(window->window()->resourceName())) {
+                continue;
+            }
+
+            const Rect outputGeometry = window->screen()->geometry();
+            const RectF windowGeometry = window->frameGeometry();
+            const bool outputSpanningBackdrop =
+                windowGeometry.width() >= outputGeometry.width() * 0.9
+                && windowGeometry.height() >= outputGeometry.height() * 0.75;
+            if (!outputSpanningBackdrop) {
+                continue;
+            }
+
+            const RectF blurBounds = RectF(blurRegion(window).boundingRect()).translated(window->pos());
+            if (blurBounds.intersects(cursorDamage) && !affectedOutputs.contains(window->screen())) {
+                affectedOutputs.append(window->screen());
+            }
+        }
+        if (affectedOutputs.isEmpty()) {
+            return;
+        }
+
+        // Cursor/overlay damage is collected after window damage in KWin 6.7.
+        // Mirror the old and new cursor rectangles onto the desktop item first
+        // so BackgroundEffectItem sees an ordinary lower-window repaint and
+        // expands it through the blur backdrop in the same frame.
+        for (EffectWindow *window : effects->stackingOrder()) {
+            if (window->isDesktop() && affectedOutputs.contains(window->screen())) {
+                window->addLayerRepaint(cursorDamage);
+            }
+        }
+    });
+#endif
 #ifdef GLASS_X11
     connect(effects, &EffectsHandler::screenRemoved, this, &BlurEffect::slotOutputRemoved);
 #else
@@ -969,27 +1026,9 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
 }
 #else
 #ifdef GLASS_KWIN_67
-// KWin 6.7: prePaintWindow is intentionally NOT overridden.
-//
-// Previously this called data.setTranslucent() for blurred windows, which
-// marks them as non-opaque in paintSimpleScreen's occlusion cull.  That
-// prevents visible -= deviceOpaque for the dock, so the WALL keeps painting
-// behind it -- but it also means the dock's own drawWindow() uses
-// PAINT_WINDOW_TRANSLUCENT, so effects->drawWindow() composites the dock
-// semi-transparently over whatever is already in the renderTarget.
-//
-// When a popup appears/disappears, the screen damage is narrow (the popup's
-// footprint).  The dock's deviceRegion shrinks to that sliver, so
-// renderTarget is NOT cleared outside it -- it retains the previous frame's
-// (blur + dock) content.  The blur onscreen pass then uses GL_BLEND to
-// composite over that stale content, producing a double-rendered flicker.
-//
-// Upstream KDE 6.7.3 blur does not override prePaintWindow.  Instead it
-// relies on BackgroundEffectItem + setPixelsToExpandRepaintsBelowOpaqueRegions
-// to expand the repaint region via the forceTranslucent mechanism in
-// collectDamage(), which subtracts the blur area from the dock's opaque
-// region so the WALL repaints behind it -- without marking the dock
-// translucent for compositing.
+// KWin 6.7 uses BackgroundEffectItem for paint-region expansion. Cursor
+// damage is mirrored to the desktop item in the constructor above so the
+// normal mechanism can see it without changing this window's paint mask.
 #else
 void BlurEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime)
 {
@@ -1305,28 +1344,41 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     }
 
     if (smoothQuickshellCard) {
-        // Only use the full-card smooth path when the repaint region covers the
-        // entire card.  When a popup appears/disappears, deviceRegion is a narrow
-        // strip and dirtyRegion only covers part of the card -- rendering the full
-        // area would blur stale framebuffer[0] content and flicker.  In that case
-        // keep the deviceRegion-clipped effectiveContentShape so the onscreen pass
-        // only touches the region that was actually updated.
-        RectF eeBounds;
-        for (const auto &r : effectiveEffectShape) {
-            eeBounds = eeBounds.united(r);
-        }
-        const bool fullCoverage = eeBounds.width() >= scaledBackgroundRect.width() * 0.99
-            && eeBounds.height() >= scaledBackgroundRect.height() * 0.99;
-        if (fullCoverage) {
-            effectiveContentShape.clear();
+        // Keep the full-card SDF for partial repaints too, but limit the
+        // onscreen geometry to the exact device damage.  Falling back to the
+        // protocol's rectangle-union shape exposes its stair-step rounded
+        // edge; painting the complete card, on the other hand, samples stale
+        // framebuffer content when only a narrow region was refreshed.
+        // Clipping the damage against the card's bounding rectangle avoids
+        // both failure modes: only valid pixels are drawn and the shader owns
+        // the anti-aliased rounded boundary.
+        effectiveContentShape.clear();
 #ifdef GLASS_X11
+        const QRectF localCardRect(0, 0, scaledBackgroundRect.width(), scaledBackgroundRect.height());
+        if (deviceRegion == infiniteRegion()) {
             effectiveContentShape.append(QRectF(0, 0, scaledBackgroundRect.width(), scaledBackgroundRect.height()));
-#else
-            effectiveContentShape.append(RectF(0, 0, scaledBackgroundRect.width(), scaledBackgroundRect.height()));
-#endif
         } else {
-            smoothQuickshellCard = false;
+            for (const QRect &clipRect : deviceRegion) {
+                const QRectF localDamage = snapToPixelGridF(scaledRect(clipRect, viewport.scale()))
+                                               .translated(-deviceBackgroundRect.topLeft());
+                if (const QRectF clipped = localDamage.intersected(localCardRect); !clipped.isEmpty()) {
+                    effectiveContentShape.append(clipped);
+                }
+            }
         }
+#else
+        const RectF localCardRect(0, 0, scaledBackgroundRect.width(), scaledBackgroundRect.height());
+        if (deviceRegion == Region::infinite()) {
+            effectiveContentShape.append(RectF(0, 0, scaledBackgroundRect.width(), scaledBackgroundRect.height()));
+        } else {
+            for (const Rect &clipRect : deviceRegion.rects()) {
+                const RectF localDamage = clipRect.translated(-deviceBackgroundRect.topLeft());
+                if (const RectF clipped = localDamage.intersected(localCardRect); !clipped.isEmpty()) {
+                    effectiveContentShape.append(clipped);
+                }
+            }
+        }
+#endif
     }
 
     // Maybe reallocate offscreen render targets. Keep in mind that the first one contains


### PR DESCRIPTION
## 问题

在 Plasma 6.7 Wayland 下移动鼠标时，启动台的 Glass 背景会留下与光标损伤矩形同尺寸的灰色方块。快速移动时方块形成拖影，随后在较大重绘时一次性消失；打开应用编辑器后，卡片顶边也可能出现轻微方形闪烁。

## 原因

KWin 在窗口损伤之后才收集 overlay／cursor 损伤，因此 BackgroundEffectItem 无法在同一帧把这类损伤传播到底层背景。Glass 随后会在窄 deviceRegion 中采样上一帧内容。同时，局部重绘会退回 Wayland 的像素矩形联合，暴露圆角边缘的阶梯形状。

## 修改

- 仅当鼠标的新旧矩形与大型 Quickshell 玻璃背景相交时，把对应区域镜像为桌面窗口损伤，让 BackgroundEffectItem 走正常的背景重绘扩展路径。
- 不使用全局 PAINT_WINDOW_TRANSLUCENT，避免重新引入 Dock／弹窗双重合成闪烁。
- 局部重绘继续使用完整卡片的 SDF 圆角参数，但屏幕绘制仍严格限制在当前 deviceRegion。
- 启动台关闭或鼠标不在玻璃区域时，不遍历窗口堆栈。

## 验证

- Plasma 6.7.4、Wayland、NVIDIA、3840×2160 @ 160 Hz、缩放 145%。
- 人工验证：启动台空白区域快速移动鼠标、打开应用编辑器、沿卡片顶边和输入框移动鼠标，方块拖影和闪烁消失。
- Glass Debug 构建通过。
- platform/tests/test_contract.py 通过。
- tools/check-docs.py 通过。
- appearance、Dock adaptive、Dock autohide 测试通过。
- data-service Go 测试通过。
- git diff --check 通过。