### PR TITLE
fix(glass): 防止小尺寸模糊区域创建零尺寸 framebuffer

### DIFF
--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -1342,7 +1342,12 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
         glClearColor(0, 0, 0, 0);
         for (size_t i = 0; i <= m_maxIterationCount; ++i) {
-            auto texture = GLTexture::allocate(textureFormat, backgroundRect.size() / (1 << i));
+            // Dual Kawase halves each level. Very thin blur regions (for
+            // example KOS's 6 px dock reveal handle) eventually truncate to
+            // zero in one dimension. Keep those levels valid without skipping
+            // the window's early animation frames altogether.
+            const QSize textureSize = (backgroundRect.size() / (1 << i)).expandedTo(QSize(1, 1));
+            auto texture = GLTexture::allocate(textureFormat, textureSize);
             if (!texture) {
                 qCWarning(KWIN_BLUR) << "Failed to allocate an offscreen texture";
                 return;


### PR DESCRIPTION
## 问题

Glass 的 Dual Kawase 管线会逐级将渲染目标减半。对于 NextKDE Dock 的 6 px reveal handle 等狭窄模糊区域，后续层级可能因整数截断得到宽度或高度为 0 的纹理。

这会反复触发：

- `GL_INVALID_VALUE`
- `GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT`
- `Failed to create an offscreen framebuffer`

并可能留下未及时刷新的合成器内容，表现为方形残影、闪烁或窗口内容缺失。

## 修复

将每一级降采样纹理的最小尺寸限制为 `1×1`，继续渲染有效动画帧，而不是因为尺寸过小而跳过整个窗口的 blur pass。

## 验证

- 独立 CMake 构建成功
- `ctest` 通过，1/1
- 完整注销并重新登录后加载修复
- 反复打开和关闭启动台
- Dock 完成多轮 `Hidden`、`RevealPending` 和 `HidePending` 切换
- 四类纹理/FBO 错误均保持为 0
- 启动台打开动画不再因跳过早期 blur pass 而被截断

Fixes #18
