### PR TITLE
fix(dock): 防止快速切换启动台时误触最右侧固定应用

### DIFF
--- a/shell/desktop/modules/dock/DockContainer.qml
+++ b/shell/desktop/modules/dock/DockContainer.qml
@@ -705,7 +705,8 @@ Item {
                                 iconSource: pinnedItemLoader.itemData.icon ?? ""
                                 displayName: pinnedItemLoader.itemData.name ?? ""
                                 isRunning: pinnedItemLoader.itemData.isRunning ?? false
-                                isActivated: pinnedItemLoader.itemData.isActivated ?? false
+                                isActivated: DockModelService.isAppActivated(
+                                    pinnedItemLoader.itemData.appId ?? "")
                                 appId: pinnedItemLoader.itemData.appId ?? ""
                                 isWindowItem: false
                                 isPinnedItem: true

--- a/shell/desktop/modules/dock/DockIcon.qml
+++ b/shell/desktop/modules/dock/DockIcon.qml
@@ -290,7 +290,7 @@ Item {
     }
 
     // ── Hover animation ──
-    property bool _hovering: false
+    readonly property bool _hovering: _mouseArea.containsMouse
     readonly property var _appWindows: {
         WindowService.revision
         if (icon.windowId) {
@@ -645,13 +645,11 @@ Item {
             }
         }
         onEntered: {
-            icon._hovering = true
             if (icon._previewWindowId && !icon.editMode
                     && !DockModelService.activeContextMenu)
                 previewDelay.restart()
         }
         onExited: {
-            icon._hovering = false
             previewDelay.stop()
             previewCloseDelay.restart()
         }

--- a/shell/desktop/modules/dock/DockModelService.qml
+++ b/shell/desktop/modules/dock/DockModelService.qml
@@ -109,17 +109,16 @@ QtObject {
                     name: identity.name || dockItem.appId,
                     icon: windows[0]?.iconSource ?? identity.iconSource,
                     isRunning: windows.length > 0,
-                    isActivated: windows.some(window => window.toplevel.activated),
                     windowCount: windows.length,
                 });
                 continue;
             }
 
         }
-        // Only replace the model when its content actually changed. The array
-        // is the Repeater's model; assigning a new array rebuilds every pinned
-        // delegate, and _refreshPinned runs on every window revision (every
-        // window open/close), so an unchanged list must not churn the Repeater.
+        // Activation changes whenever focus moves between the launcher and an
+        // application. It is intentionally not stored in this array: replacing
+        // the Repeater model for that transient state destroys every delegate
+        // and can briefly route a click to the last pinned application.
         const same = items.length === svc.pinnedItems.length
             && items.every((item, i) => {
                 const prev = svc.pinnedItems[i];
@@ -127,7 +126,6 @@ QtObject {
                     && item.name === prev.name
                     && item.icon === prev.icon
                     && item.isRunning === prev.isRunning
-                    && item.isActivated === prev.isActivated
                     && item.windowCount === prev.windowCount;
             });
         if (!same) {
@@ -427,6 +425,14 @@ QtObject {
                 return true;
         }
         return false;
+    }
+
+    function isAppActivated(appId) {
+        // Make callers reactive without putting activation into pinnedItems.
+        WindowService.revision;
+        const identity = AppIdentityService.resolve(appId);
+        return WindowService.windowsForApp(identity.desktopId)
+            .some(window => window.toplevel.activated);
     }
 
     function unpinApp(appId) {


### PR DESCRIPTION
## 问题描述

当普通应用窗口处于焦点状态时，将鼠标保持在 Dock 的“启动台”图标上并快速反复点击，Dock 最右侧的固定应用会偶发进入 hover 放大状态。继续点击后，事件可能被错误地发送给该应用，导致它被意外激活或启动。

测试环境中最右侧应用为微信，但问题与具体应用无关。整个复现过程中鼠标始终位于启动台图标上。

## 严重性

**高（输入路由与交互完整性问题）**。

这不是单纯的动画瑕疵：用户对启动台的点击会被解释为对另一个应用的点击，从而执行非预期的应用启动操作。目前没有发现数据损坏，但任何位于最右侧的固定应用都有可能被误触。

## 触发流程

测试配置：

- KDE Plasma / Wayland
- Dock 使用 grouped 窗口分组模式
- Dock 中固定多个应用
- 启动台位于 Dock 左侧
- 微信位于固定应用区域最右侧

复现步骤：

1. 聚焦 Chrome 等普通应用窗口。
2. 将鼠标移动到 Dock 的启动台图标上。
3. 快速反复点击启动台，使其连续打开和关闭。
4. 观察最右侧的固定应用图标。

修复前可能出现：

1. 最右侧图标进入与鼠标 hover 相同的放大状态。
2. 继续点击后，最右侧应用被实际启动或激活。

## 修复前日志

下面的日志记录了启动台关闭后，点击被错误发送给微信的完整过程：

```text
02:35:30.107850 [AppLauncherService] open=true
02:35:30.108233 [AppLauncherWindow] visible=true card=1324x500

02:35:30.287065 [AppLauncherService] open=false
02:35:30.287143 [AppLauncherWindow] visible=false card=1324x500

02:35:30.339744 [DockModel] launch app=com.qq.weixin.desktop
02:35:30.387171 [DockAnimation] armed launch ticket app=com.qq.weixin.desktop
02:35:30.387495 [AppAction] launch app=com.qq.weixin

02:35:30.408388 [AppLauncherService] open=true
02:35:30.408928 [AppLauncherWindow] visible=true card=1324x500
```

启动台在 `02:35:30.287` 关闭，仅 52 ms 后便出现微信启动请求，而鼠标仍位于启动台图标上。这确认了问题发生在快速窗口焦点和布局切换期间，并非用户实际点击微信。

## 原因分析

`DockModelService._refreshPinned()` 将固定应用及其运行状态保存到 JavaScript 数组，并将这个数组直接作为 `Repeater` 模型。

启动台打开或关闭时，焦点会在前台应用和启动台窗口之间切换。原实现将 `isActivated` 包含在固定项数组的内容比较中，因此每次焦点变化都会生成并赋值新数组。

替换数组模型会让 `Repeater` 销毁并重新创建所有固定应用 delegate。在快速连续点击期间，新的 delegate 会经历短暂的 Row 布局和命中区域重建过程，最后创建的最右侧 delegate 可能暂时出现在鼠标位置下方，错误进入 hover 状态并接收下一次点击。

此外，Dock 图标原先通过 `onEntered` 和 `onExited` 手动维护 `_hovering`。delegate 在重建期间被销毁时，不一定能形成完整的 enter/exit 状态对，会放大残留 hover 状态的问题。

## 修复方式

本次修改将瞬时焦点状态从固定项的结构模型中分离：

1. `pinnedItems` 不再保存或比较 `isActivated`。
2. 新增 `isAppActivated(appId)`，通过 `WindowService.revision` 响应焦点变化并实时计算应用激活状态。
3. `DockContainer` 直接绑定实时激活状态，运行指示仍会正常更新，但不会重建整个固定项 `Repeater`。
4. `_hovering` 改为只读绑定 `_mouseArea.containsMouse`，移除手动 enter/exit 状态维护。

该实现保留原有数组模型和拖拽排序流程，避免改变固定项的结构更新语义。

## 修复证明

使用与修复前相同的配置和流程，聚焦 Chrome 后快速连续打开、关闭启动台：

```text
启动台打开次数：26
启动台关闭次数：26
微信错误启动次数：0
QML 运行错误：0
```

修复后的日志连续记录了启动台开关，没有出现任何 `DockModel launch app=com.qq.weixin.desktop` 或对应的 `AppAction launch`：

```text
02:46:41.114002 [AppLauncherService] open=true
02:46:41.256889 [AppLauncherService] open=false
02:46:41.422037 [AppLauncherService] open=true
02:46:41.571941 [AppLauncherService] open=false
02:46:41.691989 [AppLauncherService] open=true
02:46:41.863930 [AppLauncherService] open=false
02:46:41.991869 [AppLauncherService] open=true
02:46:42.133921 [AppLauncherService] open=false
```

人工验证结果：

- 最右侧图标不再错误放大；
- 微信不再被意外启动；
- 固定应用激活状态仍会实时更新；
- Quickshell 保持单实例运行；
- `kos-shell.service` 没有异常重启。

## 测试

- [x] `git diff --check`
- [x] `node shell/desktop/modules/dock/test_autohide.mjs`
- [x] `node shell/desktop/modules/dock/test_adaptive.mjs`（11 项全部通过）
- [x] Chrome 聚焦时快速连续切换启动台
- [x] 检查最右侧固定应用的 hover 状态
- [x] 检查是否产生非预期应用启动日志
- [x] 检查 Quickshell 单实例及 QML 运行错误
