### PR TITLE
修复 Glass 噪声层的圆角裁剪

### DIFF
--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -183,7 +183,7 @@ BlurEffect::BlurEffect()
     }
 
     m_noisePass.shader = ShaderManager::instance()->generateShaderFromFile(ShaderTrait::MapTexture,
-                                                                           QStringLiteral(":/effects/glass/generated/vertex.vert"),
+                                                                           QStringLiteral(":/effects/glass/generated/onscreen_rounded.vert"),
                                                                            QStringLiteral(":/effects/glass/generated/noise.frag"));
     if (!m_noisePass.shader) {
         qCWarning(KWIN_BLUR) << "Failed to load noise pass shader";
@@ -191,6 +191,8 @@ BlurEffect::BlurEffect()
     } else {
         m_noisePass.mvpMatrixLocation = m_noisePass.shader->uniformLocation("modelViewProjectionMatrix");
         m_noisePass.noiseTextureSizeLocation = m_noisePass.shader->uniformLocation("noiseTextureSize");
+        m_noisePass.boxLocation = m_noisePass.shader->uniformLocation("box");
+        m_noisePass.cornerRadiusLocation = m_noisePass.shader->uniformLocation("cornerRadius");
     }
 
     initBlurStrengthValues();
@@ -1818,6 +1820,8 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
 
             m_noisePass.shader->setUniform(m_noisePass.mvpMatrixLocation, noiseProjectionMatrix);
             m_noisePass.shader->setUniform(m_noisePass.noiseTextureSizeLocation, QVector2D(noiseTexture->width(), noiseTexture->height()));
+            m_noisePass.shader->setUniform(m_noisePass.boxLocation, shaderBox);
+            m_noisePass.shader->setUniform(m_noisePass.cornerRadiusLocation, shaderCornerRadius.toVector());
 
             glActiveTexture(GL_TEXTURE0);
             noiseTexture->bind();

--- a/vendor/kwin-effects-glass/src/blur.h
+++ b/vendor/kwin-effects-glass/src/blur.h
@@ -222,6 +222,8 @@ private:
         std::unique_ptr<GLShader> shader;
         int mvpMatrixLocation;
         int noiseTextureSizeLocation;
+        int boxLocation;
+        int cornerRadiusLocation;
 
         std::unique_ptr<GLTexture> noiseTexture;
         qreal noiseTextureScale = 1.0;

--- a/vendor/kwin-effects-glass/src/shaders/noise.glsl
+++ b/vendor/kwin-effects-glass/src/shaders/noise.glsl
@@ -1,11 +1,20 @@
+#include "sdf.glsl"
+
 uniform sampler2D texUnit;
 uniform vec2 noiseTextureSize;
+uniform vec4 box;
+uniform vec4 cornerRadius;
 
-in vec2 uv;
+in vec2 vertex;
 
 void main(void)
 {
     vec2 uvNoise = vec2(gl_FragCoord.xy / noiseTextureSize);
 
-    fragColor = vec4(texture(texUnit, uvNoise).rrr, 0);
+    // Match the onscreen glass pass even when its geometry spans the full
+    // rectangular card. Noise is additively blended, so mask RGB, not alpha.
+    float f = sdfRoundedBox(vertex, box.xy, box.zw, cornerRadius);
+    float df = fwidth(f);
+    float coverage = 1.0 - clamp(0.5 + f / df, 0.0, 1.0);
+    fragColor = vec4(texture(texUnit, uvNoise).rrr * coverage, 0);
 }


### PR DESCRIPTION
# 修复 Glass 噪声层的圆角裁剪

## 问题描述

启用 Glass 噪声效果时，圆角启动台外侧会出现淡淡的矩形亮膜，破坏圆角边界。

## 复现步骤

1. 在 KWin Wayland 下启用 Glass 和噪声效果。
2. 打开圆角卡片模式的启动台，查看四角外侧。
3. 可见矩形亮膜；关闭噪声后消失，重新开启后出现。

## 修复原理

噪声层未使用主玻璃层的圆角遮罩，在绘制区域扩展为矩形时，会向圆角外叠加亮度。

让噪声层复用主玻璃层的圆角几何和抗锯齿遮罩。由于噪声采用加法混合，遮罩作用于 RGB，避免圆角外继续叠亮，同时保留内部噪声效果。

## 修改范围

仅调整 Glass 噪声 shader 及其参数传递，不改变默认配置、噪声强度或混合方式。不包含折射鼠标拖影修复及其他诊断改动。
