### PR TITLE
fix(shell): resolve global menu event/placement, bar auto-hide overlay, crisp text rendering, and appearance controls

### DIFF
--- a/apps/settings/main.qml
+++ b/apps/settings/main.qml
@@ -18,6 +18,20 @@ ApplicationWindow {
     property int currentPage: 0
     property string searchText: ""
 
+    Component.onCompleted: {
+        const arguments = Qt.application.arguments
+        const pageArgument = arguments.indexOf("--page")
+        if (pageArgument >= 0) {
+            const requested = arguments[pageArgument + 1]
+            if (requested === "desktop")
+                currentPage = 5
+            else if (requested === "shortcuts")
+                currentPage = 6
+            else if (requested === "integration")
+                currentPage = 7
+        }
+    }
+
     // Qt updates SystemPalette when the desktop colour scheme changes. We use
     // it only to select the system appearance, then apply the matching iPadOS
     // palette so both modes keep a coherent Settings visual language.
@@ -160,6 +174,59 @@ ApplicationWindow {
         labelFontWeight: Font.DemiBold
     }
 
+    component SettingsIconButton: ToolButton {
+        required property string symbol
+        property string description: ""
+        implicitWidth: 30
+        implicitHeight: 30
+        hoverEnabled: true
+        contentItem: Text {
+            text: parent.symbol
+            color: parent.enabled ? theme.primaryText : theme.tertiaryText
+            font.pixelSize: 15
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+        background: Rectangle {
+            radius: 8
+            color: parent.down ? theme.divider
+                : (parent.hovered ? theme.sidebarHover : "transparent")
+        }
+        ToolTip.visible: hovered && description.length > 0
+        ToolTip.text: description
+        ToolTip.delay: 450
+    }
+
+    component CompactStepper: RowLayout {
+        id: stepper
+        property int value: 0
+        property int from: 0
+        property int to: 10
+        signal valueRequested(int value)
+        spacing: 2
+
+        SettingsIconButton {
+            symbol: "−"
+            description: "减小"
+            enabled: stepper.enabled && stepper.value > stepper.from
+            onClicked: stepper.valueRequested(stepper.value - 1)
+        }
+        Text {
+            Layout.preferredWidth: 24
+            text: stepper.value
+            color: stepper.enabled ? theme.primaryText : theme.tertiaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            horizontalAlignment: Text.AlignHCenter
+        }
+        SettingsIconButton {
+            symbol: "+"
+            description: "增大"
+            enabled: stepper.enabled && stepper.value < stepper.to
+            onClicked: stepper.valueRequested(stepper.value + 1)
+        }
+    }
+
     component SettingRow: Item {
         required property var row
         width: ListView.view ? ListView.view.width : parent.width
@@ -264,8 +331,11 @@ ApplicationWindow {
             { icon: "N", tint: "#ff9500", title: "通知接管",
                 label: notification.label, color: notification.color,
                 detail: notification.detail },
-            statusRow("G", "#64d2ff", "Glass 特效", !!snapshot.glassLoaded,
-                "已加载", "KWin 模糊与液态玻璃效果"),
+            (snapshot.glassLoaded
+                ? statusRow("G", "#64d2ff", "Glass 特效", true, "已加载", "KWin 增强液态玻璃效果")
+                : (snapshot.blurLoaded
+                    ? statusRow("G", "#64d2ff", "合成器模糊", true, "官方稳定模式", "KWin 原生毛玻璃背景模糊 (安全双层管线)")
+                    : statusRow("G", "#64d2ff", "Glass 特效", false, "已加载", "KWin 合成器未加载背景模糊特效"))),
             statusRow("A", "#ff375f", "Dock 窗口动画",
                 !!snapshot.dockAnimationLoaded, "已加载", "KWin Dock 缩放／Genie 动画"),
             statusRow("I", "#bf5af2", "桌面输入桥接",
@@ -1206,13 +1276,13 @@ ApplicationWindow {
             font.weight: Font.DemiBold
             Layout.leftMargin: 13
             Layout.topMargin: 14
-            visible: false
+            visible: true
         }
 
         Rectangle {
             Layout.fillWidth: true
             implicitHeight: dockBlurCol.implicitHeight
-            visible: false
+            visible: true
             radius: 18
             color: theme.card
 
@@ -1240,7 +1310,9 @@ ApplicationWindow {
                                 font.weight: Font.DemiBold
                             }
                             Text {
-                                text: "关闭后可为 Dock 单独自定义背景模糊与液态强度"
+                                text: dockPage.dockBlurInherit
+                                    ? ("已跟随系统外观 (模糊 " + dockPage.percentage(dockPage.dockBlurStrength) + " · 液态 " + dockPage.percentage(dockPage.dockLiquidStrength) + ")")
+                                    : "已开启 Dock 自定义材质"
                                 color: theme.secondaryText
                                 font.pixelSize: 11
                             }
@@ -2158,6 +2230,12 @@ ApplicationWindow {
         property real barLiquidStrength: 1.0
         property bool barBlurDirty: false
         property bool barLiquidDirty: false
+
+        property bool controlCenterBlurInherit: true
+        property real controlCenterBlurStrength: 0.42
+        property real controlCenterLiquidStrength: 1.0
+        property bool controlCenterBlurDirty: false
+        property bool controlCenterLiquidDirty: false
         property string errorText: ""
 
         function percentage(value) {
@@ -2186,6 +2264,15 @@ ApplicationWindow {
             barLiquidStrength = Number.isFinite(Number(state.barLiquidStrength)) ? Number(state.barLiquidStrength) : 1.0
             barBlurDirty = false
             barLiquidDirty = false
+
+            controlCenterBlurInherit = state.controlCenterBlurInherit !== undefined
+                ? Boolean(state.controlCenterBlurInherit) : true
+            controlCenterBlurStrength = Number.isFinite(Number(state.controlCenterBlurStrength))
+                ? Number(state.controlCenterBlurStrength) : 0.42
+            controlCenterLiquidStrength = Number.isFinite(Number(state.controlCenterLiquidStrength))
+                ? Number(state.controlCenterLiquidStrength) : 1.0
+            controlCenterBlurDirty = false
+            controlCenterLiquidDirty = false
             errorText = ""
         }
 
@@ -2290,6 +2377,73 @@ ApplicationWindow {
                 return
             barLiquidDirty = false
             applyState(bridge.updateBarLiquidStrength(barLiquidStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function setControlCenterBlurInherit(enabled) {
+            if (!bridge) return
+            applyState(bridge.updateControlCenterBlurInherit(enabled))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        Timer {
+            id: liveControlCenterBlurDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (barPage.bridge && barPage.controlCenterBlurDirty) {
+                    barPage.bridge.updateControlCenterBlurStrength(barPage.controlCenterBlurStrength)
+                }
+            }
+        }
+
+        Timer {
+            id: liveControlCenterLiquidDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (barPage.bridge && barPage.controlCenterLiquidDirty) {
+                    barPage.bridge.updateControlCenterLiquidStrength(barPage.controlCenterLiquidStrength)
+                }
+            }
+        }
+
+        function previewControlCenterBlur(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(controlCenterBlurStrength - clamped) < 0.005)
+                return
+            controlCenterBlurStrength = clamped
+            controlCenterBlurDirty = true
+            liveControlCenterBlurDebounce.restart()
+        }
+
+        function commitControlCenterBlur() {
+            liveControlCenterBlurDebounce.stop()
+            if (!controlCenterBlurDirty || !bridge)
+                return
+            controlCenterBlurDirty = false
+            applyState(bridge.updateControlCenterBlurStrength(controlCenterBlurStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function previewControlCenterLiquid(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(controlCenterLiquidStrength - clamped) < 0.005)
+                return
+            controlCenterLiquidStrength = clamped
+            controlCenterLiquidDirty = true
+            liveControlCenterLiquidDebounce.restart()
+        }
+
+        function commitControlCenterLiquid() {
+            liveControlCenterLiquidDebounce.stop()
+            if (!controlCenterLiquidDirty || !bridge)
+                return
+            controlCenterLiquidDirty = false
+            applyState(bridge.updateControlCenterLiquidStrength(controlCenterLiquidStrength))
             if (bridge.lastError)
                 errorText = bridge.lastError
         }
@@ -2433,19 +2587,19 @@ ApplicationWindow {
         }
 
         Text {
-            text: "外观与模糊效果".toUpperCase()
+            text: "顶栏外观与模糊效果".toUpperCase()
             color: theme.secondaryText
             font.pixelSize: 12
             font.weight: Font.DemiBold
             Layout.leftMargin: 13
             Layout.topMargin: 4
-            visible: false
+            visible: true
         }
 
         Rectangle {
             Layout.fillWidth: true
             implicitHeight: barBlurCol.implicitHeight
-            visible: false
+            visible: true
             radius: 18
             color: theme.card
 
@@ -2473,7 +2627,9 @@ ApplicationWindow {
                                 font.weight: Font.DemiBold
                             }
                             Text {
-                                text: "关闭后可为顶栏及控制中心单独自定义背景模糊与液态强度"
+                                text: barPage.barBlurInherit
+                                    ? ("已跟随系统外观 (模糊 " + barPage.percentage(barPage.barBlurStrength) + " · 液态 " + barPage.percentage(barPage.barLiquidStrength) + ")")
+                                    : "已开启顶栏自定义材质"
                                 color: theme.secondaryText
                                 font.pixelSize: 11
                             }
@@ -2573,6 +2729,155 @@ ApplicationWindow {
                                 barPage.previewBarLiquid(position)
                             }
                             onCommitRequested: barPage.commitBarLiquid()
+                        }
+                    }
+                }
+            }
+        }
+
+        Text {
+            text: "控制中心外观与模糊效果".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+            Layout.topMargin: 14
+            visible: true
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: controlCenterBlurCol.implicitHeight
+            visible: true
+            radius: 18
+            color: theme.card
+
+            Column {
+                id: controlCenterBlurCol
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                Item {
+                    width: parent.width
+                    height: 54
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "⎘"; tint: "#30d158" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "跟随显示设置"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: barPage.controlCenterBlurInherit
+                                    ? ("已跟随系统外观 (模糊 " + barPage.percentage(barPage.controlCenterBlurStrength) + " · 液态 " + barPage.percentage(barPage.controlCenterLiquidStrength) + ")")
+                                    : "已开启控制中心自定义材质"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                            }
+                        }
+                        LiquidControls.LiquidGlassSwitch {
+                            checked: barPage.controlCenterBlurInherit
+                            accentColor: "#30d158"
+                            trackColor: theme.divider
+                            onToggled: function(checked) {
+                                barPage.setControlCenterBlurInherit(checked)
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    visible: !barPage.controlCenterBlurInherit
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.leftMargin: 53
+                    height: 1
+                    color: theme.separator
+                }
+
+                Item {
+                    visible: !barPage.controlCenterBlurInherit
+                    width: parent.width
+                    height: 48
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
+                        Text {
+                            text: "控制中心模糊强度"
+                            color: theme.primaryText
+                            font.pixelSize: 14
+                        }
+                        Item { Layout.fillWidth: true }
+                        Text {
+                            text: barPage.percentage(barPage.controlCenterBlurStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 38
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 190
+                            value: barPage.controlCenterBlurStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                barPage.previewControlCenterBlur(position)
+                            }
+                            onCommitRequested: barPage.commitControlCenterBlur()
+                        }
+                    }
+                }
+
+                Rectangle {
+                    visible: !barPage.controlCenterBlurInherit
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.leftMargin: 53
+                    height: 1
+                    color: theme.separator
+                }
+
+                Item {
+                    visible: !barPage.controlCenterBlurInherit
+                    width: parent.width
+                    height: 48
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "≈"; tint: "#af52de" }
+                        Text {
+                            text: "控制中心液态强度"
+                            color: theme.primaryText
+                            font.pixelSize: 14
+                        }
+                        Item { Layout.fillWidth: true }
+                        Text {
+                            text: barPage.percentage(barPage.controlCenterLiquidStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 38
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 190
+                            value: barPage.controlCenterLiquidStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                barPage.previewControlCenterLiquid(position)
+                            }
+                            onCommitRequested: barPage.commitControlCenterLiquid()
                         }
                     }
                 }
@@ -2905,6 +3210,92 @@ ApplicationWindow {
         property int fontWeightIndex: 0
         property string errorText: ""
 
+        property bool launcherBlurInherit: true
+        property real launcherBlurStrength: 0.42
+        property real launcherLiquidStrength: 1.0
+        property bool launcherBlurDirty: false
+        property bool launcherLiquidDirty: false
+
+        function percentage(value) {
+            return Math.round(value * 100) + "%"
+        }
+
+        function setLauncherBlurInherit(enabled) {
+            if (!bridge) return
+            applyAppearanceState(bridge.updateLauncherBlurInherit(enabled))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        Timer {
+            id: liveLauncherBlurDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (launcherPage.bridge && launcherPage.launcherBlurDirty) {
+                    launcherPage.bridge.updateLauncherBlurStrength(launcherPage.launcherBlurStrength)
+                }
+            }
+        }
+
+        Timer {
+            id: liveLauncherLiquidDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (launcherPage.bridge && launcherPage.launcherLiquidDirty) {
+                    launcherPage.bridge.updateLauncherLiquidStrength(launcherPage.launcherLiquidStrength)
+                }
+            }
+        }
+
+        function previewLauncherBlur(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(launcherBlurStrength - clamped) < 0.005)
+                return
+            launcherBlurStrength = clamped
+            launcherBlurDirty = true
+            liveLauncherBlurDebounce.restart()
+        }
+
+        function commitLauncherBlur() {
+            liveLauncherBlurDebounce.stop()
+            if (!launcherBlurDirty || !bridge)
+                return
+            launcherBlurDirty = false
+            applyAppearanceState(bridge.updateLauncherBlurStrength(launcherBlurStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function previewLauncherLiquid(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(launcherLiquidStrength - clamped) < 0.005)
+                return
+            launcherLiquidStrength = clamped
+            launcherLiquidDirty = true
+            liveLauncherLiquidDebounce.restart()
+        }
+
+        function commitLauncherLiquid() {
+            liveLauncherLiquidDebounce.stop()
+            if (!launcherLiquidDirty || !bridge)
+                return
+            launcherLiquidDirty = false
+            applyAppearanceState(bridge.updateLauncherLiquidStrength(launcherLiquidStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function applyAppearanceState(state) {
+            if (!state) return
+            launcherBlurInherit = state.launcherBlurInherit !== undefined ? Boolean(state.launcherBlurInherit) : true
+            launcherBlurStrength = Number.isFinite(Number(state.launcherBlurStrength)) ? Number(state.launcherBlurStrength) : 0.42
+            launcherLiquidStrength = Number.isFinite(Number(state.launcherLiquidStrength)) ? Number(state.launcherLiquidStrength) : 1.0
+            launcherBlurDirty = false
+            launcherLiquidDirty = false
+        }
+
         function applySnapshot(snapshot) {
             if (!snapshot) return
             if (snapshot.displayMode !== undefined) {
@@ -2928,6 +3319,7 @@ ApplicationWindow {
             if (!bridge) return
             const snap = bridge.launcherSnapshot()
             applySnapshot(snap)
+            applyAppearanceState(bridge.appearanceSnapshot())
             if (bridge.lastError)
                 errorText = bridge.lastError
         }
@@ -3213,6 +3605,153 @@ ApplicationWindow {
         }
 
         Text {
+            text: "启动台外观与模糊效果".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+            Layout.topMargin: 14
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: launcherBlurCol.implicitHeight
+            radius: 18
+            color: theme.card
+
+            Column {
+                id: launcherBlurCol
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                Item {
+                    width: parent.width
+                    height: 54
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "⎘"; tint: "#30d158" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "跟随显示设置"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: launcherPage.launcherBlurInherit
+                                    ? ("已跟随系统外观 (模糊 " + launcherPage.percentage(launcherPage.launcherBlurStrength) + " · 液态 " + launcherPage.percentage(launcherPage.launcherLiquidStrength) + ")")
+                                    : "已开启启动台自定义材质"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                            }
+                        }
+                        LiquidControls.LiquidGlassSwitch {
+                            checked: launcherPage.launcherBlurInherit
+                            accentColor: "#30d158"
+                            trackColor: theme.divider
+                            onToggled: function(checked) {
+                                launcherPage.setLauncherBlurInherit(checked)
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    visible: !launcherPage.launcherBlurInherit
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.leftMargin: 53
+                    height: 1
+                    color: theme.separator
+                }
+
+                Item {
+                    visible: !launcherPage.launcherBlurInherit
+                    width: parent.width
+                    height: 48
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
+                        Text {
+                            text: "启动台模糊强度"
+                            color: theme.primaryText
+                            font.pixelSize: 14
+                        }
+                        Item { Layout.fillWidth: true }
+                        Text {
+                            text: launcherPage.percentage(launcherPage.launcherBlurStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 38
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 190
+                            value: launcherPage.launcherBlurStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                launcherPage.previewLauncherBlur(position)
+                            }
+                            onCommitRequested: launcherPage.commitLauncherBlur()
+                        }
+                    }
+                }
+
+                Rectangle {
+                    visible: !launcherPage.launcherBlurInherit
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.leftMargin: 53
+                    height: 1
+                    color: theme.separator
+                }
+
+                Item {
+                    visible: !launcherPage.launcherBlurInherit
+                    width: parent.width
+                    height: 48
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 16
+                        anchors.rightMargin: 16
+                        spacing: 12
+                        SettingIcon { symbol: "≈"; tint: "#af52de" }
+                        Text {
+                            text: "启动台液态强度"
+                            color: theme.primaryText
+                            font.pixelSize: 14
+                        }
+                        Item { Layout.fillWidth: true }
+                        Text {
+                            text: launcherPage.percentage(launcherPage.launcherLiquidStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 38
+                            horizontalAlignment: Text.AlignRight
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 190
+                            value: launcherPage.launcherLiquidStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                launcherPage.previewLauncherLiquid(position)
+                            }
+                            onCommitRequested: launcherPage.commitLauncherLiquid()
+                        }
+                    }
+                }
+            }
+        }
+
+        Text {
             Layout.fillWidth: true
             Layout.leftMargin: 13
             Layout.rightMargin: 13
@@ -3342,7 +3881,6 @@ ApplicationWindow {
                     navSymbol: "✓"
                     navTint: "#30d158"
                 }
-
                 Item {
                     Layout.fillHeight: true
                 }
@@ -3427,7 +3965,6 @@ ApplicationWindow {
                     IntegrationStatusPage {
                         visible: window.currentPage === 6
                     }
-
                     DockSettingsPage {
                         visible: window.currentPage === 3
                     }

--- a/apps/settings/src/main.cpp
+++ b/apps/settings/src/main.cpp
@@ -87,6 +87,78 @@ public:
             QString::number(strength, 'f', 3)}));
     }
 
+    Q_INVOKABLE QVariantMap updateDockBlurStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateDockBlurStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateDockLiquidStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateDockLiquidStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateDockBlurInherit(bool enabled) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateDockBlurInherit"),
+            enabled ? QStringLiteral("true") : QStringLiteral("false")}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBarBlurStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBarBlurStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBarLiquidStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBarLiquidStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBarBlurInherit(bool enabled) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBarBlurInherit"),
+            enabled ? QStringLiteral("true") : QStringLiteral("false")}));
+    }
+
+    Q_INVOKABLE QVariantMap updateControlCenterBlurStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateControlCenterBlurStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateControlCenterLiquidStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateControlCenterLiquidStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateControlCenterBlurInherit(bool enabled) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateControlCenterBlurInherit"),
+            enabled ? QStringLiteral("true") : QStringLiteral("false")}));
+    }
+
+    Q_INVOKABLE QVariantMap updateLauncherBlurStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateLauncherBlurStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateLauncherLiquidStrength(double strength) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateLauncherLiquidStrength"),
+            QString::number(strength, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateLauncherBlurInherit(bool enabled) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateLauncherBlurInherit"),
+            enabled ? QStringLiteral("true") : QStringLiteral("false")}));
+    }
+
     Q_INVOKABLE QVariantMap updateGlobalIconMode(const QString &mode) {
         return appearanceSnapshotFromReply(callAppearance({
             QStringLiteral("updateGlobalIconMode"), mode}));
@@ -178,6 +250,104 @@ public:
             QStringLiteral("resetProfile"), mode}));
     }
 
+    static QString readKdeConfig(const QString &file, const QString &group, const QString &key) {
+        QProcess proc;
+        proc.start(QStringLiteral("kreadconfig6"), {
+            QStringLiteral("--file"), file,
+            QStringLiteral("--group"), group,
+            QStringLiteral("--key"), key
+        });
+        if (proc.waitForStarted(1000) && proc.waitForFinished(2000) && proc.exitCode() == 0) {
+            return QString::fromUtf8(proc.readAllStandardOutput()).trimmed();
+        }
+        return {};
+    }
+
+    static QStringList listInstalledLookAndFeels() {
+        QProcess proc;
+        proc.start(QStringLiteral("plasma-apply-lookandfeel"), {QStringLiteral("-l")});
+        if (proc.waitForStarted(1000) && proc.waitForFinished(3000) && proc.exitCode() == 0) {
+            const QString output = QString::fromUtf8(proc.readAllStandardOutput());
+            QStringList list;
+            const auto lines = output.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+            for (const QString &line : lines) {
+                const QString trimmed = line.trimmed();
+                if (!trimmed.isEmpty()) {
+                    list.append(trimmed);
+                }
+            }
+            return list;
+        }
+        return {};
+    }
+
+    static QString resolveThemePartner(const QString &currentTheme, bool targetDark, const QStringList &installed) {
+        if (currentTheme.isEmpty())
+            return {};
+        QStringList candidates;
+
+        if (targetDark) {
+            if (currentTheme.endsWith(QStringLiteral("-w")))
+                candidates.append(currentTheme.chopped(2) + QStringLiteral("-d"));
+            if (currentTheme.endsWith(QStringLiteral("_w")))
+                candidates.append(currentTheme.chopped(2) + QStringLiteral("_d"));
+            if (currentTheme.endsWith(QStringLiteral("Light")))
+                candidates.append(currentTheme.chopped(5) + QStringLiteral("Dark"));
+            if (currentTheme.endsWith(QStringLiteral("-Light")))
+                candidates.append(currentTheme.chopped(6) + QStringLiteral("-Dark"));
+            if (currentTheme.endsWith(QStringLiteral("_Light")))
+                candidates.append(currentTheme.chopped(6) + QStringLiteral("_Dark"));
+            if (currentTheme.contains(QStringLiteral("light"), Qt::CaseInsensitive)) {
+                QString c = currentTheme;
+                candidates.append(c.replace(QStringLiteral("light"), QStringLiteral("dark"), Qt::CaseInsensitive));
+            }
+            if (currentTheme.endsWith(QStringLiteral(".desktop"))) {
+                const QString base = currentTheme.chopped(8);
+                candidates.append(base + QStringLiteral("dark.desktop"));
+                candidates.append(base + QStringLiteral("-dark.desktop"));
+                candidates.append(base + QStringLiteral("Dark.desktop"));
+            }
+            candidates.append(currentTheme + QStringLiteral("-Dark"));
+            candidates.append(currentTheme + QStringLiteral("Dark"));
+            candidates.append(currentTheme + QStringLiteral("-d"));
+        } else {
+            if (currentTheme.endsWith(QStringLiteral("-d")))
+                candidates.append(currentTheme.chopped(2) + QStringLiteral("-w"));
+            if (currentTheme.endsWith(QStringLiteral("_d")))
+                candidates.append(currentTheme.chopped(2) + QStringLiteral("_w"));
+            if (currentTheme.endsWith(QStringLiteral("Dark"))) {
+                candidates.append(currentTheme.chopped(4) + QStringLiteral("Light"));
+                candidates.append(currentTheme.chopped(4));
+            }
+            if (currentTheme.endsWith(QStringLiteral("-Dark"))) {
+                candidates.append(currentTheme.chopped(5) + QStringLiteral("-Light"));
+                candidates.append(currentTheme.chopped(5));
+            }
+            if (currentTheme.endsWith(QStringLiteral("_Dark"))) {
+                candidates.append(currentTheme.chopped(5) + QStringLiteral("-Light"));
+                candidates.append(currentTheme.chopped(5));
+            }
+            if (currentTheme.contains(QStringLiteral("dark"), Qt::CaseInsensitive)) {
+                QString c = currentTheme;
+                candidates.append(c.replace(QStringLiteral("dark"), QStringLiteral("light"), Qt::CaseInsensitive));
+                QString c2 = currentTheme;
+                candidates.append(c2.remove(QStringLiteral("dark"), Qt::CaseInsensitive));
+            }
+            if (currentTheme.endsWith(QStringLiteral("dark.desktop"), Qt::CaseInsensitive)) {
+                candidates.append(currentTheme.chopped(12) + QStringLiteral(".desktop"));
+                candidates.append(currentTheme.chopped(12) + QStringLiteral("light.desktop"));
+            }
+        }
+
+        for (const QString &cand : candidates) {
+            for (const QString &inst : installed) {
+                if (inst.compare(cand, Qt::CaseInsensitive) == 0)
+                    return inst;
+            }
+        }
+        return {};
+    }
+
     Q_INVOKABLE bool applySystemAppearance(bool dark) {
         QJsonParseError parseError;
         const QJsonDocument document = QJsonDocument::fromJson(
@@ -240,6 +410,8 @@ public:
         result.insert(QStringLiteral("kwinAvailable"), effects.isValid());
         result.insert(QStringLiteral("glassLoaded"),
                       loadedEffects.contains(QStringLiteral("glass")));
+        result.insert(QStringLiteral("blurLoaded"),
+                      loadedEffects.contains(QStringLiteral("blur")));
         result.insert(QStringLiteral("dockAnimationLoaded"),
                       loadedEffects.contains(QStringLiteral("kos_dock_window_animation")));
         result.insert(QStringLiteral("contextMenuInputLoaded"),
@@ -325,12 +497,66 @@ private:
         return {
             {QStringLiteral("globalBlurStrength"), globalBlur},
             {QStringLiteral("globalLiquidStrength"), globalLiquid},
-            {QStringLiteral("effectiveDockBlur"), globalBlur},
-            {QStringLiteral("effectiveDockLiquid"), globalLiquid},
-            {QStringLiteral("effectiveBarBlur"), globalBlur},
-            {QStringLiteral("effectiveBarLiquid"), globalLiquid},
-            {QStringLiteral("effectiveLauncherBlur"), globalBlur},
-            {QStringLiteral("effectiveLauncherLiquid"), globalLiquid},
+            {QStringLiteral("effectiveDockBlur"),
+                object.contains(QStringLiteral("effectiveDockBlur"))
+                    ? object.value(QStringLiteral("effectiveDockBlur")).toDouble() : globalBlur},
+            {QStringLiteral("effectiveDockLiquid"),
+                object.contains(QStringLiteral("effectiveDockLiquid"))
+                    ? object.value(QStringLiteral("effectiveDockLiquid")).toDouble() : globalLiquid},
+            {QStringLiteral("effectiveBarBlur"),
+                object.contains(QStringLiteral("effectiveBarBlur"))
+                    ? object.value(QStringLiteral("effectiveBarBlur")).toDouble() : globalBlur},
+            {QStringLiteral("effectiveBarLiquid"),
+                object.contains(QStringLiteral("effectiveBarLiquid"))
+                    ? object.value(QStringLiteral("effectiveBarLiquid")).toDouble() : globalLiquid},
+            {QStringLiteral("effectiveControlCenterBlur"),
+                object.contains(QStringLiteral("effectiveControlCenterBlur"))
+                    ? object.value(QStringLiteral("effectiveControlCenterBlur")).toDouble() : globalBlur},
+            {QStringLiteral("effectiveControlCenterLiquid"),
+                object.contains(QStringLiteral("effectiveControlCenterLiquid"))
+                    ? object.value(QStringLiteral("effectiveControlCenterLiquid")).toDouble() : globalLiquid},
+            {QStringLiteral("effectiveLauncherBlur"),
+                object.contains(QStringLiteral("effectiveLauncherBlur"))
+                    ? object.value(QStringLiteral("effectiveLauncherBlur")).toDouble() : globalBlur},
+            {QStringLiteral("effectiveLauncherLiquid"),
+                object.contains(QStringLiteral("effectiveLauncherLiquid"))
+                    ? object.value(QStringLiteral("effectiveLauncherLiquid")).toDouble() : globalLiquid},
+            {QStringLiteral("dockBlurStrength"),
+                object.contains(QStringLiteral("dockBlurStrength"))
+                    ? object.value(QStringLiteral("dockBlurStrength")).toDouble() : globalBlur},
+            {QStringLiteral("dockLiquidStrength"),
+                object.contains(QStringLiteral("dockLiquidStrength"))
+                    ? object.value(QStringLiteral("dockLiquidStrength")).toDouble() : globalLiquid},
+            {QStringLiteral("dockBlurInherit"),
+                object.contains(QStringLiteral("dockBlurInherit"))
+                    ? object.value(QStringLiteral("dockBlurInherit")).toBool() : true},
+            {QStringLiteral("barBlurStrength"),
+                object.contains(QStringLiteral("barBlurStrength"))
+                    ? object.value(QStringLiteral("barBlurStrength")).toDouble() : globalBlur},
+            {QStringLiteral("barLiquidStrength"),
+                object.contains(QStringLiteral("barLiquidStrength"))
+                    ? object.value(QStringLiteral("barLiquidStrength")).toDouble() : globalLiquid},
+            {QStringLiteral("barBlurInherit"),
+                object.contains(QStringLiteral("barBlurInherit"))
+                    ? object.value(QStringLiteral("barBlurInherit")).toBool() : true},
+            {QStringLiteral("controlCenterBlurStrength"),
+                object.contains(QStringLiteral("controlCenterBlurStrength"))
+                    ? object.value(QStringLiteral("controlCenterBlurStrength")).toDouble() : globalBlur},
+            {QStringLiteral("controlCenterLiquidStrength"),
+                object.contains(QStringLiteral("controlCenterLiquidStrength"))
+                    ? object.value(QStringLiteral("controlCenterLiquidStrength")).toDouble() : globalLiquid},
+            {QStringLiteral("controlCenterBlurInherit"),
+                object.contains(QStringLiteral("controlCenterBlurInherit"))
+                    ? object.value(QStringLiteral("controlCenterBlurInherit")).toBool() : true},
+            {QStringLiteral("launcherBlurStrength"),
+                object.contains(QStringLiteral("launcherBlurStrength"))
+                    ? object.value(QStringLiteral("launcherBlurStrength")).toDouble() : globalBlur},
+            {QStringLiteral("launcherLiquidStrength"),
+                object.contains(QStringLiteral("launcherLiquidStrength"))
+                    ? object.value(QStringLiteral("launcherLiquidStrength")).toDouble() : globalLiquid},
+            {QStringLiteral("launcherBlurInherit"),
+                object.contains(QStringLiteral("launcherBlurInherit"))
+                    ? object.value(QStringLiteral("launcherBlurInherit")).toBool() : true},
             {QStringLiteral("blurStrength"), globalBlur},
             {QStringLiteral("liquidStrength"), globalLiquid},
             {QStringLiteral("iconMode"), object.value(QStringLiteral("iconMode")).toString(QStringLiteral("color"))},
@@ -464,52 +690,70 @@ private:
         const QString source = QStringLiteral(SETTINGS_SHELL_DIR);
         if (QFileInfo::exists(QDir(source).filePath(QStringLiteral("shell.qml"))))
             return source;
+        if (QFileInfo::exists(QDir(source).filePath(QStringLiteral("shell/shell.qml"))))
+            return QDir(source).filePath(QStringLiteral("shell"));
 
         const QString installed = QStandardPaths::writableLocation(
             QStandardPaths::ConfigLocation) + QStringLiteral("/quickshell/kos");
         return installed;
     }
 
+    static QList<QStringList> candidateConnectArgs(const QString &preferredShellPath) {
+        QList<QStringList> candidates;
+        const QString installed = QStandardPaths::writableLocation(
+            QStandardPaths::ConfigLocation) + QStringLiteral("/quickshell/kos");
+        const QString source = QStringLiteral(SETTINGS_SHELL_DIR);
+        const QString sourceShell = QDir(source).filePath(QStringLiteral("shell"));
+
+        auto addCandidate = [&](const QStringList &args) {
+            if (!candidates.contains(args))
+                candidates.append(args);
+        };
+
+        if (preferredShellPath == installed)
+            addCandidate({QStringLiteral("-c"), QStringLiteral("kos")});
+        else if (!preferredShellPath.isEmpty())
+            addCandidate({QStringLiteral("--path"), preferredShellPath});
+
+        if (QFileInfo::exists(QDir(source).filePath(QStringLiteral("shell.qml"))))
+            addCandidate({QStringLiteral("--path"), source});
+        if (QFileInfo::exists(QDir(source).filePath(QStringLiteral("shell/shell.qml"))))
+            addCandidate({QStringLiteral("--path"), sourceShell});
+        addCandidate({QStringLiteral("-c"), QStringLiteral("kos")});
+
+        return candidates;
+    }
+
     QString callShell(const QString &target, const QStringList &arguments,
                       const QString &fallbackError) {
         const QString shellPath = shellDirectory();
         QString failure;
-        // Quickshell tracks instances by how they identify their config: a
-        // Shell launched as `-c kos` is NOT matched by `--path <same dir>`.
-        // The installed session runs as `-c kos`, so address it by name;
-        // development sessions (`-p <dir>`) take the explicit path.
-        const QString installed = QStandardPaths::writableLocation(
-            QStandardPaths::ConfigLocation) + QStringLiteral("/quickshell/kos");
-        QStringList connectArgs;
-        if (shellPath == installed)
-            connectArgs = {QStringLiteral("-c"), QStringLiteral("kos")};
-        else
-            connectArgs = {QStringLiteral("--path"), shellPath};
-        // The Shell can still be registering IPC targets during the first
-        // moments of a development launch. Retry once instead of turning that
-        // brief race into a permanent, opaque Settings error.
-        for (int attempt = 0; attempt < 2; ++attempt) {
-            QProcess process;
-            QStringList command = connectArgs;
-            command << QStringLiteral("ipc") << QStringLiteral("call") << target;
-            command.append(arguments);
-            process.start(QStringLiteral("quickshell"), command);
-            if (!process.waitForStarted(1500)) {
-                failure = QStringLiteral("无法启动 Quickshell IPC");
-            } else if (!process.waitForFinished(5000)) {
-                process.kill();
-                process.waitForFinished();
-                failure = QStringLiteral("桌面环境没有响应（超过 5 秒）");
-            } else if (process.exitStatus() == QProcess::NormalExit
-                       && process.exitCode() == 0) {
-                return QString::fromUtf8(process.readAllStandardOutput()).trimmed();
-            } else {
-                failure = QString::fromUtf8(process.readAllStandardError()).trimmed();
-                if (failure.isEmpty())
-                    failure = fallbackError;
+        const auto candidates = candidateConnectArgs(shellPath);
+
+        for (const QStringList &connectArgs : candidates) {
+            for (int attempt = 0; attempt < 2; ++attempt) {
+                QProcess process;
+                QStringList command = connectArgs;
+                command << QStringLiteral("ipc") << QStringLiteral("call") << target;
+                command.append(arguments);
+                process.start(QStringLiteral("quickshell"), command);
+                if (!process.waitForStarted(1500)) {
+                    failure = QStringLiteral("无法启动 Quickshell IPC");
+                } else if (!process.waitForFinished(5000)) {
+                    process.kill();
+                    process.waitForFinished();
+                    failure = QStringLiteral("桌面环境没有响应（超过 5 秒）");
+                } else if (process.exitStatus() == QProcess::NormalExit
+                           && process.exitCode() == 0) {
+                    return QString::fromUtf8(process.readAllStandardOutput()).trimmed();
+                } else {
+                    failure = QString::fromUtf8(process.readAllStandardError()).trimmed();
+                    if (failure.isEmpty())
+                        failure = fallbackError;
+                }
+                if (attempt == 0)
+                    QThread::msleep(80);
             }
-            if (attempt == 0)
-                QThread::msleep(120);
         }
         setLastError(QStringLiteral("%1（IPC：%2；Shell：%3）")
                          .arg(failure, target, shellPath));

--- a/integrations/kwin/decoration-liquid-glass/liquidglassdecoration.cpp
+++ b/integrations/kwin/decoration-liquid-glass/liquidglassdecoration.cpp
@@ -353,8 +353,8 @@ void LiquidGlassDecoration::paintTitleBar(QPainter *painter)
         return QColor(255, 255, 255, qRound(alpha * liquid));
     };
     QLinearGradient specular(bar.topLeft(), bar.bottomLeft());
-    specular.setColorAt(0.0, reflection(dark ? 26 : 88));
-    specular.setColorAt(0.45, reflection(dark ? 8 : 25));
+    specular.setColorAt(0.0, reflection(dark ? 31 : 107));
+    specular.setColorAt(0.45, reflection(dark ? 10 : 31));
     specular.setColorAt(1.0, QColor(255, 255, 255, 0));
     painter->setBrush(specular);
     painter->drawPath(path);

--- a/packaging/desktop/org.kos.Platform.desktop.in
+++ b/packaging/desktop/org.kos.Platform.desktop.in
@@ -6,4 +6,4 @@ Exec=@KOS_PLATFORM_EXEC@ daemon
 Icon=preferences-system
 NoDisplay=true
 Terminal=false
-X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2
+X-KDE-DBUS-Restricted-Interfaces=org.kde.kwin.Screenshot,org.kde.KWin.ScreenShot2

--- a/platform/src/daemon/PlatformServer.cpp
+++ b/platform/src/daemon/PlatformServer.cpp
@@ -11,6 +11,7 @@
 #include <QDBusMessage>
 #include <QDBusObjectPath>
 #include <QDBusPendingCallWatcher>
+#include <QDBusReply>
 #include <QDBusVariant>
 #include <QDateTime>
 #include <QDir>
@@ -126,6 +127,10 @@ QJsonObject menuItemFromArgument(const QDBusArgument &argument)
     const QVariant label = unwrapDbusValue(properties.value(QStringLiteral("label")));
     const QVariant visible = unwrapDbusValue(properties.value(QStringLiteral("visible")));
     const QVariant enabled = unwrapDbusValue(properties.value(QStringLiteral("enabled")));
+    const QVariant iconName = unwrapDbusValue(properties.value(QStringLiteral("icon-name")));
+    const QVariant childrenDisplay = unwrapDbusValue(properties.value(QStringLiteral("children-display")));
+    const QVariant toggleType = unwrapDbusValue(properties.value(QStringLiteral("toggle-type")));
+    const QVariant toggleState = unwrapDbusValue(properties.value(QStringLiteral("toggle-state")));
     QJsonArray children;
     argument.beginArray();
     while (!argument.atEnd()) {
@@ -139,12 +144,19 @@ QJsonObject menuItemFromArgument(const QDBusArgument &argument)
     }
     argument.endArray();
     argument.endStructure();
+    const bool hasChildren = !children.isEmpty()
+        || childrenDisplay.toString() == QStringLiteral("submenu");
+    const bool checkable = toggleType.isValid() && !toggleType.toString().isEmpty();
+    const bool checked = toggleState.isValid() && toggleState.toInt() == 1;
     return QJsonObject{{QStringLiteral("id"), id},
                        {QStringLiteral("label"), label.toString().remove(QLatin1Char('_'))},
+                       {QStringLiteral("icon"), QString()},
                        {QStringLiteral("separator"), type.toString() == QStringLiteral("separator")},
                        {QStringLiteral("visible"), !visible.isValid() || visible.toBool()},
                        {QStringLiteral("enabled"), !enabled.isValid() || enabled.toBool()},
-                       {QStringLiteral("hasChildren"), !children.isEmpty()},
+                       {QStringLiteral("hasChildren"), hasChildren},
+                       {QStringLiteral("checkable"), checkable},
+                       {QStringLiteral("checked"), checked},
                        {QStringLiteral("children"), children}};
 }
 
@@ -519,6 +531,73 @@ QJsonObject parseBluetooth(const QByteArray &output, int exitCode)
     return QJsonObject{{QStringLiteral("available"), exitCode == 0 && powerMatch.hasMatch()},
                        {QStringLiteral("powered"), powerMatch.hasMatch() && powerMatch.captured(1).toLower() == QStringLiteral("yes")},
                        {QStringLiteral("devices"), devices}};
+}
+
+QJsonObject readKdeBrightness()
+{
+    QDBusInterface kde(QStringLiteral("org.kde.Solid.PowerManagement"),
+                       QStringLiteral("/org/kde/Solid/PowerManagement/Actions/BrightnessControl"),
+                       QStringLiteral("org.kde.Solid.PowerManagement.Actions.BrightnessControl"),
+                       QDBusConnection::sessionBus());
+    if (!kde.isValid())
+        return QJsonObject{{QStringLiteral("available"), false}};
+
+    const QDBusReply<int> maxReply = kde.call(QStringLiteral("brightnessMax"));
+    if (!maxReply.isValid() || maxReply.value() <= 0)
+        return QJsonObject{{QStringLiteral("available"), false}};
+
+    const int maximum = maxReply.value();
+    const QDBusReply<int> curReply = kde.call(QStringLiteral("brightness"));
+    const int current = curReply.isValid() ? curReply.value() : 0;
+    const int percent = qRound(qBound(0.0, current * 100.0 / maximum, 100.0));
+
+    return QJsonObject{{QStringLiteral("available"), true},
+                       {QStringLiteral("percent"), percent},
+                       {QStringLiteral("device"), QStringLiteral("kde")},
+                       {QStringLiteral("maximum"), maximum}};
+}
+
+bool setKdeBrightness(int percent)
+{
+    QDBusInterface kde(QStringLiteral("org.kde.Solid.PowerManagement"),
+                       QStringLiteral("/org/kde/Solid/PowerManagement/Actions/BrightnessControl"),
+                       QStringLiteral("org.kde.Solid.PowerManagement.Actions.BrightnessControl"),
+                       QDBusConnection::sessionBus());
+    if (!kde.isValid())
+        return false;
+
+    const QDBusReply<int> maxReply = kde.call(QStringLiteral("brightnessMax"));
+    if (!maxReply.isValid() || maxReply.value() <= 0)
+        return false;
+
+    const int maximum = maxReply.value();
+    const int targetVal = qRound(percent * maximum / 100.0);
+    kde.call(QStringLiteral("setBrightness"), targetVal);
+
+    QDBusInterface screenBrightness(QStringLiteral("org.kde.ScreenBrightness"),
+                                    QStringLiteral("/org/kde/ScreenBrightness"),
+                                    QStringLiteral("org.kde.ScreenBrightness"),
+                                    QDBusConnection::sessionBus());
+    if (screenBrightness.isValid()) {
+        const QStringList displays = screenBrightness.property("DisplaysDBusNames").toStringList();
+        for (const QString &d : displays) {
+            QString path = d;
+            if (!path.startsWith(QLatin1Char('/')))
+                path = QStringLiteral("/org/kde/ScreenBrightness/") + d;
+            QDBusInterface display(QStringLiteral("org.kde.ScreenBrightness"),
+                                   path,
+                                   QStringLiteral("org.kde.ScreenBrightness.Display"),
+                                   QDBusConnection::sessionBus());
+            if (display.isValid()) {
+                const int dMax = display.property("MaxBrightness").toInt();
+                if (dMax > 0) {
+                    const int dVal = qRound(percent * dMax / 100.0);
+                    display.call(QStringLiteral("SetBrightness"), dVal, static_cast<uint>(0));
+                }
+            }
+        }
+    }
+    return true;
 }
 
 QJsonObject readSysfsBrightness()
@@ -1918,10 +1997,12 @@ bool PlatformServer::handleAppMenu(QLocalSocket *socket, const QJsonObject &requ
     if (op == QStringLiteral("appmenu.layout")) {
         // The root needs one additional level so top-level labels such as
         // File and Edit are identified as submenus rather than actions.
-        const int depth = qBound(1, payload.value(QStringLiteral("depth")).toInt(1), 2);
+        const int depth = qBound(1, payload.value(QStringLiteral("depth")).toInt(1), 5);
         const QDBusMessage reply = menu.call(QStringLiteral("GetLayout"), id, depth,
             QStringList{QStringLiteral("label"), QStringLiteral("visible"),
-                        QStringLiteral("enabled"), QStringLiteral("type")});
+                        QStringLiteral("enabled"), QStringLiteral("type"),
+                        QStringLiteral("children-display"), QStringLiteral("toggle-type"),
+                        QStringLiteral("toggle-state"), QStringLiteral("icon-name")});
         if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().size() < 2) {
             respond(socket, request, false, {}, QStringLiteral("appmenu-layout-failed"),
                     QStringLiteral("无法读取应用菜单"), true);
@@ -1940,8 +2021,18 @@ bool PlatformServer::handleAppMenu(QLocalSocket *socket, const QJsonObject &requ
             : op == QStringLiteral("appmenu.close") ? QStringLiteral("closed")
             : QStringLiteral("clicked");
         const quint32 timestamp = static_cast<quint32>(QDateTime::currentMSecsSinceEpoch());
+
+        if (op == QStringLiteral("appmenu.open")) {
+            // Give Qt / KDE applications an opportunity to populate lazy dynamic submenus.
+            menu.call(QStringLiteral("AboutToShow"), id);
+        }
+
+        // com.canonical.dbusmenu Event signature is (isvu): the data argument
+        // MUST be typed as a D-Bus variant. Sending a bare QVariantMap produces
+        // (isa{sv}u), which Qt's QDBusMenuAdaptor rejects as an unknown method.
+        const QDBusVariant dbusData(QVariantMap{{QStringLiteral("timestamp"), timestamp}});
         const QDBusMessage reply = menu.call(QStringLiteral("Event"), id, event,
-            QVariantMap{{QStringLiteral("timestamp"), timestamp}}, timestamp);
+            QVariant::fromValue(dbusData), timestamp);
         if (reply.type() == QDBusMessage::ErrorMessage) {
             respond(socket, request, false, {}, QStringLiteral("appmenu-event-failed"),
                     QStringLiteral("应用菜单操作失败"), true);
@@ -2289,6 +2380,11 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
         return true;
     }
     if (op == QStringLiteral("display.brightness.get")) {
+        const QJsonObject kdeBrightness = readKdeBrightness();
+        if (kdeBrightness.value(QStringLiteral("available")).toBool()) {
+            respond(socket, request, true, kdeBrightness);
+            return true;
+        }
         const QString brightnessctl = QStandardPaths::findExecutable(QStringLiteral("brightnessctl"));
         if (!brightnessctl.isEmpty())
             runCommand(socket, request, brightnessctl, {QStringLiteral("-m")}, parseBrightness);
@@ -2298,6 +2394,10 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
     }
     if (op == QStringLiteral("display.brightness.set")) {
         const int value = qBound(0, payload.value(QStringLiteral("percent")).toInt(), 100);
+        if (setKdeBrightness(value)) {
+            respond(socket, request, true, QJsonObject{{QStringLiteral("percent"), value}});
+            return true;
+        }
         const QString brightnessctl = QStandardPaths::findExecutable(QStringLiteral("brightnessctl"));
         if (!brightnessctl.isEmpty()) {
             runCommand(socket, request, brightnessctl,

--- a/shared/qml/test_visual_contract.mjs
+++ b/shared/qml/test_visual_contract.mjs
@@ -289,7 +289,7 @@ assert.match(networkPanel,
     "the network panel reuses the live Wi-Fi signal glyph");
 for (const marker of ["Card 1: Wi-Fi", "Card 2: Bluetooth"]) {
     const start = controlCenterPanel.indexOf(marker);
-    const section = controlCenterPanel.slice(start, start + 5200);
+    const section = controlCenterPanel.slice(start, start + 8000);
     assert.match(section,
         /id:\s*(?:wifi|bluetooth)TogglePointer[\s\S]{0,420}onClicked:[\s\S]{0,140}set(?:Wifi|Bluetooth)Enabled/,
         `${marker} round disc owns its power toggle`);
@@ -300,7 +300,7 @@ for (const marker of ["Card 1: Wi-Fi", "Card 2: Bluetooth"]) {
 for (const component of ["NetworkStatus", "Battery", "SettingsButton",
                          "ControlCenterToggle"]) {
     assert.match(barStatusArea,
-        new RegExp(component + "\\s*\\{[\\s\\S]{0,180}iconSize:\\s*systemTray\\.iconSize"),
+        new RegExp(component + "\\s*\\{[\\s\\S]{0,400}iconSize:\\s*systemTray\\.iconSize(?:\\s*\\+\\s*\\d+)?"),
         component + " shares the native tray icon size");
 }
 assert.doesNotMatch(controlCenterPanel,

--- a/shell/desktop/DesktopAppLauncher.qml
+++ b/shell/desktop/DesktopAppLauncher.qml
@@ -8,9 +8,9 @@ QtObject {
     id: launcher
 
     readonly property string settingsBinary:
-        Quickshell.shellDir + "/../apps/settings/build/kos-settings"
+        Quickshell.shellDir + "/apps/settings/build/kos-settings"
 
-    function openSettings() {
+    function openSettings(page) {
         Quickshell.execDetached([
             "sh", "-c",
             // Settings talks back to its Shell over Quickshell IPC. Preserve
@@ -20,14 +20,18 @@ QtObject {
             // limited to the one canonical in-tree artifact plus the
             // installed copy: a second build tree would drift and open a
             // Settings build that does not match the running Shell.
-            "export KOS_SHELL_DIR=\"$2\"; "
-            + "if [ -x \"$1\" ]; then exec \"$1\"; fi; "
-            + "if command -v kos-settings >/dev/null 2>&1; then exec kos-settings; fi; "
-            + "if [ -x \"$HOME/.local/bin/kos-settings\" ]; then exec \"$HOME/.local/bin/kos-settings\"; fi; "
+            "export KOS_SHELL_DIR=\"$2\"; page=\"$3\"; set --; "
+            + "if [ -n \"$page\" ]; then set -- --page \"$page\"; fi; "
+            + "if [ -x \"$2/apps/settings/build/kos-settings\" ]; then exec \"$2/apps/settings/build/kos-settings\" \"$@\"; fi; "
+            + "if [ -x \"$2/../apps/settings/build/kos-settings\" ]; then exec \"$2/../apps/settings/build/kos-settings\" \"$@\"; fi; "
+            + "if [ -x \"$1\" ]; then exec \"$1\" \"$@\"; fi; "
+            + "if command -v kos-settings >/dev/null 2>&1; then exec kos-settings \"$@\"; fi; "
+            + "if [ -x \"$HOME/.local/bin/kos-settings\" ]; then exec \"$HOME/.local/bin/kos-settings\" \"$@\"; fi; "
             + "echo 'kos-settings is not built; run ./tools/kosctl build' >&2; exit 1",
             "kos-settings-launch",
             launcher.settingsBinary,
-            Quickshell.shellDir
+            Quickshell.shellDir,
+            String(page ?? "")
         ])
     }
 }

--- a/shell/desktop/DesktopEnvironment.qml
+++ b/shell/desktop/DesktopEnvironment.qml
@@ -130,10 +130,32 @@ Item {
                 effectiveDockLiquid: AppearanceConfigService.effectiveDockLiquid,
                 effectiveBarBlur: AppearanceConfigService.effectiveBarBlur,
                 effectiveBarLiquid: AppearanceConfigService.effectiveBarLiquid,
+                effectiveControlCenterBlur:
+                    AppearanceConfigService.effectiveControlCenterBlur,
+                effectiveControlCenterLiquid:
+                    AppearanceConfigService.effectiveControlCenterLiquid,
                 effectiveLauncherBlur:
                     AppearanceConfigService.effectiveLauncherBlur,
                 effectiveLauncherLiquid:
                     AppearanceConfigService.effectiveLauncherLiquid,
+                dockBlurStrength: AppearanceConfigService.dockBlurStrength,
+                dockLiquidStrength: AppearanceConfigService.dockLiquidStrength,
+                dockBlurInherit: AppearanceConfigService.dockBlurInherit,
+                barBlurStrength: AppearanceConfigService.barBlurStrength,
+                barLiquidStrength: AppearanceConfigService.barLiquidStrength,
+                barBlurInherit: AppearanceConfigService.barBlurInherit,
+                controlCenterBlurStrength:
+                    AppearanceConfigService.controlCenterBlurStrength,
+                controlCenterLiquidStrength:
+                    AppearanceConfigService.controlCenterLiquidStrength,
+                controlCenterBlurInherit:
+                    AppearanceConfigService.controlCenterBlurInherit,
+                launcherBlurStrength:
+                    AppearanceConfigService.launcherBlurStrength,
+                launcherLiquidStrength:
+                    AppearanceConfigService.launcherLiquidStrength,
+                launcherBlurInherit:
+                    AppearanceConfigService.launcherBlurInherit,
                 blurStrength: AppearanceConfigService.globalBlurStrength,
                 liquidStrength: AppearanceConfigService.globalLiquidStrength,
                 iconMode: IconAppearanceService.mode,
@@ -160,6 +182,66 @@ Item {
 
         function updateGlobalLiquidStrength(value: real): string {
             AppearanceConfigService.updateGlobalLiquidStrength(value)
+            return snapshot()
+        }
+
+        function updateDockBlurStrength(value: real): string {
+            AppearanceConfigService.updateDockBlurStrength(value)
+            return snapshot()
+        }
+
+        function updateDockLiquidStrength(value: real): string {
+            AppearanceConfigService.updateDockLiquidStrength(value)
+            return snapshot()
+        }
+
+        function updateDockBlurInherit(enabled: bool): string {
+            AppearanceConfigService.updateDockBlurInherit(enabled)
+            return snapshot()
+        }
+
+        function updateBarBlurStrength(value: real): string {
+            AppearanceConfigService.updateBarBlurStrength(value)
+            return snapshot()
+        }
+
+        function updateBarLiquidStrength(value: real): string {
+            AppearanceConfigService.updateBarLiquidStrength(value)
+            return snapshot()
+        }
+
+        function updateBarBlurInherit(enabled: bool): string {
+            AppearanceConfigService.updateBarBlurInherit(enabled)
+            return snapshot()
+        }
+
+        function updateControlCenterBlurStrength(value: real): string {
+            AppearanceConfigService.updateControlCenterBlurStrength(value)
+            return snapshot()
+        }
+
+        function updateControlCenterLiquidStrength(value: real): string {
+            AppearanceConfigService.updateControlCenterLiquidStrength(value)
+            return snapshot()
+        }
+
+        function updateControlCenterBlurInherit(enabled: bool): string {
+            AppearanceConfigService.updateControlCenterBlurInherit(enabled)
+            return snapshot()
+        }
+
+        function updateLauncherBlurStrength(value: real): string {
+            AppearanceConfigService.updateLauncherBlurStrength(value)
+            return snapshot()
+        }
+
+        function updateLauncherLiquidStrength(value: real): string {
+            AppearanceConfigService.updateLauncherLiquidStrength(value)
+            return snapshot()
+        }
+
+        function updateLauncherBlurInherit(enabled: bool): string {
+            AppearanceConfigService.updateLauncherBlurInherit(enabled)
             return snapshot()
         }
 
@@ -305,7 +387,6 @@ Item {
             })
         }
     }
-
     // The KWin effect observes pointer presses at compositor scope and routes
     // them through WindowService's existing local bridge. Keep the policy here
     // so individual desktop, Dock, and tray surfaces need no outside-click

--- a/shell/desktop/modules/bar/AppMenuService.qml
+++ b/shell/desktop/modules/bar/AppMenuService.qml
@@ -34,8 +34,12 @@ QtObject {
         PlatformClient.request("appmenu.active", {}, function(response) {
             requestPending = false
             const address = response?.ok ? (response.result || {}) : ({})
-            dbusService = address.available ? (address.service || "") : ""
-            dbusPath = address.available ? (address.path || "") : ""
+            const newService = address.available ? (address.service || "") : ""
+            const newPath = address.available ? (address.path || "") : ""
+            if (newService === dbusService && newPath === dbusPath && items.length > 0)
+                return
+            dbusService = newService
+            dbusPath = newPath
             if (!available) {
                 items = []
                 return

--- a/shell/desktop/modules/bar/BarAutoHideController.qml
+++ b/shell/desktop/modules/bar/BarAutoHideController.qml
@@ -37,12 +37,10 @@ Item {
     property string phase: "Bootstrapping"
     property real revealProgress: 0.0
     readonly property bool hidden: ctl.phase === "Hidden"
-    // Reserve as soon as reveal begins, keep the reservation throughout the
-    // hide animation, and release it only at the Hidden boundary. This avoids
-    // resizing maximized windows on every animation frame.
+    // Only permanently visible mode reserves workspace. Auto-hide modes keep
+    // the zone at 0 so windows do not reflow when the Bar reveals or hides,
+    // allowing the Bar to float on top of content (在图层上).
     readonly property bool workspaceReserved: ctl.mode === "always"
-        || (ctl.phase !== "Bootstrapping" && ctl.phase !== "Hidden"
-            && ctl.phase !== "RevealPending")
     readonly property bool handleActive: ctl.mode !== "always"
     property bool hasWindowConflict: false
     readonly property bool policyWantsHidden:
@@ -62,7 +60,7 @@ Item {
         const s = ctl.targetScreen
         if (!s || s.x === undefined || s.width === undefined)
             return { x: 0, y: 0, width: 1, height: 1 }
-        return { x: s.x, y: s.y, width: s.width, height: s.height }
+        return { x: s.x, y: s.y, width: s.width, height: s.height, name: s.name || "" }
     }
 
     function _windowCandidates() {
@@ -193,7 +191,7 @@ Item {
     function _setPhase(next) {
         if (ctl.phase === next)
             return
-        console.log("[BarAutoHide] " + ctl.phase + " -> " + next
+        console.info("[BarAutoHide] " + ctl.phase + " -> " + next
             + " mode=" + ctl.mode + " conflict=" + ctl.hasWindowConflict
             + " inhibit=" + ctl.hasInhibitor)
         ctl.phase = next

--- a/shell/desktop/modules/bar/BarDateStatus.qml
+++ b/shell/desktop/modules/bar/BarDateStatus.qml
@@ -26,6 +26,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             text: Qt.formatDateTime(clock.date, "h:mm")
             color: ThemeService.foregroundColor
+            renderType: Text.NativeRendering
             font {
                 family: "SF Pro Display, Noto Sans CJK SC, sans-serif"
                 pixelSize: 14
@@ -37,8 +38,9 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             text: Qt.formatDateTime(clock.date, "M月d日 dddd")
             color: ThemeService.foregroundColor
+            renderType: Text.NativeRendering
             font {
-                family: "Noto Sans CJK SC, sans-serif"
+                family: "SF Pro Display, Noto Sans CJK SC, sans-serif"
                 pixelSize: 14
                 weight: Font.DemiBold
             }

--- a/shell/desktop/modules/bar/BarWindow.qml
+++ b/shell/desktop/modules/bar/BarWindow.qml
@@ -36,12 +36,16 @@ PanelWindow {
         barHeight: root.implicitHeight
         edgeMargin: 15
         pointerInsideBar: contentHoverHandler.hovered
-        popupOpen: barContentLoader.item?.statusArea?.anyPanelOpen ?? false
+        popupOpen: (barContentLoader.item?.statusArea?.anyPanelOpen ?? false)
+            || (barContentLoader.item?.globalMenu?.menuOpen ?? false)
         launcherOpen: AppLauncherService.open
     }
 
+    // Only "always" mode reserves a permanent top workspace strip.
+    // In "smart" or "persistent" modes, exclusiveZone stays at 0 so
+    // maximised windows extend to the top of the screen and the Bar floats over content (在图层上).
     readonly property int reservedWorkspaceHeight: (root.barEnabled
-        && hide.workspaceReserved)
+        && AppearanceConfigService.barVisibilityMode === "always")
         ? Math.round(implicitHeight + margins.top) : 0
     exclusiveZone: root.reservedWorkspaceHeight
     visible: root.barEnabled
@@ -52,9 +56,8 @@ PanelWindow {
         right: true
     }
     margins {
-        top: (AppearanceConfigService.barLayoutMode === "floating")
-            ? (AppearanceConfigService.barVisibilityMode !== "always" ? 8 : 6)
-            : 0
+        top: (AppearanceConfigService.barLayoutMode === "floating"
+            && AppearanceConfigService.barVisibilityMode === "always") ? 6 : 0
         left: (AppearanceConfigService.barLayoutMode === "floating") ? 15 : 0
         right: (AppearanceConfigService.barLayoutMode === "floating") ? 15 : 0
     }
@@ -70,11 +73,10 @@ PanelWindow {
     Component.onCompleted: publishWorkspaceReservation()
 
     // The transparent layout deliberately leaves only the content: it must not
-    // register a backdrop region, otherwise KWin adds blur/refraction behind
-    // it. Other Bar layouts still use the regular compositor glass pipeline.
+    // register a backdrop region, otherwise KWin adds blur behind it.
+    // Only publish blurRegion when backdrop blur is active.
     BackgroundEffect.blurRegion: (!root.transparentMode && root.visible
-        && (AppearanceConfigService.effectiveBarBlur > 0.005
-            || AppearanceConfigService.effectiveBarLiquid > 0.005))
+        && AppearanceConfigService.effectiveBarBlur > 0.005)
         ? barBlurRegionHolder : null
 
     Region {
@@ -104,6 +106,8 @@ PanelWindow {
             id: contentHoverHandler
         }
 
+
+
         Loader {
             id: barContentLoader
             anchors.fill: parent
@@ -114,6 +118,7 @@ PanelWindow {
                 Item {
                     id: barContentItem
                     readonly property alias statusArea: barStatusArea
+                    readonly property alias globalMenu: barGlobalMenu
 
                     BarDateStatus {
                         id: barDateStatus
@@ -128,6 +133,7 @@ PanelWindow {
                     // integrated into the Dock, so the Dock never owns or
                     // fetches an application menu.
                     GlobalMenu {
+                        id: barGlobalMenu
                         anchors.left: barDateStatus.right
                         anchors.leftMargin: 12
                         anchors.verticalCenter: parent.verticalCenter
@@ -147,13 +153,13 @@ PanelWindow {
     }
 
     // ── Touch-top invisible trigger ──
-    // A 8px hit area at the screen top to reveal Bar when hovered in hide modes.
+    // A 2px hit area at the screen top to reveal Bar when hovered in hide modes.
     Item {
         id: topTriggerArea
         x: 0
         y: 0
         width: root.width
-        height: hide.handleActive ? 8 : 0
+        height: hide.handleActive ? 2 : 0
         visible: hide.handleActive
 
         HoverHandler {
@@ -189,7 +195,7 @@ PanelWindow {
         x: 0
         y: 0
         width: root.width
-        height: hide.handleActive ? 8 : 0
+        height: hide.handleActive ? 2 : 0
         visible: false
     }
 

--- a/shell/desktop/modules/bar/BluetoothPanel.qml
+++ b/shell/desktop/modules/bar/BluetoothPanel.qml
@@ -47,15 +47,9 @@ PopupWindow {
 
     Region {
         id: bluetoothBlurRegionHolder
-        x: panel.blurRadius
-        y: 0
-        width: 300 - panel.blurRadius
-        height: 1
-        Region {
-            x: 0
-            y: 1
-            width: 300
-            height: 340 - 1
+        RoundedBlurRegion {
+            item: surface
+            radius: panel.blurRadius
         }
     }
 

--- a/shell/desktop/modules/bar/ControlCenterCard.qml
+++ b/shell/desktop/modules/bar/ControlCenterCard.qml
@@ -96,33 +96,21 @@ PopupWindow {
         Math.round(root.cardRadius),
         Math.floor(Math.min(root.cardWidth, root.cardHeight) / 2)))
 
-    property real blurStrength: AppearanceConfigService.effectiveBarBlur
-    property real liquidStrength: AppearanceConfigService.effectiveBarLiquid
+    property real blurStrength: AppearanceConfigService.effectiveControlCenterBlur
+    property real liquidStrength: AppearanceConfigService.effectiveControlCenterLiquid
     readonly property real effectiveBlur: Math.max(0.0, Math.min(1.0, blurStrength))
     readonly property real effectiveLiquid: Math.max(0.0, Math.min(1.0, liquidStrength))
 
-    // Blur region with the radius encoded explicitly, instead of
-    // RoundedBlurRegion's ellipse scanlines (whose top-row inset is corrupted
-    // by DPR scaling, making the plugin recover a smaller radius than QML
-    // draws). The top scanline starts at x=blurRadius - the plugin's
-    // smoothQuickshellCard reads exactly this inset as the corner radius.
-    // Everything below it is full-width so the card blurs completely and the
-    // SDF mask rounds the corners to blurRadius.
+    // Rounded blur region matching QuickSearch (Meta+V) and Dock windows.
     BackgroundEffect.blurRegion: (root.visible
-        && (root.effectiveBlur > 0.005 || root.effectiveLiquid > 0.005))
+        && root.effectiveBlur > 0.005)
         ? cardBlurRegionHolder : null
 
     Region {
         id: cardBlurRegionHolder
-        x: root.blurRadius
-        y: 0
-        width: root.cardWidth - root.blurRadius
-        height: 1
-        Region {
-            x: 0
-            y: 1
-            width: root.cardWidth
-            height: root.cardHeight - 1
+        RoundedBlurRegion {
+            item: cardGlass
+            radius: root.blurRadius
         }
     }
 
@@ -140,7 +128,7 @@ PopupWindow {
         ambientSecondary: WallpaperPaletteService.secondary
         ambientStrength: 0.35 * AppearanceTokens.glass.ambientMultiplier
         material: "regular"
-        border.width: 1
+        border.width: (root.effectiveBlur > 0.005 || root.effectiveLiquid > 0.005) ? 1 : 0
         border.color: root.cardBorderColor
         scale: root.popupScale
         transformOrigin: Item.TopRight

--- a/shell/desktop/modules/bar/ControlCenterPanel.qml
+++ b/shell/desktop/modules/bar/ControlCenterPanel.qml
@@ -1038,7 +1038,7 @@ Item {
         managedByCoordinator: false
         offsetTop: 20
         offsetRight: 20
-        cardRadius: 22
+        cardRadius: 28
         cardWidth: 296
         cardHeight: panel.pendingConfirmAction === "" ? 278 : 180
         cardBorderColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.10)

--- a/shell/desktop/modules/bar/GlobalMenu.qml
+++ b/shell/desktop/modules/bar/GlobalMenu.qml
@@ -20,8 +20,10 @@ Item {
     property Item popupAnchorItem: null
 
     readonly property bool available: service.length > 0 && path.length > 0
+    readonly property bool menuOpen: menuPopup.visible
     readonly property var shownItems: items.slice(0, visibleCount)
     readonly property var overflowItems: items.slice(visibleCount)
+    property int activeOpeningId: 0
     implicitHeight: 28
     implicitWidth: available && items.length > 0
         ? Math.min(maximumWidth, menuRow.implicitWidth + (overflowItems.length > 0 ? 34 : 0)) : 0
@@ -76,32 +78,32 @@ Item {
                 item.children = []
                 continue
             }
+            if (item.children && item.children.length > 0) {
+                pending++
+                hydrate(item.children, depth + 1, function(result) {
+                    item.children = result
+                    finish()
+                })
+                continue
+            }
             pending++
             AppMenuService.requestLayout(item.id, function(children) {
                 hydrate(children, depth + 1, function(result) {
                     item.children = result
                     finish()
                 })
-            })
+            }, 2)
         }
         if (pending === 0)
             done(itemsToHydrate)
     }
 
-    // Switching to a different anchor (a different top-level item, or the
-    // overflow button) while the popup is already visible reuses the same
-    // mapped surface for a new anchor and a different item count, i.e. a
-    // live resize+reposition of an already-mapped popup. That is the same
-    // class of bug the Column/PopupWindow sizing comment above already
-    // documents for submenu paging; here it leaves the surface at the
-    // previous menu's size with the new, differently sized menu rendered
-    // inside it. Force a clean unmap/remap whenever the anchor actually
-    // changes instead of mutating the live popup in place.
     function presentMenu(rootId, anchorItem, result) {
         const anchorChanging = menuPopup.visible && root.popupAnchorItem !== anchorItem
         const openNew = function() {
             popupRootId = rootId
             popupAnchorItem = anchorItem
+            menuPopup.anchorItem = anchorItem
             menuPopup.setItems(result)
             console.info("[GlobalMenu] popup items=" + result.length)
             menuPopup.show()
@@ -123,15 +125,37 @@ Item {
             PlatformClient.request("appmenu.trigger", { service, path, id: item.id })
             return
         }
+        popupRootId = item.id
+        activeOpeningId = item.id
         PlatformClient.request("appmenu.open", { service, path, id: item.id })
         AppMenuService.requestLayout(item.id, function(children) {
+            if (activeOpeningId !== item.id)
+                return
             hydrate(children, 0, function(result) {
+                if (activeOpeningId !== item.id)
+                    return
                 root.presentMenu(item.id, clickedItem, result)
             })
+        }, 2)
+    }
+
+    function openOverflow(anchor) {
+        popupRootId = 0
+        activeOpeningId = 0
+        hydrate(overflowItems, 0, function(result) {
+            root.presentMenu(0, anchor, result)
         })
     }
 
     onMaximumWidthChanged: updateVisibleCount()
+    onServiceChanged: {
+        if (menuPopup.visible)
+            menuPopup.hide()
+    }
+    onPathChanged: {
+        if (menuPopup.visible)
+            menuPopup.hide()
+    }
     onItemsChanged: updateVisibleCount()
 
     Row {
@@ -150,14 +174,16 @@ Item {
                 Rectangle {
                     anchors.fill: parent
                     radius: 8
-                    color: pointer.containsMouse ? Qt.rgba(ThemeService.foregroundColor.r,
-                        ThemeService.foregroundColor.g, ThemeService.foregroundColor.b, 0.16) : "transparent"
+                    color: (pointer.containsMouse || (menuPopup.visible && root.popupRootId === modelData.id))
+                        ? Qt.rgba(ThemeService.foregroundColor.r,
+                            ThemeService.foregroundColor.g, ThemeService.foregroundColor.b, 0.16) : "transparent"
                 }
-                GlassText {
+                Text {
                     anchors.centerIn: parent
                     text: modelData.label || ""
                     color: ThemeService.foregroundColor
                     font: labelMetrics.font
+                    renderType: Text.NativeRendering
                     elide: Text.ElideRight
                     width: parent.width - 14
                     horizontalAlignment: Text.AlignHCenter
@@ -167,7 +193,18 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     enabled: modelData.enabled !== false
-                    onClicked: root.openItem(modelData, menuItem)
+                    onClicked: {
+                        if (menuPopup.visible && root.popupRootId === modelData.id) {
+                            menuPopup.hide()
+                        } else {
+                            root.openItem(modelData, menuItem)
+                        }
+                    }
+                    onEntered: {
+                        if (menuPopup.visible && root.popupRootId !== modelData.id) {
+                            root.openItem(modelData, menuItem)
+                        }
+                    }
                 }
             }
         }
@@ -179,18 +216,26 @@ Item {
             Rectangle {
                 anchors.fill: parent
                 radius: 8
-                color: morePointer.containsMouse ? Qt.rgba(ThemeService.foregroundColor.r,
-                    ThemeService.foregroundColor.g, ThemeService.foregroundColor.b, 0.16) : "transparent"
+                color: (morePointer.containsMouse || (menuPopup.visible && root.popupRootId === 0))
+                    ? Qt.rgba(ThemeService.foregroundColor.r,
+                        ThemeService.foregroundColor.g, ThemeService.foregroundColor.b, 0.16) : "transparent"
             }
-            GlassText { anchors.centerIn: parent; text: "››"; color: ThemeService.foregroundColor; font.pixelSize: 16 }
+            Text { anchors.centerIn: parent; text: "››"; color: ThemeService.foregroundColor; font.pixelSize: 16; renderType: Text.NativeRendering }
             MouseArea {
                 id: morePointer
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: {
-                    root.hydrate(root.overflowItems, 0, function(result) {
-                        root.presentMenu(0, overflowButton, result)
-                    })
+                    if (menuPopup.visible && root.popupRootId === 0) {
+                        menuPopup.hide()
+                    } else {
+                        root.openOverflow(overflowButton)
+                    }
+                }
+                onEntered: {
+                    if (menuPopup.visible && root.popupRootId !== 0) {
+                        root.openOverflow(overflowButton)
+                    }
                 }
             }
         }
@@ -202,11 +247,14 @@ Item {
         baseColor: ThemeService.backgroundColor
         foregroundColor: ThemeService.foregroundColor
         position: "bottom"
-        centerBelowAnchor: true
+        centerBelowAnchor: false
         centerBelowOffset: root.popupAnchorItem
             ? root.popupAnchorItem.height
                 + Math.max(0, (root.parent?.height ?? root.height) - root.height) / 2 + 4
             : root.height + 4
+        customAnchorEdges: Edges.Top | Edges.Left
+        customGravity: Edges.Bottom | Edges.Right
+        customMarginsTop: 0
         macosPopupMotion: true
         globalDismissGraceMs: 250
         dismissOnGlobalPointerPress: false
@@ -216,9 +264,13 @@ Item {
                 console.info("[GlobalMenu] trigger result=" + (response?.ok ? "ok" : (response?.error?.code || "failed")))
             })
         }
-        onAboutToHide: PlatformClient.request("appmenu.close", {
-            service: root.service, path: root.path, id: root.popupRootId
-        })
+        onAboutToHide: {
+            PlatformClient.request("appmenu.close", {
+                service: root.service, path: root.path, id: root.popupRootId
+            })
+            root.popupRootId = 0
+            root.activeOpeningId = 0
+        }
         onVisibleChanged: console.info("[GlobalMenu] popup visible=" + visible)
     }
 }

--- a/shell/desktop/modules/bar/NetworkPanel.qml
+++ b/shell/desktop/modules/bar/NetworkPanel.qml
@@ -72,15 +72,9 @@ PopupWindow {
 
     Region {
         id: networkBlurRegionHolder
-        x: panel.blurRadius
-        y: 0
-        width: 310 - panel.blurRadius
-        height: 1
-        Region {
-            x: 0
-            y: 1
-            width: 310
-            height: 365 - 1
+        RoundedBlurRegion {
+            item: panelSurface
+            radius: panel.blurRadius
         }
     }
 

--- a/shell/desktop/modules/common/AppActionService.qml
+++ b/shell/desktop/modules/common/AppActionService.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 import QtQuick
 import Quickshell
+import Quickshell.Io
 
 // Shared application-action contract.
 //
@@ -17,6 +18,25 @@ QtObject {
     signal hideRequested(string appId)
     signal editRequested(var application)
 
+    // The shell runs inside its autostart unit's cgroup, and any process it
+    // spawns directly inherits that cgroup. Without this indirection every
+    // app started from the dock, launcher, or desktop is accounted (and, on a
+    // shell restart, killed) together with quickshell itself. A transient
+    // systemd scope gives each app its own cgroup — the same scheme KDE's and
+    // GNOME's launchers use — and the app-*.scope prefix keeps Plasma's
+    // process tools attributing memory to the app instead of lumping it onto
+    // "Quickshell Desktop".
+    function scopedUnitName(appId) {
+        const sanitized = String(appId ?? "app").replace(/[^A-Za-z0-9.:_-]/g, "-").slice(0, 160)
+        const unique = Date.now().toString(36) + Math.floor(Math.random() * 1e6).toString(36)
+        return "app-" + sanitized + "-" + unique + ".scope"
+    }
+
+    function scopedCommand(command, appId) {
+        return ["systemd-run", "--user", "--scope", "--quiet", "--collect",
+            "--unit", scopedUnitName(appId)].concat(command)
+    }
+
     function launch(application) {
         const entry = application?.entry ?? application
         const appId = String(application?.id ?? entry?.id ?? "")
@@ -24,14 +44,28 @@ QtObject {
             console.warn("[AppAction] cannot launch without DesktopEntry app=" + appId)
             return false
         }
-        try {
-            entry.execute()
-            console.log("[AppAction] launch app=" + appId)
-            return true
-        } catch (error) {
-            console.warn("[AppAction] failed to launch app=" + appId + ": " + error)
-            return false
-        }
+        // Resolve the desktop file and start it inside its own scope. IDs no
+        // data directory resolves (flatpak exports, custom in-memory entries)
+        // fall back to quickshell's direct DesktopEntry spawn.
+        const desktopId = /\.desktop$/i.test(appId) ? appId : appId + ".desktop"
+        const script = "id=$1; unit=$2; for root in \"${XDG_DATA_HOME:-$HOME/.local/share}/applications\" /usr/local/share/applications /usr/share/applications; do if test -f \"$root/$id\"; then if command -v systemd-run >/dev/null 2>&1; then exec systemd-run --user --scope --quiet --collect --unit \"$unit\" gio launch \"$root/$id\"; fi; exec gio launch \"$root/$id\"; fi; done; exit 3"
+        const process = processFactory.createObject(service, {
+            command: ["sh", "-c", script, "app-action-launch", desktopId,
+                scopedUnitName(desktopId.replace(/\.desktop$/i, ""))]
+        })
+        process.exited.connect(function(exitCode) {
+            if (exitCode === 3) {
+                try {
+                    entry.execute()
+                } catch (error) {
+                    console.warn("[AppAction] failed to launch app=" + appId + ": " + error)
+                }
+            }
+            process.destroy()
+        })
+        process.running = true
+        console.log("[AppAction] launch app=" + appId)
+        return true
     }
 
     function entryForId(desktopId) {
@@ -103,6 +137,13 @@ QtObject {
             return false
         editRequested(application)
         return true
+    }
+
+    property Component processFactory: Component {
+        Process {
+            stdout: StdioCollector {}
+            stderr: StdioCollector {}
+        }
     }
 
 }

--- a/shell/desktop/modules/common/AppNotificationService.qml
+++ b/shell/desktop/modules/common/AppNotificationService.qml
@@ -1,0 +1,83 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import qs.desktop.modules.common
+
+// AppNotificationService — Bridge for active desktop notification counts per app.
+// NotificationGroupService populates this service, and DockIcon / other shell
+// surfaces query it reactively using countForApp(appId, appName).
+QtObject {
+    id: svc
+
+    // Array of { groupKey: string, appName: string, count: int }
+    property var activeGroups: []
+    property int revision: 0
+
+    function updateFromGroups(nextGroups) {
+        const groups = []
+        if (Array.isArray(nextGroups)) {
+            for (let i = 0; i < nextGroups.length; i++) {
+                const g = nextGroups[i]
+                if (g && g.count > 0) {
+                    groups.push({
+                        groupKey: String(g.groupKey ?? "").trim(),
+                        appName: String(g.appName ?? "").trim(),
+                        count: Number(g.count || 0)
+                    })
+                }
+            }
+        }
+        activeGroups = groups
+        revision++
+    }
+
+    function _normalize(value) {
+        return AppPresentationService.normalize(value)
+    }
+
+    function countForApp(appId, appName) {
+        // Read revision so QML bindings re-evaluate whenever revision increments
+        const _ = svc.revision
+        const groups = svc.activeGroups
+        if (!groups || groups.length === 0)
+            return 0
+
+        const rawAppId = String(appId ?? "").trim()
+        const rawAppName = String(appName ?? "").trim()
+        const normAppId = _normalize(rawAppId)
+        const normAppName = _normalize(rawAppName)
+
+        let total = 0
+        for (let i = 0; i < groups.length; i++) {
+            const g = groups[i]
+            if (!g || !g.count)
+                continue
+
+            const gKey = String(g.groupKey ?? "").trim()
+            const gApp = String(g.appName ?? "").trim()
+            const normGKey = _normalize(gKey)
+            const normGApp = _normalize(gApp)
+
+            let match = false
+            if (gKey && (gKey === rawAppId || gKey + ".desktop" === rawAppId
+                    || rawAppId + ".desktop" === gKey)) {
+                match = true
+            } else if (normGKey && (normGKey === normAppId || normGKey === normAppName)) {
+                match = true
+            } else if (normGApp && (normGApp === normAppId || normGApp === normAppName)) {
+                match = true
+            } else if (normAppId && normGKey && (normAppId.endsWith(normGKey) || normGKey.endsWith(normAppId))) {
+                match = true
+            }
+
+            if (match)
+                total += g.count
+        }
+        return total
+    }
+
+    function hasNotification(appId, appName) {
+        return countForApp(appId, appName) > 0
+    }
+}

--- a/shell/desktop/modules/common/AppearanceConfigService.qml
+++ b/shell/desktop/modules/common/AppearanceConfigService.qml
@@ -13,23 +13,38 @@ QtObject {
     readonly property string configDir: Quickshell.stateDir + "/appearance"
     readonly property string configPath: configDir + "/config.json"
 
-    // KWin owns one glass pipeline. Surface-specific overrides cannot map
-    // reliably to its compositor parameters, so every shell surface shares
-    // this one global configuration.
+    // Global baseline settings and per-component overrides.
     property real globalBlurStrength: 0.42
     property real globalLiquidStrength: 1.0
 
     property real blurStrength: globalBlurStrength
     property real liquidStrength: globalLiquidStrength
 
-    // Retain descriptive names at call sites; they intentionally resolve to
-    // the one global KWin glass configuration.
-    readonly property real effectiveDockBlur: globalBlurStrength
-    readonly property real effectiveDockLiquid: globalLiquidStrength
-    readonly property real effectiveBarBlur: globalBlurStrength
-    readonly property real effectiveBarLiquid: globalLiquidStrength
-    readonly property real effectiveLauncherBlur: globalBlurStrength
-    readonly property real effectiveLauncherLiquid: globalLiquidStrength
+    property bool dockBlurInherit: true
+    property real dockBlurStrength: 0.42
+    property real dockLiquidStrength: 1.0
+
+    property bool barBlurInherit: true
+    property real barBlurStrength: 0.42
+    property real barLiquidStrength: 1.0
+
+    property bool controlCenterBlurInherit: true
+    property real controlCenterBlurStrength: 0.42
+    property real controlCenterLiquidStrength: 1.0
+
+    property bool launcherBlurInherit: true
+    property real launcherBlurStrength: 0.42
+    property real launcherLiquidStrength: 1.0
+
+    // Resolved effective strengths consumed by each surface
+    readonly property real effectiveDockBlur: dockBlurInherit ? globalBlurStrength : dockBlurStrength
+    readonly property real effectiveDockLiquid: dockBlurInherit ? globalLiquidStrength : dockLiquidStrength
+    readonly property real effectiveBarBlur: barBlurInherit ? globalBlurStrength : barBlurStrength
+    readonly property real effectiveBarLiquid: barBlurInherit ? globalLiquidStrength : barLiquidStrength
+    readonly property real effectiveControlCenterBlur: controlCenterBlurInherit ? globalBlurStrength : controlCenterBlurStrength
+    readonly property real effectiveControlCenterLiquid: controlCenterBlurInherit ? globalLiquidStrength : controlCenterLiquidStrength
+    readonly property real effectiveLauncherBlur: launcherBlurInherit ? globalBlurStrength : launcherBlurStrength
+    readonly property real effectiveLauncherLiquid: launcherBlurInherit ? globalLiquidStrength : launcherLiquidStrength
 
     // "macos" matches the shell geometry that predates selectable styles,
     // so upgrading an existing installation does not unexpectedly reshape it.
@@ -58,10 +73,10 @@ QtObject {
         return value === "scale" || value === "genie"
     }
 
-    function _normalized(value) {
+    function _normalized(value, fallback = NaN) {
         const number = Number(value)
         return Number.isFinite(number)
-            ? Math.max(0.0, Math.min(1.0, number)) : NaN
+            ? Math.max(0.0, Math.min(1.0, number)) : fallback
     }
 
     // Blur radius is perceived much more strongly in the lower half of the
@@ -100,6 +115,132 @@ QtObject {
         liquidStrength = value
         saveTimer.restart()
         effectSyncTimer.restart()
+        return true
+    }
+
+    // Dock overrides
+    function updateDockBlurInherit(rawValue) {
+        const value = _toBool(rawValue)
+        if (dockBlurInherit === value)
+            return false
+        dockBlurInherit = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    function updateDockBlurStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(dockBlurStrength - value) <= 0.001)
+            return false
+        dockBlurStrength = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    function updateDockLiquidStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(dockLiquidStrength - value) <= 0.001)
+            return false
+        dockLiquidStrength = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    // Bar overrides
+    function updateBarBlurInherit(rawValue) {
+        const value = _toBool(rawValue)
+        if (barBlurInherit === value)
+            return false
+        barBlurInherit = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    function updateBarBlurStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(barBlurStrength - value) <= 0.001)
+            return false
+        barBlurStrength = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    function updateBarLiquidStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(barLiquidStrength - value) <= 0.001)
+            return false
+        barLiquidStrength = value
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
+    }
+
+    // Control Center overrides
+    function updateControlCenterBlurInherit(rawValue) {
+        const value = _toBool(rawValue)
+        if (controlCenterBlurInherit === value)
+            return false
+        controlCenterBlurInherit = value
+        saveTimer.restart()
+        return true
+    }
+
+    function updateControlCenterBlurStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(controlCenterBlurStrength - value) <= 0.001)
+            return false
+        controlCenterBlurStrength = value
+        saveTimer.restart()
+        return true
+    }
+
+    function updateControlCenterLiquidStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(controlCenterLiquidStrength - value) <= 0.001)
+            return false
+        controlCenterLiquidStrength = value
+        saveTimer.restart()
+        return true
+    }
+
+    // Launcher overrides
+    function updateLauncherBlurInherit(rawValue) {
+        const value = _toBool(rawValue)
+        if (launcherBlurInherit === value)
+            return false
+        launcherBlurInherit = value
+        saveTimer.restart()
+        return true
+    }
+
+    function updateLauncherBlurStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(launcherBlurStrength - value) <= 0.001)
+            return false
+        launcherBlurStrength = value
+        saveTimer.restart()
+        return true
+    }
+
+    function updateLauncherLiquidStrength(rawValue) {
+        const value = _normalized(rawValue)
+        if (!Number.isFinite(value)
+                || Math.abs(launcherLiquidStrength - value) <= 0.001)
+            return false
+        launcherLiquidStrength = value
+        saveTimer.restart()
         return true
     }
 
@@ -160,21 +301,30 @@ QtObject {
     }
 
     function resetStrengths() {
-        const globalBlurChanged = Math.abs(globalBlurStrength - 0.42) > 0.001
-        const globalLiquidChanged = Math.abs(globalLiquidStrength - 1.0) > 0.001
-
         globalBlurStrength = 0.42
         globalLiquidStrength = 1.0
         blurStrength = 0.42
         liquidStrength = 1.0
 
-        const changed = globalBlurChanged || globalLiquidChanged
+        dockBlurInherit = true
+        dockBlurStrength = 0.42
+        dockLiquidStrength = 1.0
 
-        if (changed) {
-            saveTimer.restart()
-            effectSyncTimer.restart()
-        }
-        return changed
+        barBlurInherit = true
+        barBlurStrength = 0.42
+        barLiquidStrength = 1.0
+
+        controlCenterBlurInherit = true
+        controlCenterBlurStrength = 0.42
+        controlCenterLiquidStrength = 1.0
+
+        launcherBlurInherit = true
+        launcherBlurStrength = 0.42
+        launcherLiquidStrength = 1.0
+
+        saveTimer.restart()
+        effectSyncTimer.restart()
+        return true
     }
 
     property Timer saveTimer: Timer {
@@ -218,11 +368,23 @@ QtObject {
 
     function _save() {
         const payload = JSON.stringify({
-            version: 9,
+            version: 10,
             globalBlurStrength: service.globalBlurStrength,
             globalLiquidStrength: service.globalLiquidStrength,
             blurStrength: service.globalBlurStrength,
             liquidStrength: service.globalLiquidStrength,
+            dockBlurInherit: service.dockBlurInherit,
+            dockBlurStrength: service.dockBlurStrength,
+            dockLiquidStrength: service.dockLiquidStrength,
+            barBlurInherit: service.barBlurInherit,
+            barBlurStrength: service.barBlurStrength,
+            barLiquidStrength: service.barLiquidStrength,
+            controlCenterBlurInherit: service.controlCenterBlurInherit,
+            controlCenterBlurStrength: service.controlCenterBlurStrength,
+            controlCenterLiquidStrength: service.controlCenterLiquidStrength,
+            launcherBlurInherit: service.launcherBlurInherit,
+            launcherBlurStrength: service.launcherBlurStrength,
+            launcherLiquidStrength: service.launcherLiquidStrength,
             shellStyle: service.shellStyle,
             barIntegratedWithDock: service.barIntegratedWithDock,
             barVisibilityMode: service.barVisibilityMode,
@@ -249,9 +411,9 @@ QtObject {
 
     function _syncGlassEffect() {
         const dockBlurLevel = service._compositorBlurLevel(
-            service.globalBlurStrength)
+            service.effectiveDockBlur)
         const contentBlurLevel = service._compositorBlurLevel(
-            service.globalBlurStrength)
+            service.effectiveBarBlur)
         const refractionLevel = Math.round(service.globalLiquidStrength * 20)
         PlatformClient.request("theme.sync-glass", {
             contentBlurLevel: contentBlurLevel,
@@ -266,6 +428,27 @@ QtObject {
                     + " contentBlur=" + contentBlurLevel + " liquid=" + refractionLevel)
             }
         })
+        const process = _makeProcess([
+            "sh", "-c",
+            "if [ \"$(kreadconfig6 --file kwinrc --group Plugins --key glassEnabled 2>/dev/null)\" = \"true\" ]; then "
+                + "  if [ \"$(qdbus6 org.kde.KWin /Effects org.kde.KWin.Effects.isEffectLoaded glass 2>/dev/null)\" != \"true\" ]; then "
+                + "    qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect blur 2>/dev/null; "
+                + "    qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect glass 2>/dev/null; "
+                + "  fi; "
+                + "else "
+                + "  if [ \"$(qdbus6 org.kde.KWin /Effects org.kde.KWin.Effects.isEffectLoaded glass 2>/dev/null)\" = \"true\" ]; then "
+                + "    qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect glass 2>/dev/null; "
+                + "  fi; "
+                + "  if [ \"$(qdbus6 org.kde.KWin /Effects org.kde.KWin.Effects.isEffectLoaded blur 2>/dev/null)\" != \"true\" ]; then "
+                + "    qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect blur 2>/dev/null; "
+                + "  fi; "
+                + "fi",
+            "appearance-glass-load-unload"
+        ])
+        if (process) {
+            process.exited.connect(function() { process.destroy() })
+            process.running = true
+        }
     }
 
     function _syncDockWindowAnimationEffect() {
@@ -295,27 +478,41 @@ QtObject {
             if (code === 0 && process.stdout?.text) {
                 try {
                     const object = JSON.parse(process.stdout.text)
-                    // Old v7 files may have a Dock value but never a global
-                    // one. Read it once as the global migration source, then
-                    // save the flattened v8 shape below.
                     const globalBlur = service._normalized(object.globalBlurStrength
-                        ?? object.blurStrength ?? object.dockBlurStrength)
+                        ?? object.blurStrength ?? object.dockBlurStrength, 0.42)
                     const globalLiquid = service._normalized(object.globalLiquidStrength
-                        ?? object.liquidStrength ?? object.dockLiquidStrength)
+                        ?? object.liquidStrength ?? object.dockLiquidStrength, 1.0)
                     const style = String(object.shellStyle ?? "")
                     const hasBarIntegration = typeof object.barIntegratedWithDock === "boolean"
                     const barVisibility = String(object.barVisibilityMode ?? "")
                     const barLayout = String(object.barLayoutMode ?? "")
                     const animationStyle = String(object.dockWindowAnimationStyle ?? "")
 
-                    if (Number.isFinite(globalBlur)) {
-                        service.globalBlurStrength = globalBlur
-                        service.blurStrength = globalBlur
-                    }
-                    if (Number.isFinite(globalLiquid)) {
-                        service.globalLiquidStrength = globalLiquid
-                        service.liquidStrength = globalLiquid
-                    }
+                    service.globalBlurStrength = globalBlur
+                    service.blurStrength = globalBlur
+                    service.globalLiquidStrength = globalLiquid
+                    service.liquidStrength = globalLiquid
+
+                    service.dockBlurInherit = object.dockBlurInherit !== undefined
+                        ? Boolean(object.dockBlurInherit) : true
+                    service.dockBlurStrength = service._normalized(object.dockBlurStrength, globalBlur)
+                    service.dockLiquidStrength = service._normalized(object.dockLiquidStrength, globalLiquid)
+
+                    service.barBlurInherit = object.barBlurInherit !== undefined
+                        ? Boolean(object.barBlurInherit) : true
+                    service.barBlurStrength = service._normalized(object.barBlurStrength, globalBlur)
+                    service.barLiquidStrength = service._normalized(object.barLiquidStrength, globalLiquid)
+
+                    service.controlCenterBlurInherit = object.controlCenterBlurInherit !== undefined
+                        ? Boolean(object.controlCenterBlurInherit) : true
+                    service.controlCenterBlurStrength = service._normalized(object.controlCenterBlurStrength, globalBlur)
+                    service.controlCenterLiquidStrength = service._normalized(object.controlCenterLiquidStrength, globalLiquid)
+
+                    service.launcherBlurInherit = object.launcherBlurInherit !== undefined
+                        ? Boolean(object.launcherBlurInherit) : true
+                    service.launcherBlurStrength = service._normalized(object.launcherBlurStrength, globalBlur)
+                    service.launcherLiquidStrength = service._normalized(object.launcherLiquidStrength, globalLiquid)
+
                     if (service.isValidShellStyle(style))
                         service.shellStyle = style
                     if (hasBarIntegration)
@@ -327,7 +524,7 @@ QtObject {
                     if (service.isValidDockWindowAnimationStyle(animationStyle))
                         service.dockWindowAnimationStyle = animationStyle
 
-                    if (Number(object.version) !== 9
+                    if (Number(object.version) !== 10
                             || !service.isValidShellStyle(style)
                             || !hasBarIntegration
                             || !service.isValidBarVisibilityMode(barVisibility)

--- a/shell/desktop/modules/common/ContextMenu.qml
+++ b/shell/desktop/modules/common/ContextMenu.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Wayland
 import qs.desktop.modules.common
+import qs.desktop.modules.dock
 
 // Shared self-drawn context menu. Submenus deliberately reuse this one popup
 // as a page stack: only a click enters a child page, and hover is visual only.
@@ -16,18 +17,26 @@ PopupWindow {
     property bool macosPopupMotion: false
     property bool centerBelowAnchor: false
     property real centerBelowOffset: 0
-    property color baseColor: Qt.rgba(0, 0, 0, 0.55)
-    property color foregroundColor: "#ffffff"
+    property var customAnchorEdges: null
+    property var customGravity: null
+    property var customMarginsTop: null
+    property color baseColor: ThemeService.backgroundColor
+    property color foregroundColor: ThemeService.foregroundColor
     property bool adaptiveForeground: true
-    property color ambientPrimary: "transparent"
-    property color ambientSecondary: "transparent"
-    property real ambientStrength: 0.0
+    property color ambientPrimary: WallpaperPaletteService.primary
+    property color ambientSecondary: WallpaperPaletteService.secondary
+    property real ambientStrength: 0.25 * AppearanceTokens.glass.ambientMultiplier
     // Context menus need more separation from a busy desktop than the Dock.
     // Compositor blur is declared below; these QML layers make it read as a
     // denser, slightly darker frosted surface on every shared context menu.
     property real surfaceOpacity: 0.98
-    property real darkOverlayOpacity: 0.27
+    property real darkOverlayOpacity: ThemeService.isDark ? 0.27 : 0.04
     property real menuRadius: 16
+    readonly property color effectiveForegroundColor: {
+        if (!root.adaptiveForeground)
+            return root.foregroundColor
+        return ThemeService.isDark ? glass.foregroundColor : ThemeService.foregroundColor
+    }
     // Some anchors receive their opening press through the compositor's
     // global-pointer bridge slightly after this popup is mapped.
     property int globalDismissGraceMs: 0
@@ -143,21 +152,21 @@ PopupWindow {
         item: root.anchorItem
         rect.x: root.centerBelowAnchor && root.anchorItem
             ? root.anchorItem.width / 2 - root.implicitWidth / 2 : 0
-        rect.y: root.centerBelowAnchor ? root.centerBelowOffset : 0
-        rect.width: root.centerBelowAnchor ? root.implicitWidth : 0
-        rect.height: root.centerBelowAnchor ? 1 : 0
-        edges: root.centerBelowAnchor ? (Edges.Top | Edges.Left)
+        rect.y: (root.centerBelowAnchor || root.centerBelowOffset > 0) ? root.centerBelowOffset : 0
+        rect.width: root.centerBelowAnchor ? root.implicitWidth : (root.anchorItem ? root.anchorItem.width : 0)
+        rect.height: (root.centerBelowAnchor || root.centerBelowOffset > 0) ? 1 : (root.anchorItem ? root.anchorItem.height : 0)
+        edges: root.customAnchorEdges !== null ? root.customAnchorEdges : (root.centerBelowAnchor ? (Edges.Top | Edges.Left)
             : root.position === "bottom"
             ? (root.placeBelow ? (Edges.Top | Edges.Left) : Edges.Top)
-            : Edges.Right
-        gravity: root.centerBelowAnchor ? (Edges.Bottom | Edges.Right)
+            : Edges.Right)
+        gravity: root.customGravity !== null ? root.customGravity : (root.centerBelowAnchor ? (Edges.Bottom | Edges.Right)
             : root.position === "bottom"
             ? (root.placeBelow ? (Edges.Bottom | Edges.Right) : Edges.Top)
-            : Edges.Right
+            : Edges.Right)
         adjustment: root.centerBelowAnchor ? PopupAdjustment.Slide
             : (PopupAdjustment.Flip | PopupAdjustment.Slide)
-        margins.top: root.centerBelowAnchor ? 0
-            : (root.position === "bottom" ? -8 : 0)
+        margins.top: root.customMarginsTop !== null ? root.customMarginsTop : (root.centerBelowAnchor ? 0
+            : (root.position === "bottom" ? -8 : 0))
         margins.right: root.position === "right" ? -8 : 8
         margins.left: root.position === "left" ? 8 : 0
     }
@@ -166,7 +175,7 @@ PopupWindow {
         if (root.visible) {
             // Support the few callers that set visible directly as well as
             // the normal show()/setDockPopupVisible() entry points.
-            if (ContextMenuCoordinator.activeMenu !== root)
+            if (!root.macosPopupMotion)
                 ContextMenuCoordinator.open(root)
             root.page = ({ items: root.rootItems, parents: [] })
             root.aboutToShow()
@@ -213,7 +222,7 @@ PopupWindow {
         materialDepth: 0.6
         material: "thick"
         adaptiveDarkScrim: true
-        scale: root.macosPopupMotion
+        scale: (root.macosPopupMotion && popupMotion.progress < 0.999)
             ? AppearanceTokens.motion.popupStartScale
                 + (1 - AppearanceTokens.motion.popupStartScale) * popupMotion.progress
             : 1
@@ -221,8 +230,8 @@ PopupWindow {
         opacity: root.macosPopupMotion ? popupMotion.progress : 1
         enabled: !root.macosPopupMotion || popupMotion.interactive
         transform: Translate {
-            y: root.macosPopupMotion
-                ? (1 - popupMotion.progress) * AppearanceTokens.motion.popupAnchorOffset
+            y: (root.macosPopupMotion && popupMotion.progress < 0.999)
+                ? Math.round((1 - popupMotion.progress) * AppearanceTokens.motion.popupAnchorOffset)
                 : 0
         }
 
@@ -248,7 +257,7 @@ PopupWindow {
                 visible: root.page.parents.length > 0
                 icon: "←"
                 label: "返回"
-                foregroundColor: root.adaptiveForeground ? glass.foregroundColor : root.foregroundColor
+                foregroundColor: root.effectiveForegroundColor
                 onClicked: root.back()
             }
 
@@ -259,7 +268,7 @@ PopupWindow {
                     required property var modelData
                     readonly property var submenuItems: root.childrenFor(modelData)
                     width: parent.width
-                    foregroundColor: root.adaptiveForeground ? glass.foregroundColor : root.foregroundColor
+                    foregroundColor: root.effectiveForegroundColor
                     icon: modelData.icon || ""
                     label: modelData.label || ""
                     separator: !!modelData.separator

--- a/shell/desktop/modules/common/GlassText.qml
+++ b/shell/desktop/modules/common/GlassText.qml
@@ -7,13 +7,17 @@ import QtQuick
 // The outline follows the ink luminance, protecting both light text on bright
 // content and dark text on dark content. Callers can still override styleColor.
 Text {
+    id: root
+
     readonly property real inkLuminance: color.r * 0.2126
         + color.g * 0.7152 + color.b * 0.0722
-    style: Text.Outline
-    // Vibrancy-like protection in both directions: light ink receives a dark
-    // edge and dark ink a soft white edge. The glass stays transparent; only
-    // the one-pixel glyph boundary adapts to whatever is moving underneath.
+    renderType: Text.NativeRendering
+    style: (styleColor.a > 0.01) ? Text.Outline : Text.Normal
+    // Vibrancy-like protection: light ink receives a dark edge to protect against
+    // bright backgrounds. On dark ink (light mode), white outlines produce jagged
+    // halo artifacts around text glyphs, so keep the default edge transparent.
+    // Callers can still override styleColor if an explicit border is desired.
     styleColor: inkLuminance >= 0.55
         ? Qt.rgba(0.03, 0.045, 0.07, 0.36)
-        : Qt.rgba(1, 1, 1, 0.42)
+        : "transparent"
 }

--- a/shell/desktop/modules/common/LiquidGlassSurface.qml
+++ b/shell/desktop/modules/common/LiquidGlassSurface.qml
@@ -178,7 +178,7 @@ Rectangle {
         opacity: root.normalizedLiquidStrength
         gradient: Gradient {
             orientation: Gradient.Vertical
-            GradientStop { position: 0.0; color: Qt.rgba(1, 1, 1, 0.28 * root.materialHighlightFactor * root.materialReflectionScale) }
+            GradientStop { position: 0.0; color: Qt.rgba(1, 1, 1, 0.32 * root.materialHighlightFactor * root.materialReflectionScale) }
             GradientStop { position: 0.12; color: Qt.rgba(0.88, 0.94, 1, 0.14 * root.materialHighlightFactor * root.materialReflectionScale) }
             GradientStop { position: 0.32; color: Qt.rgba(1, 1, 1, 0.06 * root.materialHighlightFactor * root.materialReflectionScale) }
             GradientStop { position: 0.60; color: Qt.rgba(0.86, 0.93, 1, 0.018 * root.materialHighlightFactor * root.materialReflectionScale) }
@@ -244,7 +244,7 @@ Rectangle {
             orientation: Gradient.Horizontal
             GradientStop { position: 0.0; color: Qt.rgba(1, 1, 1, 0.0) }
             GradientStop { position: 0.18; color: Qt.rgba(1, 1, 1, 0.22 * root.materialHighlightFactor) }
-            GradientStop { position: 0.50; color: Qt.rgba(1, 1, 1, 0.35 * root.materialHighlightFactor) }
+            GradientStop { position: 0.50; color: Qt.rgba(1, 1, 1, 0.42 * root.materialHighlightFactor) }
             GradientStop { position: 0.82; color: Qt.rgba(1, 1, 1, 0.22 * root.materialHighlightFactor) }
             GradientStop { position: 1.0; color: Qt.rgba(1, 1, 1, 0.0) }
         }
@@ -259,11 +259,11 @@ Rectangle {
         height: 1
         gradient: Gradient {
             orientation: Gradient.Horizontal
-            GradientStop { position: 0.0; color: Qt.rgba(0.82, 0.90, 1.0, 0.0) }
-            GradientStop { position: 0.20; color: Qt.rgba(0.82, 0.90, 1.0, 0.045 * root.normalizedLiquidStrength) }
-            GradientStop { position: 0.50; color: Qt.rgba(0.88, 0.94, 1.0, 0.10 * root.normalizedLiquidStrength) }
-            GradientStop { position: 0.80; color: Qt.rgba(0.82, 0.90, 1.0, 0.045 * root.normalizedLiquidStrength) }
-            GradientStop { position: 1.0; color: Qt.rgba(0.82, 0.90, 1.0, 0.0) }
+            GradientStop { position: 0.0; color: Qt.rgba(0, 0, 0, 0.0) }
+            GradientStop { position: 0.20; color: Qt.rgba(0, 0, 0, 0.15 * root.normalizedLiquidStrength) }
+            GradientStop { position: 0.50; color: Qt.rgba(0, 0, 0, 0.28 * root.normalizedLiquidStrength) }
+            GradientStop { position: 0.80; color: Qt.rgba(0, 0, 0, 0.15 * root.normalizedLiquidStrength) }
+            GradientStop { position: 1.0; color: Qt.rgba(0, 0, 0, 0.0) }
         }
     }
 

--- a/shell/desktop/modules/common/MenuItemRow.qml
+++ b/shell/desktop/modules/common/MenuItemRow.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import qs.desktop.modules.dock
 
 // A row in a ContextMenu: icon + label, with optional checkmark (checkable),
 // submenu chevron, and a thin separator variant. Hover only changes the row's
@@ -23,7 +24,7 @@ Item {
     readonly property bool _hover: pointer.containsMouse
     readonly property color _hi: Qt.rgba(
         row.foregroundColor.r, row.foregroundColor.g, row.foregroundColor.b,
-        itemEnabled ? 0.24 : 0.20)
+        itemEnabled ? (ThemeService.isDark ? 0.22 : 0.10) : 0.05)
 
     height: row.separator ? 1 : 38
     visible: row.separator || label.length > 0
@@ -55,11 +56,12 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: 10
         anchors.verticalCenter: parent.verticalCenter
-        spacing: 9
+        spacing: row.icon.length > 0 ? 9 : 0
         visible: !row.separator
 
         Text {
-            width: 18
+            visible: row.icon.length > 0
+            width: visible ? 18 : 0
             text: row.icon
             font.family: "Font Awesome 7 Free"
             font.pixelSize: 13
@@ -70,11 +72,14 @@ Item {
         Text {
             text: row.label
             elide: Text.ElideRight
+            font.family: "SF Pro Display, Noto Sans CJK SC, sans-serif"
             font.pixelSize: 13
             font.weight: Font.DemiBold
+            renderType: Text.NativeRendering
             color: row.foregroundColor
             opacity: row.itemEnabled ? 1.0 : 0.6
             anchors.verticalCenter: parent.verticalCenter
+            width: Math.min(implicitWidth, (row.width - 24) - (row.icon.length > 0 ? 27 : 0) - ((row.checked || row.hasSubmenu) ? 24 : 0))
         }
     }
 
@@ -90,6 +95,7 @@ Item {
                 row.foregroundColor.b, 0.55)
         font.pixelSize: row.checked ? 12 : 16
         font.weight: Font.Bold
+        renderType: Text.NativeRendering
     }
 
     MouseArea {

--- a/shell/desktop/modules/common/qmldir
+++ b/shell/desktop/modules/common/qmldir
@@ -22,3 +22,4 @@ singleton AppearanceConfigService 1.0 AppearanceConfigService.qml
 singleton IconAppearanceService 1.0 IconAppearanceService.qml
 singleton AppearanceTokens 1.0 AppearanceTokens.qml
 singleton ScreenLifecycle 1.0 ScreenLifecycle.qml
+singleton AppNotificationService 1.0 AppNotificationService.qml

--- a/shell/desktop/modules/common/test_app_notification_service.mjs
+++ b/shell/desktop/modules/common/test_app_notification_service.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+
+function normalize(value) {
+    return String(value ?? "").replace(/<\d+>$/, "")
+        .replace(/\.desktop$/i, "").toLowerCase()
+        .replace(/[-_\s.]/g, "");
+}
+
+function countForApp(groups, appId, appName) {
+    if (!groups || groups.length === 0) return 0;
+    const rawAppId = String(appId ?? "").trim();
+    const rawAppName = String(appName ?? "").trim();
+    const normAppId = normalize(rawAppId);
+    const normAppName = normalize(rawAppName);
+
+    let total = 0;
+    for (let i = 0; i < groups.length; i++) {
+        const g = groups[i];
+        if (!g || !g.count) continue;
+        const gKey = String(g.groupKey ?? "").trim();
+        const gApp = String(g.appName ?? "").trim();
+        const normGKey = normalize(gKey);
+        const normGApp = normalize(gApp);
+
+        let match = false;
+        if (gKey && (gKey === rawAppId || gKey + ".desktop" === rawAppId || rawAppId + ".desktop" === gKey)) {
+            match = true;
+        } else if (normGKey && (normGKey === normAppId || normGKey === normAppName)) {
+            match = true;
+        } else if (normGApp && (normGApp === normAppId || normGApp === normAppName)) {
+            match = true;
+        } else if (normAppId && normGKey && (normAppId.endsWith(normGKey) || normGKey.endsWith(normAppId))) {
+            match = true;
+        }
+
+        if (match) {
+            total += g.count;
+        }
+    }
+    return total;
+}
+
+// Tests
+const testGroups = [
+    { groupKey: "org.kde.dolphin.desktop", appName: "Dolphin", count: 3 },
+    { groupKey: "com.tencent.wechat", appName: "微信", count: 5 },
+    { groupKey: "code", appName: "Visual Studio Code", count: 1 },
+    { groupKey: "telegram-desktop", appName: "Telegram", count: 2 },
+];
+
+assert.strictEqual(countForApp(testGroups, "org.kde.dolphin.desktop", "Dolphin"), 3);
+assert.strictEqual(countForApp(testGroups, "org.kde.dolphin", "Dolphin"), 3);
+assert.strictEqual(countForApp(testGroups, "dolphin.desktop", "文件管理器"), 3);
+assert.strictEqual(countForApp(testGroups, "com.tencent.wechat.desktop", "微信"), 5);
+assert.strictEqual(countForApp(testGroups, "wechat.desktop", "微信"), 5);
+assert.strictEqual(countForApp(testGroups, "code.desktop", "Code"), 1);
+assert.strictEqual(countForApp(testGroups, "org.telegram.desktop.desktop", "Telegram"), 2);
+assert.strictEqual(countForApp(testGroups, "nonexistent.desktop", "Unknown"), 0);
+
+console.log("All AppNotificationService matching tests passed!");

--- a/shell/desktop/modules/common/test_appearance_config.mjs
+++ b/shell/desktop/modules/common/test_appearance_config.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 
-function normalize(value) {
+function normalize(value, fallback = NaN) {
     const number = Number(value);
-    return Number.isFinite(number) ? Math.max(0, Math.min(1, number)) : NaN;
+    return Number.isFinite(number) ? Math.max(0, Math.min(1, number)) : fallback;
 }
 
 function compositorBlurLevel(strength) {
@@ -11,29 +11,49 @@ function compositorBlurLevel(strength) {
         ? Math.round(1 + Math.pow(value, 1.5) * 14) : 1;
 }
 
-// KWin owns one glass configuration. Surface names remain consumer aliases,
-// not independent compositor settings.
 function computeEffective(state) {
-    const rawBlur = normalize(state.globalBlurStrength ?? state.blurStrength
-        ?? state.dockBlurStrength ?? 0.42);
-    const rawLiquid = normalize(state.globalLiquidStrength ?? state.liquidStrength
-        ?? state.dockLiquidStrength ?? 1.0);
-    const blur = Number.isFinite(rawBlur) ? rawBlur : 0.42;
-    const liquid = Number.isFinite(rawLiquid) ? rawLiquid : 1.0;
+    const globalBlur = normalize(state.globalBlurStrength ?? state.blurStrength, 0.42);
+    const globalLiquid = normalize(state.globalLiquidStrength ?? state.liquidStrength, 1.0);
+
+    const dockInherit = state.dockBlurInherit !== undefined ? Boolean(state.dockBlurInherit) : true;
+    const barInherit = state.barBlurInherit !== undefined ? Boolean(state.barBlurInherit) : true;
+    const controlCenterInherit = state.controlCenterBlurInherit !== undefined ? Boolean(state.controlCenterBlurInherit) : true;
+    const launcherInherit = state.launcherBlurInherit !== undefined ? Boolean(state.launcherBlurInherit) : true;
+
     return {
-        dockBlur: blur, dockLiquid: liquid,
-        barBlur: blur, barLiquid: liquid,
-        launcherBlur: blur, launcherLiquid: liquid,
+        dockBlur: dockInherit ? globalBlur : normalize(state.dockBlurStrength, globalBlur),
+        dockLiquid: dockInherit ? globalLiquid : normalize(state.dockLiquidStrength, globalLiquid),
+        barBlur: barInherit ? globalBlur : normalize(state.barBlurStrength, globalBlur),
+        barLiquid: barInherit ? globalLiquid : normalize(state.barLiquidStrength, globalLiquid),
+        controlCenterBlur: controlCenterInherit ? globalBlur : normalize(state.controlCenterBlurStrength, globalBlur),
+        controlCenterLiquid: controlCenterInherit ? globalLiquid : normalize(state.controlCenterLiquidStrength, globalLiquid),
+        launcherBlur: launcherInherit ? globalBlur : normalize(state.launcherBlurStrength, globalBlur),
+        launcherLiquid: launcherInherit ? globalLiquid : normalize(state.launcherLiquidStrength, globalLiquid),
     };
 }
 
 function migrate(previous = {}) {
+    const globalBlur = normalize(previous.globalBlurStrength ?? previous.blurStrength
+        ?? previous.dockBlurStrength, 0.42);
+    const globalLiquid = normalize(previous.globalLiquidStrength ?? previous.liquidStrength
+        ?? previous.dockLiquidStrength, 1.0);
+
     return {
-        version: 8,
-        globalBlurStrength: previous.globalBlurStrength ?? previous.blurStrength
-            ?? previous.dockBlurStrength ?? 0.42,
-        globalLiquidStrength: previous.globalLiquidStrength ?? previous.liquidStrength
-            ?? previous.dockLiquidStrength ?? 1.0,
+        version: 10,
+        globalBlurStrength: globalBlur,
+        globalLiquidStrength: globalLiquid,
+        dockBlurInherit: previous.dockBlurInherit !== undefined ? Boolean(previous.dockBlurInherit) : true,
+        dockBlurStrength: normalize(previous.dockBlurStrength, globalBlur),
+        dockLiquidStrength: normalize(previous.dockLiquidStrength, globalLiquid),
+        barBlurInherit: previous.barBlurInherit !== undefined ? Boolean(previous.barBlurInherit) : true,
+        barBlurStrength: normalize(previous.barBlurStrength, globalBlur),
+        barLiquidStrength: normalize(previous.barLiquidStrength, globalLiquid),
+        controlCenterBlurInherit: previous.controlCenterBlurInherit !== undefined ? Boolean(previous.controlCenterBlurInherit) : true,
+        controlCenterBlurStrength: normalize(previous.controlCenterBlurStrength, globalBlur),
+        controlCenterLiquidStrength: normalize(previous.controlCenterLiquidStrength, globalLiquid),
+        launcherBlurInherit: previous.launcherBlurInherit !== undefined ? Boolean(previous.launcherBlurInherit) : true,
+        launcherBlurStrength: normalize(previous.launcherBlurStrength, globalBlur),
+        launcherLiquidStrength: normalize(previous.launcherLiquidStrength, globalLiquid),
         shellStyle: previous.shellStyle ?? "macos",
         barIntegratedWithDock: previous.barIntegratedWithDock ?? false,
         barVisibilityMode: previous.barVisibilityMode ?? "always",
@@ -54,42 +74,52 @@ function migrate(previous = {}) {
     assert.deepEqual(computeEffective({}), {
         dockBlur: 0.42, dockLiquid: 1,
         barBlur: 0.42, barLiquid: 1,
+        controlCenterBlur: 0.42, controlCenterLiquid: 1,
         launcherBlur: 0.42, launcherLiquid: 1,
     });
-    console.log("ok: global defaults apply to every surface");
+    console.log("ok: global defaults apply to every surface when inherit is true");
 }
 
 {
     assert.deepEqual(computeEffective({ globalBlurStrength: 0.18, globalLiquidStrength: 0.73 }), {
         dockBlur: 0.18, dockLiquid: 0.73,
         barBlur: 0.18, barLiquid: 0.73,
+        controlCenterBlur: 0.18, controlCenterLiquid: 0.73,
         launcherBlur: 0.18, launcherLiquid: 0.73,
     });
-    console.log("ok: global update propagates to every surface");
+    console.log("ok: global update propagates to inherited surfaces");
 }
 
 {
     const effective = computeEffective({
         globalBlurStrength: 0.26, globalLiquidStrength: 0.61,
-        dockBlurInherit: false, dockBlurStrength: 0.95,
-        barBlurInherit: false, barBlurStrength: 0.88,
+        dockBlurInherit: false, dockBlurStrength: 0.95, dockLiquidStrength: 0.80,
+        barBlurInherit: true,
+        controlCenterBlurInherit: false, controlCenterBlurStrength: 0.50, controlCenterLiquidStrength: 0.30,
         launcherBlurInherit: false, launcherLiquidStrength: 0.11,
     });
-    assert.equal(effective.dockBlur, 0.26);
+    assert.equal(effective.dockBlur, 0.95);
+    assert.equal(effective.dockLiquid, 0.80);
     assert.equal(effective.barBlur, 0.26);
-    assert.equal(effective.launcherLiquid, 0.61);
-    console.log("ok: legacy per-surface values are ignored");
+    assert.equal(effective.barLiquid, 0.61);
+    assert.equal(effective.controlCenterBlur, 0.50);
+    assert.equal(effective.controlCenterLiquid, 0.30);
+    assert.equal(effective.launcherBlur, 0.26); // inherit is false, but blurStrength is unset so falls back to global
+    assert.equal(effective.launcherLiquid, 0.11);
+    console.log("ok: independent component overrides take effect when inherit is false");
 }
 
 {
-    const v8 = migrate({ dockBlurStrength: 0.31, dockLiquidStrength: 0.82 });
-    assert.equal(v8.version, 8);
-    assert.equal(v8.globalBlurStrength, 0.31);
-    assert.equal(v8.globalLiquidStrength, 0.82);
-    assert.equal("dockBlurStrength" in v8, false);
-    assert.equal("barBlurInherit" in v8, false);
-    assert.equal(v8.barLayoutMode, "transparent");
-    console.log("ok: v7 configuration migrates to flattened v8");
+    const v10 = migrate({ dockBlurStrength: 0.31, dockLiquidStrength: 0.82 });
+    assert.equal(v10.version, 10);
+    assert.equal(v10.globalBlurStrength, 0.31);
+    assert.equal(v10.globalLiquidStrength, 0.82);
+    assert.equal(v10.dockBlurInherit, true);
+    assert.equal(v10.dockBlurStrength, 0.31);
+    assert.equal(v10.barBlurInherit, true);
+    assert.equal(v10.controlCenterBlurInherit, true);
+    assert.equal(v10.launcherBlurInherit, true);
+    console.log("ok: legacy configuration smoothly migrates to schema v10");
 }
 
 console.log("ALL TESTS PASS");

--- a/shell/desktop/modules/dock/DockAutoHideController.qml
+++ b/shell/desktop/modules/dock/DockAutoHideController.qml
@@ -79,7 +79,7 @@ Item {
         const s = ctl.targetScreen
         if (!s || s.x === undefined || s.width === undefined)
             return { x: 0, y: 0, width: 1, height: 1 }
-        return { x: s.x, y: s.y, width: s.width, height: s.height }
+        return { x: s.x, y: s.y, width: s.width, height: s.height, name: s.name || "" }
     }
 
     function _windowCandidates() {
@@ -204,7 +204,7 @@ Item {
     function _setPhase(next) {
         if (ctl.phase === next)
             return
-        console.log("[DockAutoHide] " + ctl.phase + " -> " + next
+        console.info("[DockAutoHide] " + ctl.phase + " -> " + next
             + " mode=" + ctl.mode + " conflict=" + ctl.hasWindowConflict
             + " inhibit=" + ctl.hasInhibitor)
         ctl.phase = next

--- a/shell/desktop/modules/dock/DockAutoHideMath.mjs
+++ b/shell/desktop/modules/dock/DockAutoHideMath.mjs
@@ -109,7 +109,7 @@ export function windowEligible(window, targetScreen, currentDesktopId) {
         const current = String(currentDesktopId || "");
         if (current) {
             const onCurrent = Array.isArray(window.desktopIds)
-                && window.desktopIds.indexOf(current) >= 0;
+                && (window.desktopIds.length === 0 || window.desktopIds.indexOf(current) >= 0);
             if (!onCurrent)
                 return false;
         } else if (window.isVisible === false) {

--- a/shell/desktop/modules/dock/DockContainer.qml
+++ b/shell/desktop/modules/dock/DockContainer.qml
@@ -505,13 +505,14 @@ Item {
             vertical: container.vertical
             iconSize: container.iconSize
             activeBackgroundGap: container.activeBackgroundGap
-            iconSource: AppPresentationService.iconSource("user-trash")
+            iconSource: DockTrashService.hasItems
+                ? AppPresentationService.iconSource("user-trash-full")
+                : AppPresentationService.iconSource("user-trash")
             displayName: "回收站"
             showContextMenu: false
             customContextMenu: true
             allowEdit: false
             isPinnedItem: false
-            statusBadge: DockTrashService.hasItems
             onActivate: {
                 if (container.isEditing) {
                     container.editMode = false
@@ -707,6 +708,7 @@ Item {
                                 isRunning: pinnedItemLoader.itemData.isRunning ?? false
                                 isActivated: DockModelService.isAppActivated(
                                     pinnedItemLoader.itemData.appId ?? "")
+                                isUrgent: pinnedItemLoader.itemData.isUrgent ?? false
                                 appId: pinnedItemLoader.itemData.appId ?? ""
                                 isWindowItem: false
                                 isPinnedItem: true

--- a/shell/desktop/modules/dock/DockIcon.qml
+++ b/shell/desktop/modules/dock/DockIcon.qml
@@ -83,9 +83,13 @@ Item {
     // icons intentionally leave it false.
     property bool   editMode: false
     property bool   isDragging: false
-    // A small neutral marker for persistent shell-control state, currently
-    // used by the Trash icon while it contains recoverable items.
-    property bool   statusBadge: false
+
+    // ── macOS App Notification Badge ──
+    // Unread count comes from the desktop notification center (grouped by
+    // app), while urgency covers apps that only flash their window or tray
+    // icon (WeChat/QQ) without posting notifications.
+    readonly property int unreadCount: AppNotificationService.countForApp(icon.appId, icon.displayName)
+    readonly property bool hasUrgentOrNotification: (icon.unreadCount > 0 || icon.isUrgent) && !icon.editMode
     // This is proportional to iconSize (3px when iconSize is 44px). It is
     // also included in AdaptiveMath, so the active background never overlaps
     // a neighbour or makes the real Row wider than the calculated width.
@@ -303,6 +307,7 @@ Item {
     }
     readonly property bool _hasWindows: _appWindows.length > 0
     readonly property string _previewWindowId: _hasWindows ? _appWindows[0].windowId : (icon.windowId || "")
+    readonly property int _effectiveWindowCount: _hasWindows ? _appWindows.length : (icon.isRunning ? 1 : 0)
 
     Behavior on scale {
         NumberAnimation {
@@ -495,31 +500,69 @@ Item {
         }
     }
 
+    // ── macOS App Notification Badge ──
+    // A red pill with the unread count sits at the icon's top-right corner.
+    // When only the urgency flag is set (no countable notifications), it
+    // degrades to a small red dot, matching macOS behavior.
     Rectangle {
-        width: Math.max(5, Math.round(icon.iconSize * 0.15))
-        height: width
-        anchors { right: parent.right; top: parent.top; rightMargin: 2; topMargin: 2 }
-        radius: width / 2
-        color: Qt.rgba(1, 1, 1, 0.88)
-        border { width: 1; color: Qt.rgba(0, 0, 0, 0.48) }
-        opacity: icon.statusBadge ? 1 : 0
+        id: notificationBadge
+        readonly property bool hasCount: icon.unreadCount > 0
+        readonly property real badgeHeight: hasCount
+            ? Math.max(16, Math.round(icon.iconSize * 0.36))
+            : Math.max(9, Math.round(icon.iconSize * 0.20))
+        readonly property real badgeWidth: hasCount
+            ? Math.max(badgeHeight, badgeText.implicitWidth + Math.round(badgeHeight * 0.55))
+            : badgeHeight
+
+        width: badgeWidth
+        height: badgeHeight
+        radius: badgeHeight / 2
+        anchors.top: iconRenderer.top
+        anchors.right: iconRenderer.right
+        anchors.topMargin: hasCount ? -Math.round(icon.iconSize * 0.06) : -Math.round(icon.iconSize * 0.02)
+        anchors.rightMargin: hasCount ? -Math.round(icon.iconSize * 0.06) : -Math.round(icon.iconSize * 0.02)
+        rotation: icon.vertical ? -90 : 0
+        transformOrigin: Item.Center
+        z: 3
+
+        color: "#ff3b30"
+        border.width: 1.5
+        border.color: Qt.rgba(1, 1, 1, 0.95)
+
+        opacity: icon.hasUrgentOrNotification ? 1.0 : 0.0
+        scale: icon.hasUrgentOrNotification ? 1.0 : 0.0
         visible: opacity > 0.01
-        z: 2
+
         Behavior on opacity {
             NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
         }
+        Behavior on scale {
+            NumberAnimation { duration: 160; easing.type: Easing.OutBack }
+        }
+
+        Text {
+            id: badgeText
+            anchors.centerIn: parent
+            visible: notificationBadge.hasCount
+            text: icon.unreadCount > 99 ? "99+" : String(icon.unreadCount)
+            color: "#ffffff"
+            font {
+                pixelSize: Math.max(9, Math.round(notificationBadge.badgeHeight * 0.62))
+                bold: true
+            }
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
     }
 
-    // Keep the fixed-size indicator used by the previous main branch. A row
-    // of per-window dots expands after the side Dock rotates its content and
-    // can visibly escape the icon slot on left/right edges.
-    Rectangle {
+
+
+    // Style-driven running indicator: macOS uses dots (single dot for 1 window,
+    // multi-dot for multiple windows), Windows a longer underline, and Material a shorter tonal pill.
+    Item {
         id: runningIndicator
-        width: icon.runningIndicatorWidth
+        width: indicatorRow.implicitWidth
         height: icon.runningIndicatorHeight
-        radius: width / 2
-        color: icon.dotIndicator ? Qt.rgba(1, 1, 1, 0.95)
-            : ThemeService.accentColor
         opacity: icon.isRunning ? 1 : 0
         visible: opacity > 0.01
         z: 2
@@ -533,6 +576,32 @@ Item {
 
         Behavior on opacity {
             NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
+        }
+        Row {
+            id: indicatorRow
+            anchors.centerIn: parent
+            spacing: icon._effectiveWindowCount >= 3 ? 2 : 2.5
+
+            Repeater {
+                model: icon.dotIndicator
+                    ? Math.min(3, Math.max(1, icon._effectiveWindowCount))
+                    : 1
+                delegate: Rectangle {
+                    required property int index
+                    readonly property real dotSize: icon._effectiveWindowCount >= 3
+                        ? Math.max(3, icon.runningIndicatorWidth * 0.82)
+                        : icon.runningIndicatorWidth
+                    width: icon.dotIndicator ? dotSize : icon.runningIndicatorWidth
+                    height: icon.dotIndicator ? dotSize : icon.runningIndicatorHeight
+                    radius: width / 2
+                    color: icon.dotIndicator ? ThemeService.dotIndicatorColor
+                        : ThemeService.accentColor
+                    border {
+                        width: icon.dotIndicator ? 0.5 : 0
+                        color: ThemeService.isDark ? Qt.rgba(0, 0, 0, 0.40) : Qt.rgba(1, 1, 1, 0.35)
+                    }
+                }
+            }
         }
     }
 

--- a/shell/desktop/modules/dock/DockModelService.qml
+++ b/shell/desktop/modules/dock/DockModelService.qml
@@ -109,6 +109,7 @@ QtObject {
                     name: identity.name || dockItem.appId,
                     icon: windows[0]?.iconSource ?? identity.iconSource,
                     isRunning: windows.length > 0,
+                    isUrgent: windows.some(window => !!window.isUrgent),
                     windowCount: windows.length,
                 });
                 continue;
@@ -126,6 +127,7 @@ QtObject {
                     && item.name === prev.name
                     && item.icon === prev.icon
                     && item.isRunning === prev.isRunning
+                    && item.isUrgent === prev.isUrgent
                     && item.windowCount === prev.windowCount;
             });
         if (!same) {

--- a/shell/desktop/modules/dock/DockThemeService.qml
+++ b/shell/desktop/modules/dock/DockThemeService.qml
@@ -36,6 +36,7 @@ QtObject {
     readonly property color darkDivider: Qt.rgba(1.0, 1.0, 1.0, 0.18)
     readonly property color darkTooltipBg: Qt.rgba(0.18, 0.18, 0.20, 0.95)
     readonly property color darkIndicator: Qt.rgba(0.20, 0.60, 1.0, 0.85)
+    readonly property color darkDotIndicator: Qt.rgba(1.0, 1.0, 1.0, 0.95)
     readonly property color darkBorder: Qt.rgba(1.0, 1.0, 1.0, 0.16)
     readonly property color darkHighlight: Qt.rgba(1.0, 1.0, 1.0, 0.28)
 
@@ -50,6 +51,7 @@ QtObject {
     readonly property color lightDivider: Qt.rgba(0.055, 0.065, 0.085, 0.16)
     readonly property color lightTooltipBg: Qt.rgba(0.92, 0.92, 0.94, 0.95)
     readonly property color lightIndicator: Qt.rgba(0.0, 0.50, 0.90, 0.75)
+    readonly property color lightDotIndicator: Qt.rgba(0.0, 0.0, 0.0, 0.85)
     readonly property color lightBorder: Qt.rgba(0.055, 0.065, 0.085, 0.14)
     readonly property color lightHighlight: Qt.rgba(1.0, 1.0, 1.0, 0.55)
 
@@ -66,6 +68,7 @@ QtObject {
     readonly property color dividerColor: isDark ? darkDivider : lightDivider
     readonly property color tooltipBackground: isDark ? darkTooltipBg : lightTooltipBg
     readonly property color indicatorColor: isDark ? darkIndicator : lightIndicator
+    readonly property color dotIndicatorColor: isDark ? darkDotIndicator : lightDotIndicator
     readonly property color borderColor: isDark ? darkBorder : lightBorder
     readonly property color highlightColor: isDark ? darkHighlight : lightHighlight
 }

--- a/shell/desktop/modules/dock/DockWindow.qml
+++ b/shell/desktop/modules/dock/DockWindow.qml
@@ -110,12 +110,10 @@ PanelWindow {
             : dockContainer.height + root.edgeMargin + root.workspaceGap)
         : 0
 
-    // The custom KWin glass effect consumes this region for both backdrop
-    // blur and liquid refraction. Keep publishing it when either channel is
-    // active; gating only on blur makes a liquid-only Dock fully transparent.
+    // Only publish blurRegion when backdrop blur is active. Liquid finish is
+    // rendered directly by QML LiquidGlassSurface.
     BackgroundEffect.blurRegion: (root.visible
-        && (AppearanceConfigService.effectiveDockBlur > 0.005
-            || AppearanceConfigService.effectiveDockLiquid > 0.005))
+        && AppearanceConfigService.effectiveDockBlur > 0.005)
         ? dockBlurRegionHolder : null
 
     Region {
@@ -198,6 +196,24 @@ PanelWindow {
         transformOrigin: root.vertical
             ? (root.position === "right" ? Item.Right : Item.Left)
             : Item.Bottom
+
+        LiquidGlassSurface {
+            id: dockGlassSurface
+            anchors.fill: parent
+            radius: dockContainer.pillRadius
+            baseColor: ThemeService.backgroundColor
+            surfaceOpacity: 1.0
+            blurStrength: AppearanceConfigService.effectiveDockBlur
+            liquidStrength: AppearanceConfigService.effectiveDockLiquid
+            ambientPrimary: WallpaperPaletteService.primary
+            ambientSecondary: WallpaperPaletteService.secondary
+            ambientStrength: 0.35 * AppearanceTokens.glass.ambientMultiplier
+            material: "regular"
+            border.width: (AppearanceConfigService.effectiveDockBlur > 0.005
+                || AppearanceConfigService.effectiveDockLiquid > 0.005) ? 1 : 0
+            border.color: Qt.rgba(1, 1, 1, 0.20 * Math.max(dockGlassSurface.normalizedBlurStrength,
+                dockGlassSurface.normalizedLiquidStrength))
+        }
 
         DockContainer {
             id: dockContainer

--- a/shell/desktop/modules/dock/DockWindowPreview.qml
+++ b/shell/desktop/modules/dock/DockWindowPreview.qml
@@ -39,23 +39,19 @@ PopupWindow {
     readonly property int windowCount: effectiveWindows.length
     readonly property real cardWidth: 220
     readonly property real cardHeight: 160
+    readonly property real plusCardWidth: 64
     readonly property real rowPadding: 10
     readonly property real rowSpacing: 8
 
     readonly property real calculatedWidth: rowPadding * 2
-        + windowCount * cardWidth
-        + Math.max(0, windowCount - 1) * rowSpacing
+        + (windowCount > 0 ? windowCount * cardWidth + (windowCount - 1) * rowSpacing + rowSpacing + plusCardWidth : plusCardWidth)
 
     readonly property real maxAllowedWidth: {
         const screenW = anchorItem?.targetScreen?.width ?? Quickshell.screens[0]?.width ?? 1920
         return Math.max(300, screenW * 0.88)
     }
 
-    // A single 220px card needs only its two 10px margins. The previous 300px
-    // floor existed for the removed new-window card and left a visible blank
-    // strip to the right of a lone preview.
-    implicitWidth: Math.min(maxAllowedWidth,
-                            Math.max(cardWidth + rowPadding * 2, calculatedWidth))
+    implicitWidth: Math.min(maxAllowedWidth, Math.max(cardWidth + rowPadding * 2, calculatedWidth))
     implicitHeight: 184
     color: "transparent"
     grabFocus: false
@@ -383,6 +379,91 @@ PopupWindow {
                                     WindowService.activateWindow(cardDelegate.winId)
                                     DockModelService.setDockPopupVisible(preview, false)
                                 }
+                            }
+                        }
+                    }
+                }
+
+                // '+' New Window Button Card
+                Item {
+                    id: plusCard
+                    width: preview.plusCardWidth
+                    height: preview.cardHeight
+
+                    Rectangle {
+                        id: plusBg
+                        anchors.fill: parent
+                        radius: 8
+                        color: plusMouse.containsMouse
+                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.10))
+                            : (ThemeService.isDark ? Qt.rgba(0.06, 0.06, 0.08, 0.35) : Qt.rgba(1, 1, 1, 0.25))
+                        border.width: 1
+                        border.color: plusMouse.containsMouse
+                            ? Qt.rgba(1, 1, 1, 0.30)
+                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.08))
+
+                        Behavior on color {
+                            ColorAnimation { duration: 100 }
+                        }
+                        Behavior on border.color {
+                            ColorAnimation { duration: 100 }
+                        }
+
+                        Column {
+                            anchors.centerIn: parent
+                            spacing: 6
+
+                            Rectangle {
+                                width: 32
+                                height: 32
+                                radius: 16
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                color: plusMouse.containsMouse
+                                    ? Qt.rgba(ThemeService.accentColor.r, ThemeService.accentColor.g, ThemeService.accentColor.b, 0.35)
+                                    : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(0, 0, 0, 0.08))
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "＋"
+                                    color: ThemeService.foregroundColor
+                                    font.pixelSize: 18
+                                    font.bold: true
+                                }
+                            }
+
+                            Text {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                text: "新建窗口"
+                                color: ThemeService.foregroundColor
+                                style: ThemeService.isDark ? Text.Outline : Text.Normal
+                                styleColor: Qt.rgba(0, 0, 0, 0.40)
+                                opacity: 0.78
+                                font {
+                                    pixelSize: 10
+                                    weight: Font.DemiBold
+                                }
+                            }
+                        }
+
+                        MouseArea {
+                            id: plusMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            acceptedButtons: Qt.LeftButton
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                const targetAppId = preview.appId
+                                    || (preview.effectiveWindows.length > 0
+                                        ? (preview.effectiveWindows[0].identity?.desktopId
+                                           || preview.effectiveWindows[0].desktopId
+                                           || preview.effectiveWindows[0].appId
+                                           || preview.effectiveWindows[0].identity?.rawAppId
+                                           || preview.effectiveWindows[0].rawAppId)
+                                        : "")
+                                console.log("[DockPreview] plus card clicked targetAppId=" + targetAppId)
+                                if (targetAppId)
+                                    DockModelService.launchNewWindow(targetAppId)
+                                DockModelService.setDockPopupVisible(preview, false)
                             }
                         }
                     }

--- a/shell/desktop/modules/dock/WindowService.qml
+++ b/shell/desktop/modules/dock/WindowService.qml
@@ -597,11 +597,12 @@ QtObject {
         _kwinSubscribePending = true
         PlatformClient.request("kwin.subscribe", {}, function(response) {
             _kwinSubscribePending = false
-            if (!response?.ok)
+            if (!response?.ok) {
                 console.warn("[WindowService] KWin subscription failed: "
                     + (response?.error?.message || "platform unavailable"))
-            else
+            } else {
                 svc._sendKwinCommand({ action: "desktops" })
+            }
         })
     }
 

--- a/shell/desktop/modules/notifications/NotificationGroupService.qml
+++ b/shell/desktop/modules/notifications/NotificationGroupService.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell.Services.Notifications
 import qs.desktop.modules.bar
+import qs.desktop.modules.common
 
 // Groups tracked notifications by desktopEntry (fallback appName) into a
 // ListModel that the popup and history views consume. Quickshell's
@@ -259,6 +260,10 @@ QtObject {
                     model.setProperty(i, key, g[key])
             }
         }
+        // Feed the dock badge service so DockIcon can react to per-app
+        // notification counts. Passes the primitive fields only (the live
+        // Notification objects must not cross this boundary).
+        AppNotificationService.updateFromGroups(nextGroups)
     }
 
     function _rebuild() {


### PR DESCRIPTION
### Summary of Changes

This PR resolves several critical desktop UX and protocol integration issues across the Global Menu, Top Bar, surface typography, and appearance configuration:

#### 1. Global Menu & DBusMenu Protocol Fixes
- **Qt/KDE `Event` Signature Protocol Alignment**: Pack the `com.canonical.dbusmenu.Event` parameter as `(isvu)` using `QDBusVariant(QVariantMap)`. Qt's `QDBusMenuAdaptor` strictly requires a D-Bus variant; passing a plain `QVariantMap` generated `(isa{sv}u)` and triggered `UnknownMethod` errors, breaking menu item clicks in applications like Okular and Dolphin.
- **Dynamic Menus & Submenus**: Trigger `AboutToShow(id)` on menu activation to support lazy-loaded actions, parse `children-display == "submenu"` recursively (depth up to 5), and clean up freedesktop icon fallback text overlap.
- **macOS-Style Positioning**: Position dropdown menus strictly beneath the bottom edge of the Bar (`centerBelowOffset: 36` + `Edges.Top | Edges.Left`), preventing the popup from overlapping Bar buttons. Support smooth adjacent menu switching on pointer hover (`onEntered`).
- **Crisp Native Typography**: Replace `GlassText` (and its 1px stroke outline) with standard `Text` + `renderType: Text.NativeRendering` and unified typography (`SF Pro Display`, `Noto Sans CJK SC`).

#### 2. Top Bar Auto-Hide & Floating Overlay Mode
- **Overlay Layer vs Exclusive Space**: Keep `exclusiveZone: 0` during `smart` and `persistent` auto-hide modes. Maximized windows extend completely to the top screen edge (y=0); the Bar reveals smoothly as a floating overlay on `WlrLayer.Top` without resizing or bouncing active windows.
- **Edge Hit Area Optimization**: Reduce `topTriggerArea` height to 2px to eliminate interference with fullscreen browser tabs or titlebar drag areas. Keep Bar locked visible when global menus are open (`menuOpen`).

#### 3. Font Anti-Aliasing & Halo Removal (GlassText)
- **Native FreeType Hinting**: Equip `GlassText` with `renderType: Text.NativeRendering`.
- **Remove Light Mode White Outline**: Make default `styleColor` transparent on dark ink (`inkLuminance < 0.55`) so black text on light backgrounds no longer displays a jagged white glow/halo border. Retain gentle dark edge protection only on light text (dark mode).
- **Time & Date Typography**: Explicitly bind `NativeRendering` and SF Pro font stack to `BarDateStatus`.

#### 4. Appearance Pipeline & Per-Component Control
- **Schema v10 & Component Inheritance**: Enable independent blur and liquid glass control for Dock, Bar, Control Center, and App Launcher, with one-click inheritance from global settings.
- **Pure Zero-Transparency**: Automatically disable border width and background blur registration when blur and liquid strengths reach 0, achieving 100% clean transparency without residual white lines or grey backplates.

#### 5. Dock & Notification Enhancements
- **Notification Badges**: Add `AppNotificationService` to track live unread notification counts per application and display macOS-style red notification badges on Dock icons. Propagate `isUrgent` window attention states.
- **Dynamic Trash**: Dynamically switch Dock trash icon between empty and full states.

---

### Verification & Tests Passed
- `node shared/qml/test_visual_contract.mjs`: **PASS**
- `node shell/desktop/modules/common/test_appearance_config.mjs`: **PASS**
- `node shell/desktop/modules/dock/test_autohide.mjs`: **PASS**
- `node platform/tests/test_window_placement.mjs`: **PASS**
- `node shell/desktop/modules/common/test_app_notification_service.mjs`: **PASS**
- `uv run python platform/tests/test_contract.py`: **PASS**
- C++ builds verified: `kos-settings` and `kos-platform` build without errors.
