### PR TITLE
perf: 减少窗口快照与壁纸轮询的重复工作

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,25 @@ if(BUILD_TESTING)
                 ${CMAKE_CURRENT_SOURCE_DIR}/shared/qml/test_visual_contract.mjs
         )
         set_tests_properties(kos-ui.visual-contract PROPERTIES TIMEOUT 10)
+        add_test(NAME kos-shell.window-record-index
+            COMMAND ${KOS_NODE_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/shell/desktop/modules/dock/test_window_record_index.mjs
+        )
+        set_tests_properties(kos-shell.window-record-index PROPERTIES TIMEOUT 10)
+        add_test(NAME kos-shell.wallpaper-palette
+            COMMAND ${KOS_NODE_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/shell/desktop/modules/dock/test_wallpaper_palette.mjs
+        )
+        set_tests_properties(kos-shell.wallpaper-palette PROPERTIES TIMEOUT 10)
+        find_program(KOS_QUICKSHELL_EXECUTABLE NAMES quickshell)
+        if(KOS_QUICKSHELL_EXECUTABLE)
+            add_test(NAME kos-shell.static-work-runtime
+                COMMAND ${KOS_NODE_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/static-work/run.mjs
+                    ${KOS_QUICKSHELL_EXECUTABLE}
+            )
+            set_tests_properties(kos-shell.static-work-runtime PROPERTIES TIMEOUT 15)
+        endif()
     endif()
 endif()
 

--- a/platform/src/kwin/KWinBridge.cpp
+++ b/platform/src/kwin/KWinBridge.cpp
@@ -154,9 +154,14 @@ private:
     {
         if (g_eventHandler)
             g_eventHandler(event);
-        QTextStream(stdout) << "EVENT "
-                            << QJsonDocument(event).toJson(QJsonDocument::Compact)
-                            << Qt::endl;
+        // Socket subscribers receive the event above. Full JSON on stdout is
+        // diagnostic only; avoid serializing and flushing every geometry tick.
+        static const bool traceEvents = qEnvironmentVariableIntValue("KOS_PLATFORM_TRACE_EVENTS") == 1;
+        if (traceEvents) {
+            QTextStream(stdout) << "EVENT "
+                                << QJsonDocument(event).toJson(QJsonDocument::Compact)
+                                << Qt::endl;
+        }
     }
 
     void publishThumbnailError(const QString &id, const QString &message)

--- a/platform/tests/test_contract.py
+++ b/platform/tests/test_contract.py
@@ -43,8 +43,17 @@ def test_theme_toggle_uses_the_safe_palette_path() -> None:
     )
 
 
+def test_bridge_trace_is_opt_in() -> None:
+    source = (ROOT / "platform/src/kwin/KWinBridge.cpp").read_text()
+    publish = source[source.index("void publishEvent("):source.index("void publishThumbnailError(")]
+    assert 'qEnvironmentVariableIntValue("KOS_PLATFORM_TRACE_EVENTS") == 1' in publish
+    assert publish.index("g_eventHandler(event)") < publish.index("if (traceEvents)")
+    assert publish.index("if (traceEvents)") < publish.index("QJsonDocument(event).toJson")
+
+
 if __name__ == "__main__":
     test_shortcuts_service_defaults()
     test_platform_contract_mentions_socket_and_errors()
     test_theme_toggle_uses_the_safe_palette_path()
+    test_bridge_trace_is_opt_in()
     print("platform contracts: ok")

--- a/shell/desktop/modules/dock/WallpaperPaletteService.qml
+++ b/shell/desktop/modules/dock/WallpaperPaletteService.qml
@@ -16,10 +16,7 @@ QtObject {
     readonly property int preferredScreen: Quickshell.screens.length > 1 ? 1 : 0
     property url wallpaperUrl: ""
     property string configuredWallpaperUrl: ""
-    // Keep a QML-owned reference to each read process. A local JavaScript
-    // reference can be collected before its exit callback on some reloads,
-    // which leaves the old boolean guard permanently set.
-    property var _refreshProcess: null
+    // Keep a QML-owned reference while resolving a wallpaper package.
     property var _resolveProcess: null
     readonly property color primary: palette.primary
     readonly property color secondary: palette.secondary
@@ -133,40 +130,17 @@ QtObject {
     }
 
     function refresh() {
-        if (_refreshProcess)
-            return
-        const proc = _processFactory.createObject(svc, {
-            command: ["sh", "-c", "cat \"$1\"", "wallpaper-palette-read", configPath],
-        })
-        _refreshProcess = proc
-        _refreshWatchdog.restart()
-        proc.exited.connect(function(code) {
-            svc._refreshWatchdog.stop()
-            if (svc._refreshProcess === proc)
-                svc._refreshProcess = null
-            const output = proc.stdout?.text ?? ""
-            if (code === 0)
-                svc._readWallpaperText(output)
-            else
-                console.warn("[WallpaperPalette] config read failed code=" + code)
-            proc.destroy()
-        })
-        proc.running = true
+        _configFile.reload()
     }
 
-    property Timer _refreshWatchdog: Timer {
-        interval: 1500
-        repeat: false
-        onTriggered: {
-            const proc = svc._refreshProcess
-            if (!proc)
-                return
-            console.warn("[WallpaperPalette] config reader stalled; retrying")
-            svc._refreshProcess = null
-            proc.running = false
-            proc.destroy()
-            svc.refresh()
-        }
+    property FileView _configFile: FileView {
+        path: svc.configPath
+        preload: true
+        // Keep the existing periodic reload: atomic replacement must not
+        // depend on a watch of the old inode. Failed reads retain the palette.
+        watchChanges: false
+        onLoaded: svc._readWallpaperText(text())
+        onLoadFailed: error => console.warn("[WallpaperPalette] config read failed error=" + error)
     }
 
     property Component _processFactory: Component {
@@ -209,5 +183,4 @@ QtObject {
         }
     }
 
-    Component.onCompleted: refresh()
 }

--- a/shell/desktop/modules/dock/WindowRecordIndex.mjs
+++ b/shell/desktop/modules/dock/WindowRecordIndex.mjs
@@ -1,0 +1,16 @@
+// Build once per snapshot. Keep providers separate and preserve the first
+// match, just like the old linear lookup (including duplicate provider IDs).
+export function indexWindowRecords(records) {
+    const kwin = new Map();
+    const foreign = new Map();
+    for (const record of records) {
+        const index = record.provider === "kwin" ? kwin
+            : record.provider === "foreign" ? foreign : null;
+        if (!index)
+            continue;
+        const key = record.provider === "kwin" ? record.handleId : record.toplevel;
+        if (!index.has(key))
+            index.set(key, record);
+    }
+    return { kwin, foreign };
+}

--- a/shell/desktop/modules/dock/WindowService.qml
+++ b/shell/desktop/modules/dock/WindowService.qml
@@ -2,6 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell.Wayland._ToplevelManagement
 import qs.desktop.modules.platform
+import "WindowRecordIndex.mjs" as WindowRecordIndex
 
 // WindowService — provider-neutral runtime window model.
 //
@@ -171,19 +172,6 @@ QtObject {
         return result;
     }
 
-    function _findOldRecord(toplevel, provider, handleId) {
-        for (let i = 0; i < svc.records.length; i++) {
-            const record = svc.records[i];
-            if (provider === "kwin") {
-                if (record.provider === "kwin" && record.handleId === handleId)
-                    return record;
-            } else if (record.provider === "foreign" && record.toplevel === toplevel) {
-                return svc.records[i];
-            }
-        }
-        return null;
-    }
-
     function _newWindowId() {
         return "window-" + (svc._nextWindowNumber++);
     }
@@ -249,6 +237,7 @@ QtObject {
         const tops = useKwin ? svc._kwinWindows : foreignTops;
         const nextRecords = [];
         const nextById = ({});
+        const oldRecords = WindowRecordIndex.indexWindowRecords(svc.records);
 
         for (let i = 0; i < tops.length; i++) {
             const source = tops[i];
@@ -270,7 +259,8 @@ QtObject {
                 maximized: !!source.maximized,
                 visible: source.visible === undefined ? true : !!source.visible
             } : source;
-            const old = _findOldRecord(toplevel, provider, handleId);
+            const old = useKwin ? oldRecords.kwin.get(handleId)
+                : oldRecords.foreign.get(toplevel);
             const identity = AppIdentityService.resolve(toplevel.appId);
             // A user-selected icon is part of the app presentation contract
             // and must win over every provider-derived value. Otherwise use

--- a/shell/desktop/modules/dock/test_wallpaper_palette.mjs
+++ b/shell/desktop/modules/dock/test_wallpaper_palette.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const wallpaper = readFileSync(new URL("WallpaperPaletteService.qml", import.meta.url), "utf8");
+const parser = wallpaper.slice(wallpaper.indexOf("    function _readWallpaperText("),
+    wallpaper.indexOf("    function refresh()"));
+const resolved = [];
+const context = vm.createContext({
+    preferredScreen: 1, configuredWallpaperUrl: "", wallpaperUrl: "",
+    _resolveWallpaperUrl: url => resolved.push(url), console: { warn() {} },
+});
+vm.runInContext(parser, context);
+const config = "[Containments][1]\nlastScreen=0\n"
+    + "[Containments][1][Wallpaper][org.kde.image][General]\nImage=file:///first.png\n"
+    + "[Containments][2]\nlastScreen=1\n"
+    + "[Containments][2][Wallpaper][org.kde.image][General]\nImage=file:///second.png\n";
+context._readWallpaperText(config);
+context._readWallpaperText(config);
+assert.deepEqual(resolved, ["file:///second.png"]);
+context._readWallpaperText(config.replace("second.png", "replacement.png"));
+assert.equal(resolved.at(-1), "file:///replacement.png");
+context.preferredScreen = 9;
+context._readWallpaperText(config);
+assert.equal(resolved.at(-1), "file:///first.png");
+context._readWallpaperText("");
+assert.equal(context.configuredWallpaperUrl, "");
+assert.equal(context.wallpaperUrl, "");
+assert.match(wallpaper, /interval: 3000/);
+assert.match(wallpaper, /function refresh\(\)\s*\{\s*_configFile\.reload\(\)/);
+assert.doesNotMatch(wallpaper, /wallpaper-palette-read|_refreshProcess/);
+console.log("wallpaper contracts: passed");

--- a/shell/desktop/modules/dock/test_window_record_index.mjs
+++ b/shell/desktop/modules/dock/test_window_record_index.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { indexWindowRecords } from "./WindowRecordIndex.mjs";
+
+const foreignTop = {};
+const records = [
+    { provider: "kwin", handleId: "__proto__", windowId: "first" },
+    { provider: "kwin", handleId: "__proto__", windowId: "duplicate" },
+    { provider: "foreign", toplevel: foreignTop, windowId: "foreign" },
+    { provider: "foreign", toplevel: {}, windowId: "other-object" },
+    { provider: "unknown", handleId: "ignored" },
+];
+const index = indexWindowRecords(records);
+assert.equal(index.kwin.get("__proto__"), records[0]);
+assert.equal(index.foreign.get(foreignTop), records[2]);
+assert.equal(index.foreign.get({}), undefined);
+assert.equal(index.kwin.get("ignored"), undefined);
+assert.equal(indexWindowRecords([]).kwin.size, 0);
+
+// Differential check against the previous strict-identity scan, including
+// reordered snapshots, missing IDs and distinct objects with the same fields.
+const tops = Array.from({ length: 100 }, () => ({}));
+const many = tops.flatMap((top, i) => [
+    { provider: "foreign", toplevel: top, windowId: `f${i}` },
+    { provider: "kwin", handleId: String(i), windowId: `k${i}` },
+]).reverse();
+const indexed = indexWindowRecords(many);
+for (let i = 0; i <= 100; i++) {
+    assert.equal(indexed.kwin.get(String(i)), many.find(record =>
+        record.provider === "kwin" && record.handleId === String(i)));
+    assert.equal(indexed.foreign.get(tops[i]), many.find(record =>
+        record.provider === "foreign" && record.toplevel === tops[i]));
+}
+// One record-key read per input, not one whole-list scan per incoming window.
+let keyReads = 0;
+indexWindowRecords(Array.from({ length: 1000 }, (_, i) => ({
+    provider: "kwin", get handleId() { keyReads++; return String(i); },
+})));
+assert.equal(keyReads, 1000);
+
+console.log("window record index: passed");

--- a/tests/static-work/run.mjs
+++ b/tests/static-work/run.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const directory = mkdtempSync(join(tmpdir(), "nextkde-static-work-"));
+try {
+    copyFileSync(new URL("shell.qml", import.meta.url), join(directory, "shell.qml"));
+    copyFileSync(new URL("../../shell/desktop/modules/dock/WindowRecordIndex.mjs", import.meta.url),
+        join(directory, "WindowRecordIndex.mjs"));
+    const result = spawnSync(process.argv[2] || "quickshell", ["-p", directory], {
+        encoding: "utf8", timeout: 10000,
+        env: { ...process.env, QT_QPA_PLATFORM: "offscreen", QT_QUICK_BACKEND: "software" },
+    });
+    const output = (result.stdout || "") + (result.stderr || "");
+    assert.equal(result.error, undefined, String(result.error));
+    assert.equal(result.status, 0, output);
+    assert.doesNotMatch(output, /STATIC_WORK_FAIL/);
+    assert.match(output, /STATIC_WORK_PASS/);
+    console.log("Quickshell offscreen: identity, reload and recovery passed");
+} finally {
+    rmSync(directory, { recursive: true, force: true });
+}

--- a/tests/static-work/shell.qml
+++ b/tests/static-work/shell.qml
@@ -1,0 +1,72 @@
+// Run with node run.mjs, which stages the module inside an isolated config.
+// This isolated fixture loads no desktop services and opens no windows.
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "WindowRecordIndex.mjs" as WindowRecordIndex
+
+QtObject {
+    id: root
+    property int stage: 0
+    property string fixturePath: Qt.resolvedUrl("WindowRecordIndex.mjs").toString().replace(/^file:\/\//, "")
+    property QtObject firstTop: QtObject {}
+    property QtObject secondTop: QtObject {}
+    property FileView reader: FileView {
+        preload: true
+        watchChanges: false
+        printErrors: false
+        onLoaded: {
+            if (!text().includes("indexWindowRecords")) {
+                console.error("STATIC_WORK_FAIL: fixture read")
+                Qt.quit()
+                return
+            }
+            if (root.stage === 0 || root.stage === 1) {
+                root.stage++
+                nextStep.start()
+            } else if (root.stage === 3) {
+                console.log("STATIC_WORK_PASS: QObject identity, reload, failed read and recovery")
+                Qt.quit()
+            }
+        }
+        onLoadFailed: {
+            if (root.stage !== 2) {
+                console.error("STATIC_WORK_FAIL: unexpected read failure")
+                Qt.quit()
+                return
+            }
+            root.stage = 3
+            nextStep.start()
+        }
+    }
+    property Timer nextStep: Timer {
+        interval: 1
+        onTriggered: {
+            if (root.stage === 1)
+                root.reader.reload()
+            else if (root.stage === 2)
+                root.reader.path = root.fixturePath + ".nonexistent-test-file"
+            else
+                root.reader.path = root.fixturePath
+        }
+    }
+    property Timer deadline: Timer {
+        interval: 5000
+        running: true
+        onTriggered: {
+            console.error("STATIC_WORK_FAIL: timeout")
+            Qt.quit()
+        }
+    }
+    Component.onCompleted: {
+        const first = { provider: "foreign", toplevel: firstTop }
+        const second = { provider: "foreign", toplevel: secondTop }
+        const index = WindowRecordIndex.indexWindowRecords([first, second])
+        if (index.foreign.get(firstTop) !== first || index.foreign.get(secondTop) !== second) {
+            console.error("STATIC_WORK_FAIL: QObject identity")
+            Qt.quit()
+            return
+        }
+        reader.path = fixturePath
+    }
+}


### PR DESCRIPTION
## 问题描述

窗口移动、缩放及日常桌面运行期间存在三类额外开销：完整事件 JSON 的日志序列化与刷新、旧窗口记录的重复线性扫描，以及每 3 秒启动一次壁纸配置读取进程。属于性能改进，不涉及闪烁问题修复。

## 触发场景

- 移动、缩放窗口时持续产生窗口快照。
- 窗口数量增加时，旧记录匹配开销呈平方增长。
- 桌面空闲时仍周期性启动 shell 读取壁纸配置。

## 优化原理与范围

1. 完整事件日志改为显式开启（KOS_PLATFORM_TRACE_EVENTS=1），保留 socket 事件分发。
2. 每轮快照建立旧记录索引，保留 provider、对象身份及首个匹配语义，将记录匹配降为线性规模。
3. 使用 FileView 读取壁纸配置，保留 3 秒重读周期及读取失败时保留配色的行为。

按三个优化点拆分 commit。不修改 shader、Glass、画质、Dock 交互或刷新周期。

## 验证

- 平台程序编译、平台契约测试通过。
- 新增 CTest 3/3 通过，覆盖索引、壁纸解析与隔离 Quickshell 读取恢复。
- Dock 自动隐藏、布局及桌面小组件测试通过，部署后验收通过。
- 现有视觉契约测试仍在未修改的 Wi-Fi 卡片断言处失败，不属于本次改动。