### PR TITLE
perf: 分离窗口位置变化与呈现更新

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ if(BUILD_TESTING)
                 ${CMAKE_CURRENT_SOURCE_DIR}/shared/qml/test_visual_contract.mjs
         )
         set_tests_properties(kos-ui.visual-contract PROPERTIES TIMEOUT 10)
+        add_test(NAME kos-shell.window-placement-updates
+            COMMAND ${KOS_NODE_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/shell/desktop/modules/dock/test_window_placement_updates.mjs
+        )
+        set_tests_properties(kos-shell.window-placement-updates PROPERTIES TIMEOUT 10)
     endif()
 endif()
 

--- a/shell/desktop/modules/bar/BarAutoHideController.qml
+++ b/shell/desktop/modules/bar/BarAutoHideController.qml
@@ -391,7 +391,7 @@ Item {
 
     Connections {
         target: WindowService
-        function onRevisionChanged() {
+        function onPlacementRevisionChanged() {
             if (ctl._recomputeConflict())
                 ctl._doEvaluate()
             else if (ctl.mode !== "always")

--- a/shell/desktop/modules/dock/DockAutoHideController.qml
+++ b/shell/desktop/modules/dock/DockAutoHideController.qml
@@ -411,11 +411,11 @@ Item {
     Connections {
         target: WindowService
         // Geographic/desktop changes to windows, or a just-completed first
-        // snapshot, all wake the conflict pass. A revision bump means a window
+        // snapshot, all wake the conflict pass. A placement bump means a window
         // moved/resized/appeared — the cached conflict must be recomputed, not
         // just re-evaluated against the stale value (otherwise a window that
         // arrives after boot never hides a smart dock).
-        function onRevisionChanged() {
+        function onPlacementRevisionChanged() {
             // Geometry snapshots are already throttled at the KWin boundary.
             // React to an actual collision edge immediately; waiting on the
             // generic 80ms debounce made reveal/hide lag behind the window.

--- a/shell/desktop/modules/dock/WindowService.qml
+++ b/shell/desktop/modules/dock/WindowService.qml
@@ -17,6 +17,9 @@ QtObject {
     readonly property int windowCount: windowModel.count
     property var records: []
     property int revision: 0
+    // Placement consumers must observe this counter, not recordsChanged.
+    // Pure geometry updates retain the presentation array and its objects.
+    property int placementRevision: 0
     property string activeWindowId: ""
 
     // Forwarded by the KWin input effect through this service's existing local
@@ -188,7 +191,7 @@ QtObject {
         return "window-" + (svc._nextWindowNumber++);
     }
 
-    function _recordsEqual(left, right) {
+    function _presentationEqual(left, right) {
         return left.windowId === right.windowId
             && left.provider === right.provider
             && left.handleId === right.handleId
@@ -203,11 +206,29 @@ QtObject {
             && !!left.toplevel.fullscreen === !!right.toplevel.fullscreen
             && !!left.onAllDesktops === !!right.onAllDesktops
             && left.desktopIds.length === right.desktopIds.length
-            && left.desktopIds.every((id, i) => id === right.desktopIds[i])
-            && !!left.isMaximized === !!right.isMaximized
+            && left.desktopIds.every((id, i) => id === right.desktopIds[i]);
+    }
+
+    function _placementEqual(left, right) {
+        return !!left.isMaximized === !!right.isMaximized
             && !!left.isVisible === !!right.isVisible
             && (left.screenName || "") === (right.screenName || "")
             && geometriesEqual(left.geometry, right.geometry);
+    }
+
+    function _updatePlacement(record, next) {
+        record.geometry = next.geometry;
+        record.screenName = next.screenName;
+        record.isMaximized = next.isMaximized;
+        record.isVisible = next.isVisible;
+        // KWin toplevels are plain snapshot objects; foreign toplevels are
+        // provider-owned QObjects and must never be written here.
+        if (record.provider === "kwin") {
+            record.toplevel.geometry = next.toplevel.geometry;
+            record.toplevel.outputName = next.toplevel.outputName;
+            record.toplevel.maximized = next.toplevel.maximized;
+            record.toplevel.visible = next.toplevel.visible;
+        }
     }
 
     // Null-safe geometry equality. A window that moves (or stops reporting
@@ -314,12 +335,16 @@ QtObject {
         }
 
         let changed = svc.records.length !== nextRecords.length;
-        if (!changed) {
+        let presentationChanged = changed;
+        if (!presentationChanged) {
             for (let i = 0; i < nextRecords.length; i++) {
-                if (!svc._recordsEqual(svc.records[i], nextRecords[i])) {
+                if (!svc._presentationEqual(svc.records[i], nextRecords[i])) {
+                    presentationChanged = true;
                     changed = true;
                     break;
                 }
+                if (!svc._placementEqual(svc.records[i], nextRecords[i]))
+                    changed = true;
             }
         }
         if (!changed)
@@ -328,6 +353,13 @@ QtObject {
         svc._hasRebuiltOnce = true;
         if (!useKwin)
             svc._foreignRebuiltOnce = true;
+
+        if (!presentationChanged) {
+            for (let i = 0; i < nextRecords.length; i++)
+                svc._updatePlacement(svc.records[i], nextRecords[i]);
+            svc.placementRevision++;
+            return;
+        }
 
         while (windowModel.count > tops.length)
             windowModel.remove(windowModel.count - 1);
@@ -377,6 +409,9 @@ QtObject {
         const active = nextRecords.find(record => record.toplevel.activated);
         svc.activeWindowId = active?.windowId ?? "";
         svc.revision++;
+        // Add/remove, minimization and desktop membership also affect
+        // collision eligibility, so presentation updates notify both lanes.
+        svc.placementRevision++;
     }
 
     // ── Virtual desktops (KWin D-Bus, via the bridge) ──

--- a/shell/desktop/modules/dock/test_window_placement_updates.mjs
+++ b/shell/desktop/modules/dock/test_window_placement_updates.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+// Execute the production QML functions, mocking only provider and ListModel.
+const source = readFileSync(new URL("WindowService.qml", import.meta.url), "utf8");
+// Also exercise the same update path after the independent indexing PR lands.
+const usesIndex = source.includes("WindowRecordIndex.indexWindowRecords");
+const WindowRecordIndex = usesIndex ? await import("./WindowRecordIndex.mjs") : null;
+const names = ["_newWindowId", "_presentationEqual", "_placementEqual",
+    "_updatePlacement", "geometriesEqual", "_rebuild"];
+if (!usesIndex) names.push("_findOldRecord");
+const functions = names.map(name => {
+    const match = source.match(new RegExp(`^    function ${name}\\([^]*?^    }`, "m"));
+    assert.ok(match, name);
+    return match[0];
+}).join("\n");
+let writes = 0;
+const rows = [];
+const windowModel = {
+    get count() { return rows.length; },
+    get: i => rows[i],
+    append: row => { writes++; rows.push(row); },
+    remove: i => { writes++; rows.splice(i, 1); },
+    setProperty: (i, key, value) => { writes++; rows[i][key] = value; },
+};
+const svc = { records: [], _kwinWindows: [], _nextWindowNumber: 1,
+    revision: 0, placementRevision: 0, _recordsById: {} };
+const context = vm.createContext({ svc, windowModel, WindowRecordIndex,
+    _collectToplevels: () => [],
+    AppIdentityService: { resolve: id => ({ desktopId: id, rawAppId: id, iconSource: id }) },
+});
+vm.runInContext(functions, context);
+for (const name of names) svc[name] = context[name];
+const window = id => ({ id, appId: id, title: id, desktops: ["desktop-1"],
+    geometry: { x: 0, y: 0, width: 100, height: 100 }, visible: true });
+svc._kwinWindows = [window("one"), window("two")];
+svc._rebuild();
+assert.equal(svc.revision, 1);
+assert.equal(svc.placementRevision, 1);
+const records = svc.records;
+const record = records[0];
+const byId = svc._recordsById;
+writes = 0;
+// All placement-only fields, including geometry loss and restoration.
+for (const patch of [
+    { geometry: { x: 500, y: 20, width: 90, height: 80 } },
+    { outputName: "DP-2" }, { maximized: true }, { visible: false },
+    { geometry: null }, { geometry: { x: 0, y: 0, width: 100, height: 100 } },
+]) {
+    svc._kwinWindows[0] = { ...svc._kwinWindows[0], ...patch };
+    const previous = svc.placementRevision;
+    svc._rebuild();
+    assert.equal(svc.placementRevision, previous + 1);
+    assert.equal(svc.revision, 1);
+    assert.equal(svc.records, records);
+    assert.equal(svc.records[0], record);
+    assert.equal(svc._recordsById, byId);
+    assert.equal(writes, 0);
+}
+assert.equal(record.geometry.x, 0);
+assert.equal(record.screenName, "DP-2");
+assert.equal(record.toplevel.outputName, "DP-2");
+assert.equal(record.isVisible, false);
+const unchanged = svc.placementRevision;
+svc._rebuild();
+assert.equal(svc.placementRevision, unchanged);
+// Each presentation field must still wake both presentation and collision.
+for (const patch of [{ title: "renamed" }, { activated: true }, { minimized: true },
+    { fullscreen: true }, { urgent: true }, { desktops: ["desktop-2"] },
+    { onAllDesktops: true }, { appId: "new-app" }, { iconPath: "/new.png" }, { pid: 123 }]) {
+    const revision = svc.revision, placement = svc.placementRevision;
+    svc._kwinWindows[0] = { ...svc._kwinWindows[0], ...patch };
+    svc._rebuild();
+    assert.equal(svc.revision, revision + 1);
+    assert.equal(svc.placementRevision, placement + 1);
+}
+// Earlier placement differences must not hide a later presentation change.
+svc._kwinWindows[0] = { ...svc._kwinWindows[0], geometry: null };
+svc._kwinWindows[1] = { ...svc._kwinWindows[1], title: "second changed" };
+let revision = svc.revision;
+svc._rebuild();
+assert.equal(svc.revision, revision + 1);
+assert.equal(rows[1].title, "second changed");
+const firstId = svc.records[0].windowId;
+svc._kwinWindows.reverse();
+svc._rebuild();
+assert.equal(svc.records[1].windowId, firstId);
+svc._kwinWindows = [];
+svc._rebuild();
+assert.equal(rows.length, 0);
+assert.equal(svc.activeWindowId, "");
+// Provider-owned foreign objects are read-only; placement updates cannot
+// assign to them. Their normalized record still receives the new placement.
+const foreign = { provider: "foreign", toplevel: Object.freeze({ visible: true }) };
+svc._updatePlacement(foreign, { geometry: null, screenName: "", isMaximized: false,
+    isVisible: false, toplevel: { visible: false } });
+assert.equal(foreign.toplevel.visible, true);
+assert.equal(foreign.isVisible, false);
+for (const file of ["DockAutoHideController.qml", "../bar/BarAutoHideController.qml"]) {
+    const controller = readFileSync(new URL(file, import.meta.url), "utf8");
+    assert.match(controller, /function onPlacementRevisionChanged\(\)/);
+    assert.match(controller, /function onCurrentDesktopIdChanged\(\)/);
+}
+console.log("window placement updates: passed");


### PR DESCRIPTION
## 问题描述

窗口移动、缩放时，位置变化会触发完整呈现更新，包括替换窗口记录数组、遍历 ListModel 和通知 Dock、搜索等消费者。这些消费者不需要位置数据，却承担了重复计算。属于性能优化，不涉及闪烁修复。

## 触发场景

打开多个窗口并连续移动、缩放其中一个窗口；窗口标题、应用归属和焦点不变时，仍会触发呈现更新。

## 优化原理与范围

- 分离呈现比较与位置比较，新增 placementRevision。
- 纯位置变化原地更新记录，只通知 Dock 和顶部栏避让逻辑，不替换呈现数组或写入 ListModel。
- 标题、焦点、窗口增删、最小化、全屏及虚拟桌面归属变化保留原更新路径，并通知避让逻辑。

不改变画质、Glass、Dock 交互或快照频率。本 PR 基于 main 独立提交，不包含尚未合并的 #33。

## 验证

新增测试覆盖纯位置更新零模型写入、记录身份保持、混合变化、窗口重排及关闭；Dock 自动隐藏和布局测试通过。与上一轮优化共同部署后验收通过，独立 main 基线测试也通过。