### PR TITLE
perf: 按日期与分钟更新时钟派生内容

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,21 @@ if(BUILD_TESTING)
                 ${CMAKE_CURRENT_SOURCE_DIR}/shared/qml/test_visual_contract.mjs
         )
         set_tests_properties(kos-ui.visual-contract PROPERTIES TIMEOUT 10)
+        add_test(NAME kos-shell.date-buckets
+            COMMAND ${KOS_NODE_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/shell/desktop/modules/common/test_date_buckets.mjs
+        )
+        set_tests_properties(kos-shell.date-buckets PROPERTIES TIMEOUT 10)
+        find_program(KOS_QMLTESTRUNNER_EXECUTABLE NAMES qmltestrunner
+            HINTS /usr/lib/qt6/bin)
+        if(KOS_QMLTESTRUNNER_EXECUTABLE)
+            add_test(NAME kos-shell.date-projection
+                COMMAND ${KOS_NODE_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/date-projection/run.mjs
+                    ${KOS_QMLTESTRUNNER_EXECUTABLE}
+            )
+            set_tests_properties(kos-shell.date-projection PROPERTIES TIMEOUT 15)
+        endif()
     endif()
 endif()
 

--- a/shell/desktop/modules/common/DateBuckets.mjs
+++ b/shell/desktop/modules/common/DateBuckets.mjs
@@ -1,0 +1,10 @@
+// Snapshot local calendar fields as values: getters on an old Date would use
+// the NEW timezone after a system timezone change, hiding the transition.
+export function dayKey(date) {
+    return [date.getFullYear(), date.getMonth(), date.getDate(),
+        date.getTimezoneOffset()].join(":");
+}
+
+export function minuteKey(date) {
+    return Math.floor(date.getTime() / 60000) + ":" + date.getTimezoneOffset();
+}

--- a/shell/desktop/modules/common/DateProjection.qml
+++ b/shell/desktop/modules/common/DateProjection.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import "DateBuckets.mjs" as DateBuckets
+
+// No extra timer: consume the existing clock and only notify consumers when
+// their calendar/minute bucket changes, including clock jumps and DST.
+QtObject {
+    id: projection
+    property date sourceDate: new Date()
+    readonly property date dayDate: _dayDate
+    readonly property date minuteDate: _minuteDate
+    property date _dayDate: new Date(0)
+    property date _minuteDate: new Date(0)
+    property string _dayKey: ""
+    property string _minuteKey: ""
+
+    function refresh() {
+        const nextDay = DateBuckets.dayKey(sourceDate)
+        const nextMinute = DateBuckets.minuteKey(sourceDate)
+        if (nextDay !== _dayKey) {
+            _dayKey = nextDay
+            _dayDate = sourceDate
+        }
+        if (nextMinute !== _minuteKey) {
+            _minuteKey = nextMinute
+            _minuteDate = sourceDate
+        }
+    }
+
+    onSourceDateChanged: refresh()
+    Component.onCompleted: refresh()
+}

--- a/shell/desktop/modules/common/qmldir
+++ b/shell/desktop/modules/common/qmldir
@@ -1,4 +1,5 @@
 module qs.desktop.modules.common
+DateProjection 1.0 DateProjection.qml
 GlassText 1.0 GlassText.qml
 GlassSlider 1.0 GlassSlider.qml
 GlassToggle 1.0 GlassToggle.qml

--- a/shell/desktop/modules/common/test_date_buckets.mjs
+++ b/shell/desktop/modules/common/test_date_buckets.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { dayKey, minuteKey } from "./DateBuckets.mjs";
+
+const base = new Date(2026, 8, 8, 12, 30, 0);
+for (let second = 1; second < 60; second++) {
+    const next = new Date(2026, 8, 8, 12, 30, second);
+    assert.equal(dayKey(base), dayKey(next));
+    assert.equal(minuteKey(base), minuteKey(next));
+}
+for (const next of [new Date(2026, 8, 8, 12, 31), new Date(2026, 8, 8, 13, 30),
+    new Date(2026, 8, 8, 11, 30)]) {
+    assert.equal(dayKey(base), dayKey(next));
+    assert.notEqual(minuteKey(base), minuteKey(next));
+}
+for (const next of [new Date(2026, 8, 9, 12, 30), new Date(2026, 9, 8, 12, 30),
+    new Date(2027, 8, 8, 12, 30)]) {
+    assert.notEqual(dayKey(base), dayKey(next));
+    assert.notEqual(minuteKey(base), minuteKey(next));
+}
+// Snapshot keys must notice an offset change even at an unchanged instant.
+const before = dayKey(base), beforeMinute = minuteKey(base);
+const changedZone = new Date(base);
+changedZone.getTimezoneOffset = () => base.getTimezoneOffset() + 60;
+assert.notEqual(dayKey(changedZone), before);
+assert.notEqual(minuteKey(changedZone), beforeMinute);
+// Both occurrences of 01:30 during US fall-back must update the minute lane.
+assert.notEqual(minuteKey(new Date("2026-11-01T01:30:00-04:00")),
+    minuteKey(new Date("2026-11-01T01:30:00-05:00")));
+assert.notEqual(dayKey(new Date(2026, 11, 31, 23, 59, 59)),
+    dayKey(new Date(2027, 0, 1, 0, 0, 0)));
+console.log("date buckets: passed");

--- a/shell/desktop/modules/deskcenter/DeskCenterWindow.qml
+++ b/shell/desktop/modules/deskcenter/DeskCenterWindow.qml
@@ -218,6 +218,11 @@ PanelWindow {
         precision: SystemClock.Seconds
     }
 
+    DateProjection {
+        id: calendarClock
+        sourceDate: clock.date
+    }
+
     // Global desktop background click handler: catches clicks on any empty area of the desktop
     // (left widget columns, margins, empty spaces between widgets, and background wallpaper).
     MouseArea {
@@ -589,14 +594,14 @@ PanelWindow {
                 }
                 Text {
                     anchors { horizontalCenter: parent.horizontalCenter; top: parent.top; topMargin: 5 }
-                    text: Qt.formatDateTime(clock.date, "yyyy年M月")
+                    text: Qt.formatDateTime(calendarClock.dayDate, "yyyy年M月")
                     color: "white"
                     font { pixelSize: 11; weight: Font.Bold }
                 }
-                Text { anchors.centerIn: parent; anchors.verticalCenterOffset: 10; text: Qt.formatDateTime(clock.date, "d日 dddd"); color: "#111118"; font { pixelSize: 24; weight: Font.Bold } }
+                Text { anchors.centerIn: parent; anchors.verticalCenterOffset: 10; text: Qt.formatDateTime(calendarClock.dayDate, "d日 dddd"); color: "#111118"; font { pixelSize: 24; weight: Font.Bold } }
                 Text {
                     anchors { horizontalCenter: parent.horizontalCenter; bottom: parent.bottom; bottomMargin: 10 }
-                    text: Qt.formatDateTime(clock.date, "dddd")
+                    text: Qt.formatDateTime(calendarClock.dayDate, "dddd")
                     color: "#3c3c43"
                     font.pixelSize: 9
                 }
@@ -1802,8 +1807,8 @@ PanelWindow {
 	                id: calendarContent
 	                anchors.fill: parent
 	                readonly property bool glassMode: IconAppearanceService.mode !== "color"
-                readonly property int year: clock.date.getFullYear()
-                readonly property int month: clock.date.getMonth()
+                readonly property int year: calendarClock.dayDate.getFullYear()
+                readonly property int month: calendarClock.dayDate.getMonth()
                 // Monday-first month layout: 星期一 is the first column and
                 // 星期日 is the final column, matching the requested reading order.
                 readonly property int firstWeekday: (new Date(year, month, 1).getDay() + 6) % 7
@@ -1868,20 +1873,20 @@ PanelWindow {
 
                 Text {
                     anchors.centerIn: calendarHeader
-                    text: Qt.formatDateTime(clock.date, "yyyy年M月")
+                    text: Qt.formatDateTime(calendarClock.dayDate, "yyyy年M月")
                     horizontalAlignment: Text.AlignHCenter
                     color: "white"
                     font { pixelSize: 15; weight: Font.Bold }
                 }
                 Text {
                     anchors { left: parent.left; top: parent.top; leftMargin: 15; topMargin: calendarContent.headerHeight + 7 }
-                    text: Qt.formatDateTime(clock.date, "d日")
+                    text: Qt.formatDateTime(calendarClock.dayDate, "d日")
 	                    color: calendarContent.glassMode ? IconAppearanceService.glassContentColor() : "#15151a"
                     font { family: "SF Pro Display"; pixelSize: 32; weight: Font.DemiBold }
                 }
                 Text {
                     anchors { left: parent.left; top: parent.top; leftMargin: 16; topMargin: calendarContent.headerHeight + 46 }
-                    text: Qt.formatDateTime(clock.date, "ddd") + " · " + root.lunarDate(clock.date)
+                    text: Qt.formatDateTime(calendarClock.dayDate, "ddd") + " · " + root.lunarDate(calendarClock.dayDate)
 	                    color: calendarContent.glassMode ? IconAppearanceService.glassContentColor(0.74) : "#4d4d55"
                     font { pixelSize: 10; weight: Font.DemiBold }
                 }
@@ -1939,8 +1944,8 @@ PanelWindow {
                                 width: parent.width / 7
                                 height: parent.height / calendarContent.weekCount
                                 readonly property int day: index - calendarContent.firstWeekday + 1
-                                readonly property bool today: day === clock.date.getDate()
-                                    && calendarContent.month === clock.date.getMonth()
+                                readonly property bool today: day === calendarClock.dayDate.getDate()
+                                    && calendarContent.month === calendarClock.dayDate.getMonth()
                                 Rectangle {
                                     anchors.centerIn: parent
                                     width: 16

--- a/shell/desktop/modules/dock/DockClockWidget.qml
+++ b/shell/desktop/modules/dock/DockClockWidget.qml
@@ -25,6 +25,11 @@ Item {
         precision: SystemClock.Seconds
     }
 
+    DateProjection {
+        id: calendarClock
+        sourceDate: clock.date
+    }
+
     function shortWeekday(date) {
         return ["周日", "周一", "周二", "周三", "周四", "周五", "周六"][date.getDay()]
     }
@@ -223,8 +228,8 @@ Item {
             Text {
                 width: parent.width
                 height: Math.round(widget.iconSize * 0.27)
-                text: Qt.formatDateTime(clock.date, "yyyy年M月d日")
-                    + " " + widget.shortWeekday(clock.date)
+                text: Qt.formatDateTime(calendarClock.dayDate, "yyyy年M月d日")
+                    + " " + widget.shortWeekday(calendarClock.dayDate)
                 color: ThemeService.foregroundColor
                 opacity: 0.82
                 horizontalAlignment: Text.AlignHCenter
@@ -274,7 +279,7 @@ Item {
             glyphColor: "white"
         }
         Text {
-            text: Qt.formatDateTime(clock.date, "HH:mm")
+            text: Qt.formatDateTime(calendarClock.minuteDate, "HH:mm")
             color: "white"
             anchors.verticalCenter: parent.verticalCenter
             font {

--- a/tests/date-projection/run.mjs
+++ b/tests/date-projection/run.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const directory = mkdtempSync(join(tmpdir(), "nextkde-date-projection-"));
+try {
+    copyFileSync(new URL("tst_projection.qml", import.meta.url), join(directory, "tst_projection.qml"));
+    for (const name of ["DateProjection.qml", "DateBuckets.mjs"])
+        copyFileSync(new URL(`../../shell/desktop/modules/common/${name}`, import.meta.url), join(directory, name));
+    const result = spawnSync(process.argv[2] || "qmltestrunner", ["-input", directory], {
+        encoding: "utf8", timeout: 10000,
+        env: { ...process.env, QT_QPA_PLATFORM: "offscreen", QT_QUICK_BACKEND: "software" },
+    });
+    const output = (result.stdout || "") + (result.stderr || "");
+    assert.equal(result.error, undefined, String(result.error));
+    assert.equal(result.status, 0, output);
+    assert.match(output, /0 failed/);
+    console.log(output.trim());
+} finally {
+    rmSync(directory, { recursive: true, force: true });
+}

--- a/tests/date-projection/tst_projection.qml
+++ b/tests/date-projection/tst_projection.qml
@@ -1,0 +1,32 @@
+import QtQuick
+import QtTest
+
+TestCase {
+    name: "DateProjection"
+    DateProjection { id: projection; sourceDate: new Date(2026, 8, 8, 12, 30, 0) }
+    SignalSpy { id: daySpy; target: projection; signalName: "dayDateChanged" }
+    SignalSpy { id: minuteSpy; target: projection; signalName: "minuteDateChanged" }
+
+    function test_notifications() {
+        projection.sourceDate = new Date(2026, 8, 8, 12, 30, 0)
+        daySpy.clear()
+        minuteSpy.clear()
+        for (let second = 1; second < 60; second++)
+            projection.sourceDate = new Date(2026, 8, 8, 12, 30, second)
+        compare(daySpy.count, 0)
+        compare(minuteSpy.count, 0)
+        projection.sourceDate = new Date(2026, 8, 8, 12, 31, 0)
+        compare(daySpy.count, 0)
+        compare(minuteSpy.count, 1)
+        projection.sourceDate = new Date(2026, 8, 8, 13, 31, 0)
+        compare(minuteSpy.count, 2)
+        projection.sourceDate = new Date(2027, 8, 8, 13, 31, 0)
+        compare(daySpy.count, 1)
+        compare(minuteSpy.count, 3)
+        compare(projection.dayDate.getFullYear(), 2027)
+        // A backwards clock adjustment also updates the projections.
+        projection.sourceDate = new Date(2026, 8, 8, 12, 30, 0)
+        compare(daySpy.count, 2)
+        compare(minuteSpy.count, 4)
+    }
+}


### PR DESCRIPTION
## 问题描述

桌面时钟的秒级更新同时触发日期文本、农历与日历格子重算；Dock 的日期和仅显示小时、分钟的时间也跟随每秒更新，产生不必要的持续开销。

## 触发场景

显示桌面时钟、日历或 Dock 时钟，日期和分钟未变化时，相关绑定仍被秒级时钟唤醒。

## 优化原理与范围

- 新增 DateProjection，复用现有时钟，不增加定时器。
- 日期内容仅在本地日期或时区偏移变化时更新；简短时间按分钟更新。
- 使用完整日期、分钟时间戳及偏移判断，处理跨年、校时和夏令时边界。
- 秒针、带秒时间、倒计时及点击打开日历的当前日期逻辑保持不变。

仅调整更新粒度，不修改视觉效果、Glass 或交互。不包含 #33、#34 的改动。

## 验证

日期分组与隔离 Qt 通知测试通过，覆盖连续秒级更新、跨分钟、跨小时、跨年和向后校时；分组测试在不同时区下通过。与前两轮优化共同部署后验收通过，独立 main 基线上的本轮测试也通过。