### PR TITLE
feat(control-center): implement native submenus, per-app audio mixer, night light tile, and bar tray alignment

### DIFF
--- a/platform/src/daemon/PlatformServer.cpp
+++ b/platform/src/daemon/PlatformServer.cpp
@@ -2087,14 +2087,15 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
                     QStringLiteral("设置模块不受支持"), false);
             return true;
         }
-        const QString systemsettings = QStandardPaths::findExecutable(
-            QStringLiteral("systemsettings"));
-        if (systemsettings.isEmpty()) {
+        const QString kcmshell = QStandardPaths::findExecutable(QStringLiteral("kcmshell6"));
+        const QString systemsettings = QStandardPaths::findExecutable(QStringLiteral("systemsettings"));
+        const QString executable = !kcmshell.isEmpty() ? kcmshell : systemsettings;
+        if (executable.isEmpty()) {
             respond(socket, request, false, {}, QStringLiteral("settings-unavailable"),
                     QStringLiteral("KDE 系统设置不可用"), false);
             return true;
         }
-        const bool started = QProcess::startDetached(systemsettings, {module});
+        const bool started = QProcess::startDetached(executable, {module});
         respond(socket, request, started, {{QStringLiteral("started"), started}});
         return true;
     }
@@ -2107,11 +2108,22 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
         const bool enabled = nightLight.property("enabled").toBool();
         const bool running = nightLight.property("running").toBool();
         const bool inhibited = nightLight.property("inhibited").toBool();
+        const uint mode = nightLight.property("mode").toUInt();
+        const uint targetTemp = nightLight.property("targetTemperature").toUInt();
+        const uint currentTemp = nightLight.property("currentTemperature").toUInt();
+
+        // Screen is in warm/eye-comfort mode if running, not inhibited, and either mode is Constant (0)
+        // or temperature target is warm (< 6000K)
+        const bool isWarm = running && !inhibited && (mode == 0 || targetTemp < 6000 || currentTemp < 6000);
+
         QJsonObject result{
             {QStringLiteral("available"), available},
             {QStringLiteral("enabled"), enabled},
-            {QStringLiteral("running"), running},
-            {QStringLiteral("inhibited"), inhibited}
+            {QStringLiteral("running"), isWarm},
+            {QStringLiteral("inhibited"), inhibited},
+            {QStringLiteral("mode"), static_cast<int>(mode)},
+            {QStringLiteral("targetTemperature"), static_cast<int>(targetTemp)},
+            {QStringLiteral("currentTemperature"), static_cast<int>(currentTemp)}
         };
         respond(socket, request, true, result);
         return true;
@@ -2122,36 +2134,59 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
                                   QStringLiteral("org.kde.KWin.NightLight"),
                                   QDBusConnection::sessionBus());
         const bool available = nightLight.property("available").toBool();
-        const bool enabled = nightLight.property("enabled").toBool();
+        const bool running = nightLight.property("running").toBool();
+        const bool inhibited = nightLight.property("inhibited").toBool();
+        const uint mode = nightLight.property("mode").toUInt();
+        const uint targetTemp = nightLight.property("targetTemperature").toUInt();
+        const uint currentTemp = nightLight.property("currentTemperature").toUInt();
 
-        if (!enabled) {
-            const QString kwriteconfig = QStandardPaths::findExecutable(QStringLiteral("kwriteconfig6"));
-            if (!kwriteconfig.isEmpty()) {
+        const bool currentlyWarm = running && !inhibited && (mode == 0 || targetTemp < 6000 || currentTemp < 6000);
+        const bool wantWarm = !currentlyWarm;
+
+        const QString kwriteconfig = QStandardPaths::findExecutable(QStringLiteral("kwriteconfig6"));
+        if (!kwriteconfig.isEmpty()) {
+            if (wantWarm) {
+                // Instantly switch to warm temperature by setting Mode=Constant with --notify
                 QProcess::execute(kwriteconfig, {QStringLiteral("--file"), QStringLiteral("kwinrc"),
                                                  QStringLiteral("--group"), QStringLiteral("NightColor"),
                                                  QStringLiteral("--key"), QStringLiteral("Active"),
-                                                 QStringLiteral("true")});
+                                                 QStringLiteral("--type"), QStringLiteral("bool"),
+                                                 QStringLiteral("--notify"), QStringLiteral("true")});
+                QProcess::execute(kwriteconfig, {QStringLiteral("--file"), QStringLiteral("kwinrc"),
+                                                 QStringLiteral("--group"), QStringLiteral("NightColor"),
+                                                 QStringLiteral("--key"), QStringLiteral("Mode"),
+                                                 QStringLiteral("--notify"), QStringLiteral("Constant")});
+                if (inhibited) {
+                    QDBusInterface accel(QStringLiteral("org.kde.kglobalaccel"),
+                                         QStringLiteral("/component/kwin"),
+                                         QStringLiteral("org.kde.kglobalaccel.Component"),
+                                         QDBusConnection::sessionBus());
+                    accel.call(QStringLiteral("invokeShortcut"), QStringLiteral("Toggle Night Color"));
+                }
+            } else {
+                // Switch back to neutral/daylight schedule by restoring Mode=DarkLight with --notify
+                QProcess::execute(kwriteconfig, {QStringLiteral("--file"), QStringLiteral("kwinrc"),
+                                                 QStringLiteral("--group"), QStringLiteral("NightColor"),
+                                                 QStringLiteral("--key"), QStringLiteral("Mode"),
+                                                 QStringLiteral("--notify"), QStringLiteral("DarkLight")});
+                // If the scheduled temperature is still warm (e.g. night time), also inhibit
+                // so the screen returns to neutral (6500K) immediately.
+                const uint recheckTarget = nightLight.property("targetTemperature").toUInt();
+                if (recheckTarget < 6000 && !inhibited) {
+                    QDBusInterface accel(QStringLiteral("org.kde.kglobalaccel"),
+                                         QStringLiteral("/component/kwin"),
+                                         QStringLiteral("org.kde.kglobalaccel.Component"),
+                                         QDBusConnection::sessionBus());
+                    accel.call(QStringLiteral("invokeShortcut"), QStringLiteral("Toggle Night Color"));
+                }
             }
-            QDBusInterface kwin(QStringLiteral("org.kde.KWin"),
-                                QStringLiteral("/KWin"),
-                                QStringLiteral("org.kde.KWin"),
-                                QDBusConnection::sessionBus());
-            kwin.call(QStringLiteral("reconfigure"));
-        } else {
-            QDBusInterface accel(QStringLiteral("org.kde.kglobalaccel"),
-                                 QStringLiteral("/component/kwin"),
-                                 QStringLiteral("org.kde.kglobalaccel.Component"),
-                                 QDBusConnection::sessionBus());
-            accel.call(QStringLiteral("invokeShortcut"), QStringLiteral("Toggle Night Color"));
         }
 
-        const bool newRunning = nightLight.property("running").toBool();
-        const bool newInhibited = nightLight.property("inhibited").toBool();
         QJsonObject result{
             {QStringLiteral("available"), available},
-            {QStringLiteral("enabled"), nightLight.property("enabled").toBool()},
-            {QStringLiteral("running"), newRunning},
-            {QStringLiteral("inhibited"), newInhibited}
+            {QStringLiteral("enabled"), true},
+            {QStringLiteral("running"), wantWarm},
+            {QStringLiteral("inhibited"), wantWarm ? false : true}
         };
         respond(socket, request, true, result);
         return true;

--- a/platform/src/daemon/PlatformServer.cpp
+++ b/platform/src/daemon/PlatformServer.cpp
@@ -2069,11 +2069,19 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
     const QString op = operation(request);
     const QJsonObject payload = request.value(QStringLiteral("payload")).toObject();
     if (op == QStringLiteral("settings.open")) {
-        const QString module = payload.value(QStringLiteral("module")).toString();
+        QString module = payload.value(QStringLiteral("module")).toString();
+        if (module == QStringLiteral("kcm_nightcolor")) {
+            module = QStringLiteral("kcm_nightlight");
+        }
         static const QSet<QString> allowedModules{
             QStringLiteral("kcm_bluetooth"),
             QStringLiteral("kcm_keys"),
-            QStringLiteral("kcm_networkmanagement")};
+            QStringLiteral("kcm_networkmanagement"),
+            QStringLiteral("kcm_kscreen"),
+            QStringLiteral("kcm_pulseaudio"),
+            QStringLiteral("kcm_nightlight"),
+            QStringLiteral("kcm_notifications"),
+            QStringLiteral("kcm_soundtheme")};
         if (!allowedModules.contains(module)) {
             respond(socket, request, false, {}, QStringLiteral("invalid-settings-module"),
                     QStringLiteral("设置模块不受支持"), false);
@@ -2086,7 +2094,66 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
                     QStringLiteral("KDE 系统设置不可用"), false);
             return true;
         }
-        runCommand(socket, request, systemsettings, {module});
+        const bool started = QProcess::startDetached(systemsettings, {module});
+        respond(socket, request, started, {{QStringLiteral("started"), started}});
+        return true;
+    }
+    if (op == QStringLiteral("nightlight.get")) {
+        QDBusInterface nightLight(QStringLiteral("org.kde.KWin"),
+                                  QStringLiteral("/org/kde/KWin/NightLight"),
+                                  QStringLiteral("org.kde.KWin.NightLight"),
+                                  QDBusConnection::sessionBus());
+        const bool available = nightLight.property("available").toBool();
+        const bool enabled = nightLight.property("enabled").toBool();
+        const bool running = nightLight.property("running").toBool();
+        const bool inhibited = nightLight.property("inhibited").toBool();
+        QJsonObject result{
+            {QStringLiteral("available"), available},
+            {QStringLiteral("enabled"), enabled},
+            {QStringLiteral("running"), running},
+            {QStringLiteral("inhibited"), inhibited}
+        };
+        respond(socket, request, true, result);
+        return true;
+    }
+    if (op == QStringLiteral("nightlight.toggle")) {
+        QDBusInterface nightLight(QStringLiteral("org.kde.KWin"),
+                                  QStringLiteral("/org/kde/KWin/NightLight"),
+                                  QStringLiteral("org.kde.KWin.NightLight"),
+                                  QDBusConnection::sessionBus());
+        const bool available = nightLight.property("available").toBool();
+        const bool enabled = nightLight.property("enabled").toBool();
+
+        if (!enabled) {
+            const QString kwriteconfig = QStandardPaths::findExecutable(QStringLiteral("kwriteconfig6"));
+            if (!kwriteconfig.isEmpty()) {
+                QProcess::execute(kwriteconfig, {QStringLiteral("--file"), QStringLiteral("kwinrc"),
+                                                 QStringLiteral("--group"), QStringLiteral("NightColor"),
+                                                 QStringLiteral("--key"), QStringLiteral("Active"),
+                                                 QStringLiteral("true")});
+            }
+            QDBusInterface kwin(QStringLiteral("org.kde.KWin"),
+                                QStringLiteral("/KWin"),
+                                QStringLiteral("org.kde.KWin"),
+                                QDBusConnection::sessionBus());
+            kwin.call(QStringLiteral("reconfigure"));
+        } else {
+            QDBusInterface accel(QStringLiteral("org.kde.kglobalaccel"),
+                                 QStringLiteral("/component/kwin"),
+                                 QStringLiteral("org.kde.kglobalaccel.Component"),
+                                 QDBusConnection::sessionBus());
+            accel.call(QStringLiteral("invokeShortcut"), QStringLiteral("Toggle Night Color"));
+        }
+
+        const bool newRunning = nightLight.property("running").toBool();
+        const bool newInhibited = nightLight.property("inhibited").toBool();
+        QJsonObject result{
+            {QStringLiteral("available"), available},
+            {QStringLiteral("enabled"), nightLight.property("enabled").toBool()},
+            {QStringLiteral("running"), newRunning},
+            {QStringLiteral("inhibited"), newInhibited}
+        };
+        respond(socket, request, true, result);
         return true;
     }
     if (op == QStringLiteral("shortcuts.apply")) {

--- a/platform/src/daemon/PlatformServer.cpp
+++ b/platform/src/daemon/PlatformServer.cpp
@@ -396,6 +396,49 @@ QJsonObject parseAudio(const QByteArray &output, int exitCode)
                        {QStringLiteral("muted"), text.contains(QStringLiteral("[MUTED]"))}};
 }
 
+QJsonObject parseAudioApplications(const QByteArray &output, int exitCode)
+{
+    if (exitCode != 0)
+        return QJsonObject{{QStringLiteral("available"), false}};
+
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(output, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isArray())
+        return QJsonObject{{QStringLiteral("available"), false}};
+
+    QJsonArray applications;
+    for (const QJsonValue &value : document.array()) {
+        const QJsonObject stream = value.toObject();
+        const QJsonObject properties = stream.value(QStringLiteral("properties")).toObject();
+        QString name = properties.value(QStringLiteral("application.name")).toString().trimmed();
+        if (name.isEmpty())
+            name = properties.value(QStringLiteral("media.name")).toString().trimmed();
+        if (name.isEmpty())
+            name = QStringLiteral("音频应用");
+
+        const QJsonObject volume = stream.value(QStringLiteral("volume")).toObject();
+        double volumePercent = 0.0;
+        for (auto it = volume.constBegin(); it != volume.constEnd(); ++it) {
+            const QJsonObject channel = it.value().toObject();
+            const QString percent = channel.value(QStringLiteral("value_percent")).toString();
+            if (!percent.isEmpty()) {
+                volumePercent = percent.left(percent.indexOf(QLatin1Char('%'))).toDouble();
+                break;
+            }
+        }
+
+        applications.append(QJsonObject{
+            {QStringLiteral("id"), stream.value(QStringLiteral("index")).toInt()},
+            {QStringLiteral("name"), name},
+            {QStringLiteral("percent"), qBound(0, qRound(volumePercent), 150)},
+            {QStringLiteral("muted"), stream.value(QStringLiteral("mute")).toBool()},
+            {QStringLiteral("icon"), properties.value(QStringLiteral("application.icon-name")).toString()}
+        });
+    }
+    return QJsonObject{{QStringLiteral("available"), true},
+                       {QStringLiteral("applications"), applications}};
+}
+
 QJsonObject parseNetworkScan(const QByteArray &output, int exitCode)
 {
     QJsonArray networks;
@@ -2241,6 +2284,55 @@ bool PlatformServer::handleSystemOperation(QLocalSocket *socket, const QJsonObje
     if (op == QStringLiteral("audio.set-mute")) {
         runCommand(socket, request, QStringLiteral("wpctl"),
                    {QStringLiteral("set-mute"), QStringLiteral("@DEFAULT_AUDIO_SINK@"),
+                    payload.value(QStringLiteral("muted")).toBool() ? QStringLiteral("1") : QStringLiteral("0")});
+        return true;
+    }
+    if (op == QStringLiteral("audio.applications")) {
+        const QString pactl = QStandardPaths::findExecutable(QStringLiteral("pactl"));
+        if (pactl.isEmpty()) {
+            respond(socket, request, false, {}, QStringLiteral("audio-unavailable"),
+                    QStringLiteral("音频服务不可用"), true);
+            return true;
+        }
+        runCommand(socket, request, pactl,
+                   {QStringLiteral("--format=json"), QStringLiteral("list"),
+                    QStringLiteral("sink-inputs")}, parseAudioApplications);
+        return true;
+    }
+    if (op == QStringLiteral("audio.application.set-volume")) {
+        const int id = payload.value(QStringLiteral("id")).toInt(-1);
+        const int value = qBound(0, payload.value(QStringLiteral("percent")).toInt(), 150);
+        if (id < 0) {
+            respond(socket, request, false, {}, QStringLiteral("invalid-audio-stream"),
+                    QStringLiteral("音频应用无效"), false);
+            return true;
+        }
+        const QString pactl = QStandardPaths::findExecutable(QStringLiteral("pactl"));
+        if (pactl.isEmpty()) {
+            respond(socket, request, false, {}, QStringLiteral("audio-unavailable"),
+                    QStringLiteral("音频服务不可用"), true);
+            return true;
+        }
+        runCommand(socket, request, pactl,
+                   {QStringLiteral("set-sink-input-volume"), QString::number(id),
+                    QString::number(value) + QLatin1Char('%')});
+        return true;
+    }
+    if (op == QStringLiteral("audio.application.set-mute")) {
+        const int id = payload.value(QStringLiteral("id")).toInt(-1);
+        if (id < 0) {
+            respond(socket, request, false, {}, QStringLiteral("invalid-audio-stream"),
+                    QStringLiteral("音频应用无效"), false);
+            return true;
+        }
+        const QString pactl = QStandardPaths::findExecutable(QStringLiteral("pactl"));
+        if (pactl.isEmpty()) {
+            respond(socket, request, false, {}, QStringLiteral("audio-unavailable"),
+                    QStringLiteral("音频服务不可用"), true);
+            return true;
+        }
+        runCommand(socket, request, pactl,
+                   {QStringLiteral("set-sink-input-mute"), QString::number(id),
                     payload.value(QStringLiteral("muted")).toBool() ? QStringLiteral("1") : QStringLiteral("0")});
         return true;
     }

--- a/shared/contracts/platform.v1.md
+++ b/shared/contracts/platform.v1.md
@@ -39,7 +39,9 @@ Current operation groups are:
   shortcuts; the Shell composes each Exec line, the daemon validates,
   persists, and registers)
 - `network.*` (including `network.traffic` for read-only interface counters),
-  `audio.*`, `bluetooth.*`, `display.*`, `session.*`,
+  `audio.*` (including `audio.applications`,
+  `audio.application.set-volume`, and `audio.application.set-mute` for
+  per-application PipeWire/PulseAudio sink-input control), `bluetooth.*`, `display.*`, `session.*`,
   `theme.*`, and `screenshot.*`
 
 KWin events are sent to subscribers as `window.snapshot`, `desktops`,

--- a/shared/qml/test_visual_contract.mjs
+++ b/shared/qml/test_visual_contract.mjs
@@ -289,7 +289,7 @@ assert.match(networkPanel,
     "the network panel reuses the live Wi-Fi signal glyph");
 for (const marker of ["Card 1: Wi-Fi", "Card 2: Bluetooth"]) {
     const start = controlCenterPanel.indexOf(marker);
-    const section = controlCenterPanel.slice(start, start + 5200);
+    const section = controlCenterPanel.slice(start, start + 8000);
     assert.match(section,
         /id:\s*(?:wifi|bluetooth)TogglePointer[\s\S]{0,420}onClicked:[\s\S]{0,140}set(?:Wifi|Bluetooth)Enabled/,
         `${marker} round disc owns its power toggle`);
@@ -300,7 +300,7 @@ for (const marker of ["Card 1: Wi-Fi", "Card 2: Bluetooth"]) {
 for (const component of ["NetworkStatus", "Battery", "SettingsButton",
                          "ControlCenterToggle"]) {
     assert.match(barStatusArea,
-        new RegExp(component + "\\s*\\{[\\s\\S]{0,180}iconSize:\\s*systemTray\\.iconSize"),
+        new RegExp(component + "\\s*\\{[\\s\\S]{0,400}iconSize:\\s*systemTray\\.iconSize(?:\\s*\\+\\s*\\d+)?"),
         component + " shares the native tray icon size");
 }
 assert.doesNotMatch(controlCenterPanel,

--- a/shell/desktop/assets/night-light.svg
+++ b/shell/desktop/assets/night-light.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 4V2" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M4.93 6.93L3.51 5.51" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M19.07 6.93L20.49 5.51" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M12 8a6 6 0 0 0-6 6h12a6 6 0 0 0-6-6z" fill="#ffffff"/>
+  <path d="M3 18h18" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  <path d="M6 21h12" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/shell/desktop/modules/bar/BarStatusArea.qml
+++ b/shell/desktop/modules/bar/BarStatusArea.qml
@@ -7,6 +7,8 @@ Item {
 
     implicitWidth: statusArea.implicitWidth
     implicitHeight: 24
+    width: implicitWidth
+    height: implicitHeight
     property bool dockHosted: false
     property string dockEdge: "bottom"
     readonly property bool verticalDock: dockHosted && dockEdge !== "bottom"

--- a/shell/desktop/modules/bar/BarStatusArea.qml
+++ b/shell/desktop/modules/bar/BarStatusArea.qml
@@ -192,19 +192,6 @@ Item {
             ControlCenterPanel {
                 dockHosted: root.dockHosted
                 dockEdge: root.dockEdge
-                onNetworkRequested: {
-                    root.closeControlCenter()
-                    bluetoothPanel.close()
-                    const anchor = root.networkStatusAnchor()
-                    if (anchor)
-                        networkPanel.open(anchor)
-                }
-                onBluetoothRequested: {
-                    root.closeControlCenter()
-                    const anchor = root.controlCenterAnchor()
-                    if (anchor)
-                        bluetoothPanel.open(anchor)
-                }
             }
         }
     }

--- a/shell/desktop/modules/bar/ControlCenterPanel.qml
+++ b/shell/desktop/modules/bar/ControlCenterPanel.qml
@@ -67,11 +67,9 @@ Item {
 
     function openSettingsModule(module) {
         panel.close()
-        PlatformClient.request("settings.open", { module: module }, function(response) {
-            if (!response?.ok) {
-                Quickshell.execDetached(["kcmshell6", module])
-            }
-        })
+        // Launch directly from the shell so a closing popup or a stale daemon
+        // response cannot swallow the click.
+        Quickshell.execDetached(["kcmshell6", module])
     }
 
     onNetworkRequested: openSubmenu("wifi")
@@ -649,10 +647,10 @@ Item {
     ControlCenterCard {
         coordinator: coordinator
         offsetTop: 155
-        offsetRight: 262
-        cardRadius: 27
-        cardWidth: 54
-        cardHeight: 54
+        offsetRight: 264
+        cardRadius: 26
+        cardWidth: 52
+        cardHeight: 52
         cardBorderColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.24) : Qt.rgba(0, 0, 0, 0.10)
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
@@ -661,7 +659,7 @@ Item {
         Behavior on cardScale { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
         Rectangle {
             anchors.fill: parent
-            radius: 27
+            radius: 26
             color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45)
             opacity: screenshotPointer.containsMouse && !screenshotPointer.pressed ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: 140 } }
@@ -688,10 +686,10 @@ Item {
     ControlCenterCard {
         coordinator: coordinator
         offsetTop: 155
-        offsetRight: 198
-        cardRadius: 27
-        cardWidth: 54
-        cardHeight: 54
+        offsetRight: 203
+        cardRadius: 26
+        cardWidth: 52
+        cardHeight: 52
         cardBorderColor: ThemeService.isDark
             ? Qt.rgba(1, 1, 1, 0.24) : Qt.rgba(0, 0, 0, 0.10)
         blurStrength: panel.effectiveBlur
@@ -701,7 +699,7 @@ Item {
         Behavior on cardScale { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
         Rectangle {
             anchors.fill: parent
-            radius: 27
+            radius: 26
             color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45)
             opacity: themePointer.containsMouse && !themePointer.pressed ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: 140 } }
@@ -731,10 +729,10 @@ Item {
     ControlCenterCard {
         coordinator: coordinator
         offsetTop: 155
-        offsetRight: 134
-        cardRadius: 27
-        cardWidth: 54
-        cardHeight: 54
+        offsetRight: 142
+        cardRadius: 26
+        cardWidth: 52
+        cardHeight: 52
         cardBorderColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.24) : Qt.rgba(0, 0, 0, 0.10)
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
@@ -743,7 +741,7 @@ Item {
         Behavior on cardScale { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
         Rectangle {
             anchors.fill: parent
-            radius: 27
+            radius: 26
             color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45)
             opacity: powerPointer.containsMouse && !powerPointer.pressed ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: 140 } }
@@ -777,31 +775,33 @@ Item {
     ControlCenterCard {
         coordinator: coordinator
         offsetTop: 155
-        offsetRight: 20
-        cardRadius: 27
-        cardWidth: 104
-        cardHeight: 54
+        offsetRight: 81
+        cardRadius: 26
+        cardWidth: 52
+        cardHeight: 52
         cardBorderColor: ControlCenterService.doNotDisturbEnabled
             ? "#0a84ff" : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.24) : Qt.rgba(0, 0, 0, 0.10))
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
 
-        cardScale: dndPointer.pressed ? 0.97 : (dndPointer.containsMouse ? 1.025 : 1.0)
+        cardScale: dndPointer.pressed ? 0.91 : (dndPointer.containsMouse ? 1.06 : 1.0)
         Behavior on cardScale { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
         Rectangle {
             anchors.fill: parent
-            radius: 27
-            color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45)
-            opacity: dndPointer.containsMouse && !dndPointer.pressed ? 1 : 0
+            radius: 26
+            color: ControlCenterService.doNotDisturbEnabled
+                ? (ThemeService.isDark ? Qt.rgba(0.04, 0.52, 1.0, 0.28) : Qt.rgba(0.04, 0.52, 1.0, 0.18))
+                : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45))
+            opacity: ControlCenterService.doNotDisturbEnabled || (dndPointer.containsMouse && !dndPointer.pressed) ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: 140 } }
         }
         Image {
-            anchors { left: parent.left; leftMargin: 14; verticalCenter: parent.verticalCenter }
-            width: 21
-            height: 21
+            anchors.centerIn: parent
+            width: 22
+            height: 22
             source: "../../assets/do-not-disturb.svg"
-            sourceSize.width: 46
-            sourceSize.height: 46
+            sourceSize.width: 44
+            sourceSize.height: 44
             fillMode: Image.PreserveAspectFit
             smooth: true
             layer.enabled: true
@@ -811,16 +811,65 @@ Item {
                     ? "#0a84ff" : (ThemeService.isDark ? ThemeService.foregroundColor : "#000000")
             }
         }
-        GlassText {
-            anchors { left: parent.left; leftMargin: 42; verticalCenter: parent.verticalCenter }
-            text: "勿扰"
-            color: ThemeService.foregroundColor
-            font { pixelSize: 12; weight: Font.Bold; family: "Noto Sans CJK SC" }
+        MouseArea {
+            id: dndPointer
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: ControlCenterService.toggleDoNotDisturb()
         }
-        MouseArea { id: dndPointer; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: ControlCenterService.toggleDoNotDisturb() }
     }
 
-    // ── Card 7: Display brightness ───────────────────────────────────
+    // ── Card 8: Night Light ──────────────────────────────────────────
+    ControlCenterCard {
+        coordinator: coordinator
+        offsetTop: 155
+        offsetRight: 20
+        cardRadius: 26
+        cardWidth: 52
+        cardHeight: 52
+        cardBorderColor: ControlCenterService.nightLightActive
+            ? "#ff9f0a" : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.24) : Qt.rgba(0, 0, 0, 0.10))
+        blurStrength: panel.effectiveBlur
+        liquidStrength: panel.effectiveLiquid
+
+        cardScale: nightLightPointer.pressed ? 0.91 : (nightLightPointer.containsMouse ? 1.06 : 1.0)
+        Behavior on cardScale { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
+        Rectangle {
+            anchors.fill: parent
+            radius: 26
+            color: ControlCenterService.nightLightActive
+                ? (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.28) : Qt.rgba(1, 0.62, 0.04, 0.18))
+                : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(1, 1, 1, 0.45))
+            opacity: ControlCenterService.nightLightActive || (nightLightPointer.containsMouse && !nightLightPointer.pressed) ? 1 : 0
+            Behavior on opacity { NumberAnimation { duration: 140 } }
+        }
+        Image {
+            anchors.centerIn: parent
+            width: 22
+            height: 22
+            source: "../../assets/night-light.svg"
+            sourceSize.width: 44
+            sourceSize.height: 44
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                colorization: 1.0
+                colorizationColor: ControlCenterService.nightLightActive
+                    ? "#ff9f0a" : (ThemeService.isDark ? ThemeService.foregroundColor : "#000000")
+            }
+        }
+        MouseArea {
+            id: nightLightPointer
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: ControlCenterService.toggleNightLight()
+        }
+    }
+
+    // ── Card 9: Display brightness ───────────────────────────────────
     ControlCenterCard {
         coordinator: coordinator
         offsetTop: 217
@@ -840,19 +889,6 @@ Item {
                 color: ThemeService.foregroundColor
                 font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
             }
-            GlassText {
-                text: "›"
-                color: ThemeService.foregroundColor
-                opacity: 0.50
-                font { pixelSize: 13; weight: Font.Bold }
-            }
-        }
-        MouseArea {
-            anchors { left: parent.left; top: parent.top; right: parent.right }
-            height: 26
-            cursorShape: Qt.PointingHandCursor
-            hoverEnabled: true
-            onClicked: panel.openSubmenu("display")
         }
         GlassText {
             anchors { right: parent.right; top: parent.top; rightMargin: 14; topMargin: 8 }
@@ -1560,7 +1596,7 @@ Item {
         }
     }
 
-    // ── Card 11 (Submenu Panel): Wi-Fi, Bluetooth, Sound, Display ─────
+    // ── Card 11 (Submenu Panel): Wi-Fi, Bluetooth, Sound ─────────────
     ControlCenterCard {
         id: submenuCard
         coordinator: coordinator
@@ -1571,8 +1607,7 @@ Item {
         cardWidth: 296
         cardHeight: panel.activeSubmenu === "wifi" ? 360
             : (panel.activeSubmenu === "bluetooth" ? 340
-            : (panel.activeSubmenu === "sound" ? 220
-            : (panel.activeSubmenu === "display" ? 240 : 280)))
+            : (panel.activeSubmenu === "sound" ? 420 : 280))
         cardBorderColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.10)
         cardShown: panel.activeSubmenu !== "" && panel.activeSubmenu !== "session"
         blurStrength: panel.effectiveBlur
@@ -1637,8 +1672,7 @@ Item {
                 }
                 text: panel.activeSubmenu === "wifi" ? "Wi‑Fi"
                     : (panel.activeSubmenu === "bluetooth" ? "蓝牙"
-                    : (panel.activeSubmenu === "sound" ? "声音"
-                    : (panel.activeSubmenu === "display" ? "显示器" : "")))
+                    : (panel.activeSubmenu === "sound" ? "声音" : ""))
                 color: ThemeService.foregroundColor
                 font { pixelSize: 13; weight: Font.Bold; family: "Noto Sans CJK SC" }
             }
@@ -2382,6 +2416,157 @@ Item {
             }
 
             Item {
+                id: soundApplicationsSection
+                anchors {
+                    top: soundOutputSection.bottom
+                    topMargin: 10
+                    left: parent.left
+                    right: parent.right
+                    bottom: soundFooter.top
+                    leftMargin: 14
+                    rightMargin: 14
+                    bottomMargin: 4
+                }
+
+                GlassText {
+                    id: soundApplicationsTitle
+                    anchors { left: parent.left; top: parent.top }
+                    text: "应用音量"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.60
+                    font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    visible: ControlCenterService.audioApplications.length === 0
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 8
+                    text: ControlCenterService.audioApplicationsRefreshInProgress ? "正在读取…" : "没有活动的音频应用"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.45
+                    font { pixelSize: 10; family: "Noto Sans CJK SC" }
+                }
+
+                Column {
+                    anchors {
+                        top: soundApplicationsTitle.bottom
+                        topMargin: 5
+                        left: parent.left
+                        right: parent.right
+                    }
+                    spacing: 3
+
+                    Repeater {
+                        model: ControlCenterService.audioApplications.slice(0, 3)
+
+                        delegate: Item {
+                            id: appVolumeRow
+                            required property var modelData
+                            width: parent.width
+                            height: 58
+                            property int volumePreview: Number(modelData.percent || 0)
+                            property bool muted: !!modelData.muted
+
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: 8
+                                color: appVolumeHover.hovered
+                                    ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.055))
+                                    : "transparent"
+                                Behavior on color { ColorAnimation { duration: 100 } }
+                            }
+
+                            Rectangle {
+                                id: appMuteButton
+                                anchors { left: parent.left; leftMargin: 4; verticalCenter: parent.verticalCenter }
+                                width: 28
+                                height: 28
+                                radius: 8
+                                color: appVolumeRow.muted
+                                    ? Qt.rgba(1.0, 0.27, 0.23, ThemeService.isDark ? 0.30 : 0.18)
+                                    : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(0, 0, 0, 0.07))
+
+                                GlassText {
+                                    anchors.centerIn: parent
+                                    text: appVolumeRow.muted ? "×" : "♪"
+                                    color: appVolumeRow.muted ? "#ff453a" : ThemeService.foregroundColor
+                                    font { pixelSize: appVolumeRow.muted ? 15 : 13; weight: Font.Bold }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        appVolumeRow.muted = !appVolumeRow.muted
+                                        ControlCenterService.setApplicationMuted(appVolumeRow.modelData.id,
+                                            appVolumeRow.muted)
+                                    }
+                                }
+                            }
+
+                            GlassText {
+                                id: appVolumeName
+                                anchors {
+                                    left: appMuteButton.right
+                                    leftMargin: 8
+                                    right: appVolumePercent.left
+                                    rightMargin: 6
+                                    top: parent.top
+                                    topMargin: 5
+                                }
+                                text: appVolumeRow.modelData.name || "音频应用"
+                                elide: Text.ElideRight
+                                color: ThemeService.foregroundColor
+                                font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                            }
+
+                            GlassText {
+                                id: appVolumePercent
+                                anchors { right: parent.right; rightMargin: 5; verticalCenter: appVolumeName.verticalCenter }
+                                text: Math.round(appVolumeRow.volumePreview) + "%"
+                                color: ThemeService.foregroundColor
+                                opacity: 0.55
+                                font { pixelSize: 9; family: "Noto Sans CJK SC" }
+                            }
+
+                            LiquidControls.LiquidSlider {
+                                anchors {
+                                    left: appMuteButton.right
+                                    leftMargin: 8
+                                    right: parent.right
+                                    rightMargin: 4
+                                    bottom: parent.bottom
+                                    bottomMargin: 3
+                                }
+                                height: 27
+                                value: Math.min(1, appVolumeRow.volumePreview / 150)
+                                trackHeight: 4
+                                trackColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.17) : Qt.rgba(0, 0, 0, 0.15)
+                                accentColor: appVolumeRow.muted ? Qt.rgba(1, 1, 1, 0.25)
+                                    : (ThemeService.isDark ? "#ffffff" : Qt.rgba(0, 0, 0, 0.40))
+                                thumbColor: ThemeService.isDark ? "#ffffff" : "#e7f1ff"
+                                onPreviewChanged: function(v) {
+                                    appVolumeRow.volumePreview = Math.round(v * 150)
+                                }
+                                onCommitRequested: function(v) {
+                                    if (appVolumeRow.muted) {
+                                        appVolumeRow.muted = false
+                                        ControlCenterService.setApplicationMuted(appVolumeRow.modelData.id, false)
+                                    }
+                                    ControlCenterService.setApplicationVolume(appVolumeRow.modelData.id,
+                                        Math.round(v * 150))
+                                }
+                            }
+
+                            HoverHandler { id: appVolumeHover }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                id: soundFooter
                 anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
                 height: 38
 
@@ -2412,237 +2597,6 @@ Item {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: panel.openSettingsModule("kcm_pulseaudio")
-                }
-            }
-        }
-
-        // ── View D: Display ──
-        Item {
-            id: displaySubmenuView
-            visible: panel.activeSubmenu === "display"
-            anchors {
-                top: submenuDivider.bottom
-                topMargin: 6
-                left: parent.left
-                right: parent.right
-                bottom: parent.bottom
-            }
-
-            Item {
-                id: displayBrightnessSection
-                anchors {
-                    top: parent.top
-                    left: parent.left
-                    right: parent.right
-                    leftMargin: 14
-                    rightMargin: 14
-                }
-                height: 62
-
-                GlassText {
-                    anchors { left: parent.left; top: parent.top; topMargin: 2 }
-                    text: "显示亮度"
-                    color: ThemeService.foregroundColor
-                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
-                }
-
-                GlassText {
-                    anchors { right: parent.right; top: parent.top; topMargin: 2 }
-                    text: ControlCenterService.brightnessAvailable ? Math.round(panel.brightnessPreview) + "%" : "无亮度设备"
-                    color: ThemeService.foregroundColor
-                    opacity: 0.65
-                    font { pixelSize: 10; family: "Noto Sans CJK SC" }
-                }
-
-                GlassText {
-                    anchors { left: parent.left; leftMargin: 3; bottom: parent.bottom; bottomMargin: 9 }
-                    text: "☀"
-                    color: ThemeService.foregroundColor
-                    opacity: 0.65
-                    font.pixelSize: 13
-                }
-
-                LiquidControls.LiquidSlider {
-                    id: submenuBrightnessSlider
-                    anchors { left: parent.left; right: parent.right; bottom: parent.bottom; leftMargin: 24; rightMargin: 2; bottomMargin: 4 }
-                    height: 28
-                    value: panel.brightnessPreview / 100
-                    enabled: ControlCenterService.brightnessAvailable
-                    trackHeight: 4
-                    trackColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.17) : Qt.rgba(0, 0, 0, 0.12)
-                    accentColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.42) : Qt.rgba(0, 0, 0, 0.35)
-                    thumbColor: ThemeService.isDark ? "#ffffff" : "#e7f1ff"
-                    onPreviewChanged: function(v) {
-                        panel.draggingBrightness = true
-                        panel.brightnessPreview = Math.round(v * 100)
-                    }
-                    onCommitRequested: function(v) {
-                        panel.draggingBrightness = false
-                        ControlCenterService.setBrightness(Math.round(v * 100))
-                    }
-                }
-            }
-
-            Item {
-                id: displayTilesSection
-                anchors {
-                    top: displayBrightnessSection.bottom
-                    topMargin: 10
-                    left: parent.left
-                    right: parent.right
-                    leftMargin: 14
-                    rightMargin: 14
-                }
-                height: 66
-
-                Row {
-                    anchors.centerIn: parent
-                    spacing: 12
-
-                    Rectangle {
-                        width: 126
-                        height: 60
-                        radius: 14
-                        color: darkTileMouse.containsMouse
-                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
-                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
-                        border.width: 1
-                        border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08)
-
-                        Column {
-                            anchors.centerIn: parent
-                            spacing: 4
-
-                            Image {
-                                anchors.horizontalCenter: parent.horizontalCenter
-                                width: 20
-                                height: 20
-                                source: "../../assets/theme-appearance.svg"
-                                sourceSize.width: 40
-                                sourceSize.height: 40
-                                fillMode: Image.PreserveAspectFit
-                                smooth: true
-                                rotation: ThemeService.isDark ? 0 : 180
-                                Behavior on rotation { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
-                                layer.enabled: true
-                                layer.effect: MultiEffect {
-                                    colorization: 1.0
-                                    colorizationColor: ThemeService.foregroundColor
-                                }
-                            }
-
-                            GlassText {
-                                anchors.horizontalCenter: parent.horizontalCenter
-                                text: ThemeService.isDark ? "深色模式 (开)" : "深色模式 (关)"
-                                color: ThemeService.foregroundColor
-                                font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
-                            }
-                        }
-
-                        MouseArea {
-                            id: darkTileMouse
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: ControlCenterService.toggleDarkMode()
-                        }
-                    }
-
-                    Rectangle {
-                        width: 126
-                        height: 60
-                        radius: 14
-                        color: {
-                            if (ControlCenterService.nightLightActive) {
-                                return nightTileMouse.containsMouse
-                                    ? (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.28) : Qt.rgba(1, 0.62, 0.04, 0.20))
-                                    : (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.18) : Qt.rgba(1, 0.62, 0.04, 0.12))
-                            }
-                            return nightTileMouse.containsMouse
-                                ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
-                                : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
-                        }
-                        border.width: 1
-                        border.color: ControlCenterService.nightLightActive
-                            ? (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.40) : Qt.rgba(1, 0.62, 0.04, 0.30))
-                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08))
-                        Behavior on color { ColorAnimation { duration: 150 } }
-                        Behavior on border.color { ColorAnimation { duration: 150 } }
-
-                        Column {
-                            anchors.centerIn: parent
-                            spacing: 4
-
-                            Image {
-                                anchors.horizontalCenter: parent.horizontalCenter
-                                width: 20
-                                height: 20
-                                source: "../../assets/night-light.svg"
-                                sourceSize.width: 40
-                                sourceSize.height: 40
-                                fillMode: Image.PreserveAspectFit
-                                smooth: true
-                                layer.enabled: true
-                                layer.effect: MultiEffect {
-                                    colorization: 1.0
-                                    colorizationColor: ControlCenterService.nightLightActive
-                                        ? "#ff9f0a"
-                                        : ThemeService.foregroundColor
-                                }
-                            }
-
-                            GlassText {
-                                anchors.horizontalCenter: parent.horizontalCenter
-                                text: ControlCenterService.nightLightActive ? "夜览 (开)" : "夜览 (关)"
-                                color: ControlCenterService.nightLightActive
-                                    ? (ThemeService.isDark ? "#ffb340" : "#d97706")
-                                    : ThemeService.foregroundColor
-                                font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
-                            }
-                        }
-
-                        MouseArea {
-                            id: nightTileMouse
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: ControlCenterService.toggleNightLight()
-                        }
-                    }
-                }
-            }
-
-            Item {
-                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
-                height: 38
-
-                Rectangle {
-                    anchors { left: parent.left; right: parent.right; top: parent.top; leftMargin: 12; rightMargin: 12 }
-                    height: 1
-                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.06)
-                }
-
-                GlassText {
-                    anchors { left: parent.left; leftMargin: 16; verticalCenter: parent.verticalCenter }
-                    text: "显示器设置…"
-                    color: displaySettingsMouse.containsMouse ? "#0a84ff" : ThemeService.foregroundColor
-                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
-                }
-
-                GlassText {
-                    anchors { right: parent.right; rightMargin: 16; verticalCenter: parent.verticalCenter }
-                    text: "›"
-                    color: ThemeService.foregroundColor
-                    opacity: 0.45
-                    font { pixelSize: 13; weight: Font.Bold }
-                }
-
-                MouseArea {
-                    id: displaySettingsMouse
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: panel.openSettingsModule("kcm_kscreen")
                 }
             }
         }

--- a/shell/desktop/modules/bar/ControlCenterPanel.qml
+++ b/shell/desktop/modules/bar/ControlCenterPanel.qml
@@ -33,8 +33,40 @@ Item {
     property bool sessionModalVisible: false
     property string pendingConfirmAction: ""
     property alias logoutConfirmationVisible: panel.sessionModalVisible
+    property string activeSubmenu: ""
+    readonly property bool hasActiveSubmenu: activeSubmenu !== "" || sessionModalVisible
     signal networkRequested()
     signal bluetoothRequested()
+
+    function openSubmenu(name) {
+        if (name === "session") {
+            openSessionPanel()
+            return
+        }
+        _triggerTransitionGuard()
+        activeSubmenu = name
+        sessionModalVisible = false
+        if (name === "wifi") {
+            NetworkService.refreshWifiNetworks()
+        } else if (name === "bluetooth") {
+            ControlCenterService.refresh()
+            ControlCenterService.refreshBluetoothDevices()
+        }
+        if (!coordinator.open)
+            coordinator.openAll()
+        coordinator.modalActive = true
+    }
+
+    function closeSubmenu() {
+        _triggerTransitionGuard()
+        activeSubmenu = ""
+        sessionModalVisible = false
+        pendingConfirmAction = ""
+        coordinator.modalActive = false
+    }
+
+    onNetworkRequested: openSubmenu("wifi")
+    onBluetoothRequested: openSubmenu("bluetooth")
 
     // Bar reads this for sharedPanelOpen / toggle state.
     readonly property bool isOpen: coordinator.open
@@ -133,16 +165,19 @@ Item {
         }
         if (!panel.sessionModalVisible) {
             panel.pendingConfirmAction = ""
+            if (panel.activeSubmenu === "")
+                coordinator.modalActive = false
         }
     }
 
     function toggle(item) {
         anchorItem = item
         _triggerTransitionGuard()
-        if (coordinator.open || panel.sessionModalVisible) {
+        if (coordinator.open || panel.sessionModalVisible || panel.activeSubmenu !== "") {
             close()
         } else {
             panel.sessionModalVisible = false
+            panel.activeSubmenu = ""
             panel.pendingConfirmAction = ""
             ControlCenterService.refresh()
             coordinator.openAll()
@@ -150,14 +185,16 @@ Item {
     }
     function close() {
         _triggerTransitionGuard()
-        const closingModal = sessionModalVisible
+        const closingModal = sessionModalVisible || activeSubmenu !== ""
         coordinator.closeAll(closingModal)
         sessionModalVisible = false
+        activeSubmenu = ""
         pendingConfirmAction = ""
     }
 
     function openSessionPanel() {
         pendingConfirmAction = ""
+        activeSubmenu = ""
         sessionModalVisible = true
     }
 
@@ -167,7 +204,7 @@ Item {
         id: dismissalBackdrop
         screen: panel.targetScreen
         visible: ScreenLifecycle.outputAvailable && panel.targetScreen !== null
-            && (coordinator.open || panel.sessionModalVisible)
+            && (coordinator.open || panel.sessionModalVisible || panel.activeSubmenu !== "")
         color: "transparent"
         exclusionMode: ExclusionMode.Ignore
         WlrLayershell.layer: WlrLayer.Top
@@ -190,7 +227,7 @@ Item {
     Connections {
         target: WindowService
         function onActiveWindowIdChanged() {
-            if (!panel._internalTransition && (coordinator.open || panel.sessionModalVisible)) {
+            if (!panel._internalTransition && (coordinator.open || panel.sessionModalVisible || panel.activeSubmenu !== "")) {
                 panel.close()
             }
         }
@@ -198,10 +235,12 @@ Item {
 
     Shortcut {
         sequence: "Escape"
-        enabled: coordinator.open || panel.sessionModalVisible
+        enabled: coordinator.open || panel.sessionModalVisible || panel.activeSubmenu !== ""
         onActivated: {
-            if (panel.sessionModalVisible) {
-                panel.sessionModalVisible = false
+            if (panel.pendingConfirmAction !== "") {
+                panel.pendingConfirmAction = ""
+            } else if (panel.hasActiveSubmenu) {
+                panel.closeSubmenu()
             } else {
                 panel.close()
             }
@@ -299,7 +338,7 @@ Item {
             }
         }
         Column {
-            anchors { left: parent.left; right: parent.right; leftMargin: 58; rightMargin: 10; verticalCenter: parent.verticalCenter }
+            anchors { left: parent.left; right: parent.right; leftMargin: 58; rightMargin: 18; verticalCenter: parent.verticalCenter }
             spacing: 1
             GlassText {
                 width: parent.width
@@ -315,6 +354,13 @@ Item {
                 opacity: 1.0
                 font { pixelSize: 10; family: "Noto Sans CJK SC" }
             }
+        }
+        GlassText {
+            anchors { right: parent.right; rightMargin: 8; verticalCenter: parent.verticalCenter }
+            text: "›"
+            color: wifiCard.materialSecondaryForegroundColor
+            opacity: 0.60
+            font { pixelSize: 14; weight: Font.Bold }
         }
         MouseArea {
             anchors {
@@ -443,7 +489,7 @@ Item {
             }
         }
         Column {
-            anchors { left: parent.left; right: parent.right; leftMargin: 58; rightMargin: 10; verticalCenter: parent.verticalCenter }
+            anchors { left: parent.left; right: parent.right; leftMargin: 58; rightMargin: 18; verticalCenter: parent.verticalCenter }
             spacing: 1
             GlassText {
                 width: parent.width
@@ -458,6 +504,13 @@ Item {
                 opacity: 1.0
                 font { pixelSize: 10; family: "Noto Sans CJK SC" }
             }
+        }
+        GlassText {
+            anchors { right: parent.right; rightMargin: 8; verticalCenter: parent.verticalCenter }
+            text: "›"
+            color: bluetoothCard.materialSecondaryForegroundColor
+            opacity: 0.60
+            font { pixelSize: 14; weight: Font.Bold }
         }
         MouseArea {
             anchors {
@@ -770,12 +823,27 @@ Item {
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
 
-        GlassText {
+        Row {
             anchors { left: parent.left; top: parent.top; leftMargin: 14; topMargin: 8 }
-            text: "显示亮度"
-            color: ThemeService.foregroundColor
-            opacity: 0.70
-            font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+            spacing: 4
+            GlassText {
+                text: "显示亮度"
+                color: ThemeService.foregroundColor
+                font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+            }
+            GlassText {
+                text: "›"
+                color: ThemeService.foregroundColor
+                opacity: 0.50
+                font { pixelSize: 13; weight: Font.Bold }
+            }
+        }
+        MouseArea {
+            anchors { left: parent.left; top: parent.top; right: parent.right }
+            height: 26
+            cursorShape: Qt.PointingHandCursor
+            hoverEnabled: true
+            onClicked: panel.openSubmenu("display")
         }
         GlassText {
             anchors { right: parent.right; top: parent.top; rightMargin: 14; topMargin: 8 }
@@ -824,11 +892,27 @@ Item {
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
 
-        GlassText {
+        Row {
             anchors { left: parent.left; top: parent.top; leftMargin: 14; topMargin: 8 }
-            text: "声音"
-            color: ThemeService.foregroundColor
-            font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+            spacing: 4
+            GlassText {
+                text: "声音"
+                color: ThemeService.foregroundColor
+                font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+            }
+            GlassText {
+                text: "›"
+                color: ThemeService.foregroundColor
+                opacity: 0.50
+                font { pixelSize: 13; weight: Font.Bold }
+            }
+        }
+        MouseArea {
+            anchors { left: parent.left; top: parent.top; right: parent.right }
+            height: 26
+            cursorShape: Qt.PointingHandCursor
+            hoverEnabled: true
+            onClicked: panel.openSubmenu("sound")
         }
         GlassText {
             anchors { right: parent.right; top: parent.top; rightMargin: 14; topMargin: 8 }
@@ -1049,7 +1133,7 @@ Item {
         blurStrength: panel.effectiveBlur
         liquidStrength: panel.effectiveLiquid
         onMotionClosed: {
-            if (!panel.sessionModalVisible)
+            if (!panel.sessionModalVisible && panel.activeSubmenu === "")
                 coordinator.modalActive = false
         }
 
@@ -1461,6 +1545,1084 @@ Item {
                                 ControlCenterService.logoutCurrentSession()
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Card 11 (Submenu Panel): Wi-Fi, Bluetooth, Sound, Display ─────
+    ControlCenterCard {
+        id: submenuCard
+        coordinator: coordinator
+        managedByCoordinator: false
+        offsetTop: 20
+        offsetRight: 20
+        cardRadius: 22
+        cardWidth: 296
+        cardHeight: panel.activeSubmenu === "wifi" ? 360
+            : (panel.activeSubmenu === "bluetooth" ? 340
+            : (panel.activeSubmenu === "sound" ? 220
+            : (panel.activeSubmenu === "display" ? 240 : 280)))
+        cardBorderColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.10)
+        cardShown: panel.activeSubmenu !== "" && panel.activeSubmenu !== "session"
+        blurStrength: panel.effectiveBlur
+        liquidStrength: panel.effectiveLiquid
+        onMotionClosed: {
+            if (panel.activeSubmenu === "" && !panel.sessionModalVisible)
+                coordinator.modalActive = false
+        }
+
+        // Navigation Header
+        Item {
+            id: submenuHeader
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+                topMargin: 12
+                leftMargin: 12
+                rightMargin: 12
+            }
+            height: 28
+
+            // Back button
+            Rectangle {
+                id: submenuBackBtn
+                width: 26
+                height: 26
+                radius: 13
+                anchors { left: parent.left; verticalCenter: parent.verticalCenter }
+                color: submenuBackMouse.pressed
+                    ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.26) : Qt.rgba(0, 0, 0, 0.14))
+                    : (submenuBackMouse.containsMouse
+                        ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.09))
+                        : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.05)))
+                border.width: 1
+                border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08)
+                Behavior on color { ColorAnimation { duration: 110 } }
+
+                GlassText {
+                    anchors.centerIn: parent
+                    anchors.horizontalCenterOffset: -1
+                    text: "‹"
+                    color: ThemeService.foregroundColor
+                    font { pixelSize: 18; weight: Font.Bold }
+                }
+
+                MouseArea {
+                    id: submenuBackMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: panel.closeSubmenu()
+                }
+            }
+
+            // Title
+            GlassText {
+                anchors {
+                    left: submenuBackBtn.right
+                    leftMargin: 8
+                    verticalCenter: parent.verticalCenter
+                }
+                text: panel.activeSubmenu === "wifi" ? "Wi‑Fi"
+                    : (panel.activeSubmenu === "bluetooth" ? "蓝牙"
+                    : (panel.activeSubmenu === "sound" ? "声音"
+                    : (panel.activeSubmenu === "display" ? "显示器" : "")))
+                color: ThemeService.foregroundColor
+                font { pixelSize: 13; weight: Font.Bold; family: "Noto Sans CJK SC" }
+            }
+
+            // Right toggle switch for Wi-Fi and Bluetooth
+            Rectangle {
+                id: submenuToggleSwitch
+                visible: panel.activeSubmenu === "wifi" || panel.activeSubmenu === "bluetooth"
+                anchors {
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                }
+                width: 38
+                height: 22
+                radius: 11
+                readonly property bool isChecked: panel.activeSubmenu === "wifi"
+                    ? NetworkService.wifiEnabled : ControlCenterService.bluetoothPowered
+                readonly property bool inProgress: panel.activeSubmenu === "wifi"
+                    ? NetworkService.wifiToggleInProgress : ControlCenterService.bluetoothChangeInProgress
+
+                color: isChecked
+                    ? "#0a84ff"
+                    : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.20) : Qt.rgba(0, 0, 0, 0.14))
+                opacity: inProgress ? 0.6 : 1.0
+                Behavior on color { ColorAnimation { duration: 160 } }
+
+                Rectangle {
+                    width: 18
+                    height: 18
+                    radius: 9
+                    anchors.verticalCenter: parent.verticalCenter
+                    x: submenuToggleSwitch.isChecked ? parent.width - width - 2 : 2
+                    Behavior on x { NumberAnimation { duration: 160; easing.type: Easing.OutCubic } }
+                    color: "#ffffff"
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    enabled: !submenuToggleSwitch.inProgress
+                    onClicked: {
+                        if (panel.activeSubmenu === "wifi") {
+                            NetworkService.setWifiEnabled(!NetworkService.wifiEnabled)
+                        } else if (panel.activeSubmenu === "bluetooth") {
+                            ControlCenterService.setBluetoothEnabled(!ControlCenterService.bluetoothPowered)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Header divider
+        Rectangle {
+            id: submenuDivider
+            anchors {
+                top: submenuHeader.bottom
+                topMargin: 9
+                left: parent.left
+                right: parent.right
+                leftMargin: 12
+                rightMargin: 12
+            }
+            height: 1
+            color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.08)
+        }
+
+        // ── View A: Wi-Fi ──
+        Item {
+            id: wifiSubmenuView
+            visible: panel.activeSubmenu === "wifi"
+            anchors {
+                top: submenuDivider.bottom
+                topMargin: 6
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+
+            // Wi-Fi Off state
+            Item {
+                anchors.fill: parent
+                visible: !NetworkService.wifiEnabled
+
+                Column {
+                    anchors.centerIn: parent
+                    spacing: 8
+                    GlassText {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Wi‑Fi 已关闭"
+                        color: ThemeService.foregroundColor
+                        font { pixelSize: 13; weight: Font.Bold; family: "Noto Sans CJK SC" }
+                    }
+                    GlassText {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "在上方开启开关以查看附近网络"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.55
+                        font { pixelSize: 11; family: "Noto Sans CJK SC" }
+                    }
+                }
+            }
+
+            // Wi-Fi On state
+            Item {
+                anchors.fill: parent
+                visible: NetworkService.wifiEnabled
+
+                Item {
+                    id: wifiSectionHeader
+                    anchors {
+                        top: parent.top
+                        left: parent.left
+                        right: parent.right
+                        leftMargin: 14
+                        rightMargin: 14
+                    }
+                    height: 22
+
+                    GlassText {
+                        anchors { left: parent.left; verticalCenter: parent.verticalCenter }
+                        text: "附近网络"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.60
+                        font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                    }
+
+                    GlassText {
+                        anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                        visible: NetworkService.wifiScanInProgress
+                        text: "正在扫描…"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.50
+                        font { pixelSize: 9; family: "Noto Sans CJK SC" }
+                    }
+                }
+
+                ListView {
+                    id: submenuWifiList
+                    anchors {
+                        top: wifiSectionHeader.bottom
+                        topMargin: 2
+                        left: parent.left
+                        right: parent.right
+                        bottom: wifiFooter.top
+                        leftMargin: 8
+                        rightMargin: 8
+                        bottomMargin: 4
+                    }
+                    clip: true
+                    spacing: 2
+                    model: NetworkService.nearbyWifi
+
+                    delegate: Rectangle {
+                        required property var modelData
+                        width: submenuWifiList.width
+                        height: 38
+                        radius: 10
+                        color: wifiRowMouse.containsMouse
+                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(0, 0, 0, 0.06))
+                            : "transparent"
+                        Behavior on color { ColorAnimation { duration: 100 } }
+
+                        GlassText {
+                            visible: !!modelData.active
+                            anchors { left: parent.left; leftMargin: 8; verticalCenter: parent.verticalCenter }
+                            text: "✓"
+                            color: "#0a84ff"
+                            font { pixelSize: 13; weight: Font.Bold }
+                        }
+
+                        WifiSignalIcon {
+                            anchors {
+                                left: parent.left
+                                leftMargin: 26
+                                verticalCenter: parent.verticalCenter
+                            }
+                            width: 16
+                            height: 16
+                            wifiEnabled: true
+                            connected: !!modelData.active
+                            signalStrength: modelData.signalStrength !== undefined ? modelData.signalStrength : 70
+                            glyphColor: modelData.active ? "#0a84ff" : (ThemeService.isDark ? "white" : "#000000")
+                        }
+
+                        GlassText {
+                            anchors {
+                                left: parent.left
+                                right: wifiRowRightArea.left
+                                leftMargin: 48
+                                rightMargin: 6
+                                verticalCenter: parent.verticalCenter
+                            }
+                            text: modelData.ssid || "隐藏网络"
+                            elide: Text.ElideRight
+                            color: modelData.active ? "#0a84ff" : ThemeService.foregroundColor
+                            font {
+                                pixelSize: 11
+                                weight: modelData.active ? Font.Bold : Font.Normal
+                                family: "Noto Sans CJK SC"
+                            }
+                        }
+
+                        Row {
+                            id: wifiRowRightArea
+                            anchors { right: parent.right; rightMargin: 8; verticalCenter: parent.verticalCenter }
+                            spacing: 6
+
+                            GlassText {
+                                visible: modelData.security && modelData.security !== "none"
+                                anchors.verticalCenter: parent.verticalCenter
+                                text: "🔒"
+                                opacity: 0.50
+                                font.pixelSize: 10
+                            }
+
+                            Rectangle {
+                                visible: !!modelData.active
+                                width: 38
+                                height: 20
+                                radius: 10
+                                color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.14) : Qt.rgba(0, 0, 0, 0.08)
+                                border.width: 1
+                                border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.20) : Qt.rgba(0, 0, 0, 0.10)
+                                GlassText {
+                                    anchors.centerIn: parent
+                                    text: "断开"
+                                    color: ThemeService.foregroundColor
+                                    font { pixelSize: 9; weight: Font.Medium; family: "Noto Sans CJK SC" }
+                                }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: NetworkService.disconnectActiveWifi()
+                                }
+                            }
+                        }
+
+                        MouseArea {
+                            id: wifiRowMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                if (modelData.active) return
+                                if (modelData.savedProfileUuid) {
+                                    NetworkService.connectWifi(modelData.ssid, "", modelData.savedProfileUuid)
+                                } else {
+                                    panel.close()
+                                    PlatformClient.request("settings.open", { module: "kcm_networkmanagement" })
+                                }
+                            }
+                        }
+                    }
+
+                    GlassText {
+                        anchors.centerIn: parent
+                        visible: submenuWifiList.count === 0 && !NetworkService.wifiScanInProgress
+                        text: "未搜索到 Wi‑Fi 网络"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.45
+                        font { pixelSize: 11; family: "Noto Sans CJK SC" }
+                    }
+                }
+            }
+
+            Item {
+                id: wifiFooter
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: 38
+
+                Rectangle {
+                    anchors { left: parent.left; right: parent.right; top: parent.top; leftMargin: 12; rightMargin: 12 }
+                    height: 1
+                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                }
+
+                GlassText {
+                    anchors { left: parent.left; leftMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "网络设置…"
+                    color: wifiSettingsMouse.containsMouse ? "#0a84ff" : ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; rightMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "›"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.45
+                    font { pixelSize: 13; weight: Font.Bold }
+                }
+
+                MouseArea {
+                    id: wifiSettingsMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        panel.close()
+                        PlatformClient.request("settings.open", { module: "kcm_networkmanagement" })
+                    }
+                }
+            }
+        }
+
+        // ── View B: Bluetooth ──
+        Item {
+            id: bluetoothSubmenuView
+            visible: panel.activeSubmenu === "bluetooth"
+            anchors {
+                top: submenuDivider.bottom
+                topMargin: 6
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+
+            Item {
+                anchors.fill: parent
+                visible: !ControlCenterService.bluetoothPowered
+
+                Column {
+                    anchors.centerIn: parent
+                    spacing: 8
+                    GlassText {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "蓝牙已关闭"
+                        color: ThemeService.foregroundColor
+                        font { pixelSize: 13; weight: Font.Bold; family: "Noto Sans CJK SC" }
+                    }
+                    GlassText {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "在上方开启开关以连接设备"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.55
+                        font { pixelSize: 11; family: "Noto Sans CJK SC" }
+                    }
+                }
+            }
+
+            Item {
+                anchors.fill: parent
+                visible: ControlCenterService.bluetoothPowered
+
+                Item {
+                    id: btSectionHeader
+                    anchors {
+                        top: parent.top
+                        left: parent.left
+                        right: parent.right
+                        leftMargin: 14
+                        rightMargin: 14
+                    }
+                    height: 22
+
+                    GlassText {
+                        anchors { left: parent.left; verticalCenter: parent.verticalCenter }
+                        text: "设备"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.60
+                        font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                    }
+
+                    GlassText {
+                        anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+                        visible: ControlCenterService.bluetoothDevicesRefreshInProgress
+                        text: "正在刷新…"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.50
+                        font { pixelSize: 9; family: "Noto Sans CJK SC" }
+                    }
+                }
+
+                ListView {
+                    id: submenuBtList
+                    anchors {
+                        top: btSectionHeader.bottom
+                        topMargin: 2
+                        left: parent.left
+                        right: parent.right
+                        bottom: btFooter.top
+                        leftMargin: 8
+                        rightMargin: 8
+                        bottomMargin: 4
+                    }
+                    clip: true
+                    spacing: 2
+                    model: ControlCenterService.bluetoothDevices
+
+                    delegate: Rectangle {
+                        required property var modelData
+                        width: submenuBtList.width
+                        height: 42
+                        radius: 10
+                        color: btRowMouse.containsMouse
+                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(0, 0, 0, 0.06))
+                            : "transparent"
+                        Behavior on color { ColorAnimation { duration: 100 } }
+
+                        GlassText {
+                            visible: !!modelData.connected
+                            anchors { left: parent.left; leftMargin: 8; verticalCenter: parent.verticalCenter }
+                            text: "✓"
+                            color: "#0a84ff"
+                            font { pixelSize: 13; weight: Font.Bold }
+                        }
+
+                        Canvas {
+                            anchors {
+                                left: parent.left
+                                leftMargin: 26
+                                verticalCenter: parent.verticalCenter
+                            }
+                            width: 16
+                            height: 16
+                            onPaint: {
+                                const ctx = getContext("2d")
+                                ctx.reset()
+                                ctx.strokeStyle = modelData.connected ? "#0a84ff" : (ThemeService.isDark ? "white" : "#000000")
+                                ctx.lineWidth = 1.6
+                                ctx.lineCap = "round"
+                                ctx.lineJoin = "round"
+                                ctx.scale(0.55, 0.55)
+                                ctx.beginPath()
+                                ctx.moveTo(13.5, 2.5)
+                                ctx.lineTo(20, 9)
+                                ctx.lineTo(13.5, 15)
+                                ctx.lineTo(20, 21)
+                                ctx.lineTo(13.5, 26.5)
+                                ctx.lineTo(13.5, 2.5)
+                                ctx.moveTo(7, 8.5)
+                                ctx.lineTo(13.5, 15)
+                                ctx.lineTo(7, 21.5)
+                                ctx.stroke()
+                            }
+                        }
+
+                        Column {
+                            anchors {
+                                left: parent.left
+                                right: btBatteryArea.left
+                                leftMargin: 50
+                                rightMargin: 6
+                                verticalCenter: parent.verticalCenter
+                            }
+                            spacing: 1
+
+                            GlassText {
+                                width: parent.width
+                                text: modelData.name || "未知设备"
+                                elide: Text.ElideRight
+                                color: modelData.connected ? "#0a84ff" : ThemeService.foregroundColor
+                                font { pixelSize: 11; weight: modelData.connected ? Font.DemiBold : Font.Normal; family: "Noto Sans CJK SC" }
+                            }
+
+                            GlassText {
+                                text: modelData.connected ? "已连接" : "未连接"
+                                color: ThemeService.foregroundColor
+                                opacity: 0.50
+                                font { pixelSize: 9; family: "Noto Sans CJK SC" }
+                            }
+                        }
+
+                        Item {
+                            id: btBatteryArea
+                            anchors { right: parent.right; rightMargin: 10; verticalCenter: parent.verticalCenter }
+                            width: btBatteryText.implicitWidth
+                            height: 16
+                            visible: modelData.battery !== undefined && modelData.battery !== null
+
+                            GlassText {
+                                id: btBatteryText
+                                anchors.centerIn: parent
+                                text: (modelData.battery || 0) + "%"
+                                color: ThemeService.foregroundColor
+                                opacity: 0.60
+                                font { pixelSize: 10; family: "Noto Sans CJK SC" }
+                            }
+                        }
+
+                        MouseArea {
+                            id: btRowMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            enabled: !ControlCenterService.bluetoothDeviceChangeInProgress
+                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            onClicked: ControlCenterService.setBluetoothDeviceConnected(modelData, !modelData.connected)
+                        }
+                    }
+
+                    GlassText {
+                        anchors.centerIn: parent
+                        visible: submenuBtList.count === 0 && !ControlCenterService.bluetoothDevicesRefreshInProgress
+                        text: "未发现已配对设备"
+                        color: ThemeService.foregroundColor
+                        opacity: 0.45
+                        font { pixelSize: 11; family: "Noto Sans CJK SC" }
+                    }
+                }
+            }
+
+            Item {
+                id: btFooter
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: 38
+
+                Rectangle {
+                    anchors { left: parent.left; right: parent.right; top: parent.top; leftMargin: 12; rightMargin: 12 }
+                    height: 1
+                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                }
+
+                GlassText {
+                    anchors { left: parent.left; leftMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "蓝牙设置…"
+                    color: btSettingsMouse.containsMouse ? "#0a84ff" : ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; rightMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "›"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.45
+                    font { pixelSize: 13; weight: Font.Bold }
+                }
+
+                MouseArea {
+                    id: btSettingsMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        panel.close()
+                        PlatformClient.request("settings.open", { module: "kcm_bluetooth" })
+                    }
+                }
+            }
+        }
+
+        // ── View C: Sound ──
+        Item {
+            id: soundSubmenuView
+            visible: panel.activeSubmenu === "sound"
+            anchors {
+                top: submenuDivider.bottom
+                topMargin: 6
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+
+            Item {
+                id: soundVolumeSection
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 14
+                    rightMargin: 14
+                }
+                height: 62
+
+                GlassText {
+                    anchors { left: parent.left; top: parent.top; topMargin: 2 }
+                    text: "主音量"
+                    color: ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; top: parent.top; topMargin: 2 }
+                    text: Math.round(panel.volumePreview) + "%"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.65
+                    font { pixelSize: 10; family: "Noto Sans CJK SC" }
+                }
+
+                Canvas {
+                    id: submenuVolumeGlyph
+                    anchors { left: parent.left; leftMargin: 2; verticalCenter: submenuVolumeSlider.verticalCenter }
+                    width: 19
+                    height: 16
+                    renderTarget: Canvas.Image
+
+                    readonly property int volumeLevel: Math.round(panel.volumePreview)
+                    readonly property bool isMuted: ControlCenterService.audioMuted
+                    readonly property bool isDark: ThemeService.isDark
+
+                    onVolumeLevelChanged: requestPaint()
+                    onIsMutedChanged: requestPaint()
+                    onIsDarkChanged: requestPaint()
+
+                    onPaint: {
+                        const ctx = getContext("2d")
+                        ctx.reset()
+                        const fg = isDark ? Qt.rgba(1, 1, 1, 1.0) : Qt.rgba(0.06, 0.08, 0.12, 1.0)
+                        const bodyColor = isMuted
+                            ? (isDark ? Qt.rgba(1, 1, 1, 0.50) : Qt.rgba(0.06, 0.08, 0.12, 0.50))
+                            : fg
+
+                        ctx.fillStyle = bodyColor
+                        ctx.strokeStyle = fg
+                        ctx.lineWidth = 1.5
+                        ctx.lineCap = "round"
+                        ctx.lineJoin = "round"
+
+                        ctx.fillRect(1.0, 5.5, 3.2, 5.0)
+
+                        ctx.beginPath()
+                        ctx.moveTo(4.2, 5.5)
+                        ctx.lineTo(7.5, 2.5)
+                        ctx.lineTo(7.5, 13.5)
+                        ctx.lineTo(4.2, 10.5)
+                        ctx.closePath()
+                        ctx.fill()
+
+                        if (isMuted) {
+                            ctx.globalCompositeOperation = "destination-out"
+                            ctx.lineWidth = 2.6
+                            ctx.beginPath()
+                            ctx.moveTo(0.8, 2.0)
+                            ctx.lineTo(8.8, 14.0)
+                            ctx.stroke()
+
+                            ctx.globalCompositeOperation = "source-over"
+                            ctx.lineWidth = 1.5
+                            ctx.strokeStyle = fg
+                            ctx.beginPath()
+                            ctx.moveTo(0.8, 2.0)
+                            ctx.lineTo(8.8, 14.0)
+                            ctx.stroke()
+                        } else {
+                            const arcs = volumeLevel > 66 ? 3 : (volumeLevel > 33 ? 2 : (volumeLevel > 0 ? 1 : 0))
+                            const cx = 6.0, cy = 8.0
+                            if (arcs >= 1) {
+                                ctx.beginPath()
+                                ctx.arc(cx, cy, 4.2, -0.65, 0.65)
+                                ctx.stroke()
+                            }
+                            if (arcs >= 2) {
+                                ctx.beginPath()
+                                ctx.arc(cx, cy, 7.0, -0.70, 0.70)
+                                ctx.stroke()
+                            }
+                            if (arcs >= 3) {
+                                ctx.beginPath()
+                                ctx.arc(cx, cy, 9.8, -0.72, 0.72)
+                                ctx.stroke()
+                            }
+                        }
+                    }
+
+                    Connections {
+                        target: ControlCenterService
+                        function onAudioMutedChanged() { submenuVolumeGlyph.requestPaint() }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        anchors.margins: -6
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: ControlCenterService.setMuted(!ControlCenterService.audioMuted)
+                    }
+                }
+
+                LiquidControls.LiquidSlider {
+                    id: submenuVolumeSlider
+                    anchors { left: parent.left; right: parent.right; bottom: parent.bottom; leftMargin: 26; rightMargin: 2; bottomMargin: 4 }
+                    height: 28
+                    value: panel.volumePreview / 100
+                    trackHeight: 5
+                    trackColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.17) : Qt.rgba(0, 0, 0, 0.15)
+                    accentColor: ThemeService.isDark ? "#ffffff" : Qt.rgba(0, 0, 0, 0.40)
+                    thumbColor: ThemeService.isDark ? "#ffffff" : "#e7f1ff"
+                    onPreviewChanged: function(v) {
+                        panel.draggingVolume = true
+                        panel.volumePreview = Math.round(v * 100)
+                    }
+                    onCommitRequested: function(v) {
+                        panel.draggingVolume = false
+                        if (ControlCenterService.audioMuted)
+                            ControlCenterService.setMuted(false)
+                        ControlCenterService.setVolume(Math.round(v * 100))
+                    }
+                }
+            }
+
+            Item {
+                id: soundOutputSection
+                anchors {
+                    top: soundVolumeSection.bottom
+                    topMargin: 8
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 14
+                    rightMargin: 14
+                }
+                height: 52
+
+                GlassText {
+                    anchors { left: parent.left; top: parent.top }
+                    text: "输出设备"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.60
+                    font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                Rectangle {
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        top: parent.top
+                        topMargin: 18
+                        bottom: parent.bottom
+                    }
+                    radius: 10
+                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.05)
+                    border.width: 1
+                    border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.15) : Qt.rgba(0, 0, 0, 0.08)
+
+                    Row {
+                        anchors { left: parent.left; leftMargin: 10; verticalCenter: parent.verticalCenter }
+                        spacing: 8
+
+                        GlassText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "✓"
+                            color: "#0a84ff"
+                            font { pixelSize: 12; weight: Font.Bold }
+                        }
+
+                        GlassText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "🔊"
+                            font.pixelSize: 12
+                        }
+
+                        GlassText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "默认音频输出设备"
+                            color: ThemeService.foregroundColor
+                            font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: 38
+
+                Rectangle {
+                    anchors { left: parent.left; right: parent.right; top: parent.top; leftMargin: 12; rightMargin: 12 }
+                    height: 1
+                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                }
+
+                GlassText {
+                    anchors { left: parent.left; leftMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "声音设置…"
+                    color: soundSettingsMouse.containsMouse ? "#0a84ff" : ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; rightMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "›"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.45
+                    font { pixelSize: 13; weight: Font.Bold }
+                }
+
+                MouseArea {
+                    id: soundSettingsMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        panel.close()
+                        PlatformClient.request("settings.open", { module: "kcm_pulseaudio" })
+                    }
+                }
+            }
+        }
+
+        // ── View D: Display ──
+        Item {
+            id: displaySubmenuView
+            visible: panel.activeSubmenu === "display"
+            anchors {
+                top: submenuDivider.bottom
+                topMargin: 6
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+
+            Item {
+                id: displayBrightnessSection
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 14
+                    rightMargin: 14
+                }
+                height: 62
+
+                GlassText {
+                    anchors { left: parent.left; top: parent.top; topMargin: 2 }
+                    text: "显示亮度"
+                    color: ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; top: parent.top; topMargin: 2 }
+                    text: ControlCenterService.brightnessAvailable ? Math.round(panel.brightnessPreview) + "%" : "无亮度设备"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.65
+                    font { pixelSize: 10; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { left: parent.left; leftMargin: 3; bottom: parent.bottom; bottomMargin: 9 }
+                    text: "☀"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.65
+                    font.pixelSize: 13
+                }
+
+                LiquidControls.LiquidSlider {
+                    id: submenuBrightnessSlider
+                    anchors { left: parent.left; right: parent.right; bottom: parent.bottom; leftMargin: 24; rightMargin: 2; bottomMargin: 4 }
+                    height: 28
+                    value: panel.brightnessPreview / 100
+                    enabled: ControlCenterService.brightnessAvailable
+                    trackHeight: 4
+                    trackColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.17) : Qt.rgba(0, 0, 0, 0.12)
+                    accentColor: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.42) : Qt.rgba(0, 0, 0, 0.35)
+                    thumbColor: ThemeService.isDark ? "#ffffff" : "#e7f1ff"
+                    onPreviewChanged: function(v) {
+                        panel.draggingBrightness = true
+                        panel.brightnessPreview = Math.round(v * 100)
+                    }
+                    onCommitRequested: function(v) {
+                        panel.draggingBrightness = false
+                        ControlCenterService.setBrightness(Math.round(v * 100))
+                    }
+                }
+            }
+
+            Item {
+                id: displayTilesSection
+                anchors {
+                    top: displayBrightnessSection.bottom
+                    topMargin: 10
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 14
+                    rightMargin: 14
+                }
+                height: 66
+
+                Row {
+                    anchors.centerIn: parent
+                    spacing: 12
+
+                    Rectangle {
+                        width: 126
+                        height: 60
+                        radius: 14
+                        color: darkTileMouse.containsMouse
+                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
+                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
+                        border.width: 1
+                        border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08)
+
+                        Column {
+                            anchors.centerIn: parent
+                            spacing: 4
+
+                            Image {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                width: 20
+                                height: 20
+                                source: "../../assets/theme-appearance.svg"
+                                sourceSize.width: 40
+                                sourceSize.height: 40
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                rotation: ThemeService.isDark ? 0 : 180
+                                Behavior on rotation { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }
+                                layer.enabled: true
+                                layer.effect: MultiEffect {
+                                    colorization: 1.0
+                                    colorizationColor: ThemeService.foregroundColor
+                                }
+                            }
+
+                            GlassText {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                text: ThemeService.isDark ? "深色模式 (开)" : "深色模式 (关)"
+                                color: ThemeService.foregroundColor
+                                font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                            }
+                        }
+
+                        MouseArea {
+                            id: darkTileMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: ControlCenterService.toggleDarkMode()
+                        }
+                    }
+
+                    Rectangle {
+                        width: 126
+                        height: 60
+                        radius: 14
+                        color: nightTileMouse.containsMouse
+                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
+                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
+                        border.width: 1
+                        border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08)
+
+                        Column {
+                            anchors.centerIn: parent
+                            spacing: 4
+
+                            GlassText {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                text: "🌙"
+                                font.pixelSize: 16
+                            }
+
+                            GlassText {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                text: "夜览 / 护眼"
+                                color: ThemeService.foregroundColor
+                                font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                            }
+                        }
+
+                        MouseArea {
+                            id: nightTileMouse
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                panel.close()
+                                PlatformClient.request("settings.open", { module: "kcm_nightcolor" })
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                height: 38
+
+                Rectangle {
+                    anchors { left: parent.left; right: parent.right; top: parent.top; leftMargin: 12; rightMargin: 12 }
+                    height: 1
+                    color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                }
+
+                GlassText {
+                    anchors { left: parent.left; leftMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "显示器设置…"
+                    color: displaySettingsMouse.containsMouse ? "#0a84ff" : ThemeService.foregroundColor
+                    font { pixelSize: 11; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
+                }
+
+                GlassText {
+                    anchors { right: parent.right; rightMargin: 16; verticalCenter: parent.verticalCenter }
+                    text: "›"
+                    color: ThemeService.foregroundColor
+                    opacity: 0.45
+                    font { pixelSize: 13; weight: Font.Bold }
+                }
+
+                MouseArea {
+                    id: displaySettingsMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        panel.close()
+                        PlatformClient.request("settings.open", { module: "kcm_kscreen" })
                     }
                 }
             }

--- a/shell/desktop/modules/bar/ControlCenterPanel.qml
+++ b/shell/desktop/modules/bar/ControlCenterPanel.qml
@@ -65,6 +65,15 @@ Item {
         coordinator.modalActive = false
     }
 
+    function openSettingsModule(module) {
+        panel.close()
+        PlatformClient.request("settings.open", { module: module }, function(response) {
+            if (!response?.ok) {
+                Quickshell.execDetached(["systemsettings", module])
+            }
+        })
+    }
+
     onNetworkRequested: openSubmenu("wifi")
     onBluetoothRequested: openSubmenu("bluetooth")
 
@@ -1926,10 +1935,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        panel.close()
-                        PlatformClient.request("settings.open", { module: "kcm_networkmanagement" })
-                    }
+                    onClicked: panel.openSettingsModule("kcm_networkmanagement")
                 }
             }
         }
@@ -2161,10 +2167,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        panel.close()
-                        PlatformClient.request("settings.open", { module: "kcm_bluetooth" })
-                    }
+                    onClicked: panel.openSettingsModule("kcm_bluetooth")
                 }
             }
         }
@@ -2408,10 +2411,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        panel.close()
-                        PlatformClient.request("settings.open", { module: "kcm_pulseaudio" })
-                    }
+                    onClicked: panel.openSettingsModule("kcm_pulseaudio")
                 }
             }
         }
@@ -2552,26 +2552,51 @@ Item {
                         width: 126
                         height: 60
                         radius: 14
-                        color: nightTileMouse.containsMouse
-                            ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
-                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
+                        color: {
+                            if (ControlCenterService.nightLightActive) {
+                                return nightTileMouse.containsMouse
+                                    ? (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.28) : Qt.rgba(1, 0.62, 0.04, 0.20))
+                                    : (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.18) : Qt.rgba(1, 0.62, 0.04, 0.12))
+                            }
+                            return nightTileMouse.containsMouse
+                                ? (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.18) : Qt.rgba(0, 0, 0, 0.08))
+                                : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.10) : Qt.rgba(0, 0, 0, 0.04))
+                        }
                         border.width: 1
-                        border.color: ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08)
+                        border.color: ControlCenterService.nightLightActive
+                            ? (ThemeService.isDark ? Qt.rgba(1, 0.62, 0.04, 0.40) : Qt.rgba(1, 0.62, 0.04, 0.30))
+                            : (ThemeService.isDark ? Qt.rgba(1, 1, 1, 0.16) : Qt.rgba(0, 0, 0, 0.08))
+                        Behavior on color { ColorAnimation { duration: 150 } }
+                        Behavior on border.color { ColorAnimation { duration: 150 } }
 
                         Column {
                             anchors.centerIn: parent
                             spacing: 4
 
-                            GlassText {
+                            Image {
                                 anchors.horizontalCenter: parent.horizontalCenter
-                                text: "🌙"
-                                font.pixelSize: 16
+                                width: 20
+                                height: 20
+                                source: "../../assets/night-light.svg"
+                                sourceSize.width: 40
+                                sourceSize.height: 40
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                layer.enabled: true
+                                layer.effect: MultiEffect {
+                                    colorization: 1.0
+                                    colorizationColor: ControlCenterService.nightLightActive
+                                        ? "#ff9f0a"
+                                        : ThemeService.foregroundColor
+                                }
                             }
 
                             GlassText {
                                 anchors.horizontalCenter: parent.horizontalCenter
-                                text: "夜览 / 护眼"
-                                color: ThemeService.foregroundColor
+                                text: ControlCenterService.nightLightActive ? "夜览 (开)" : "夜览 (关)"
+                                color: ControlCenterService.nightLightActive
+                                    ? (ThemeService.isDark ? "#ffb340" : "#d97706")
+                                    : ThemeService.foregroundColor
                                 font { pixelSize: 10; weight: Font.DemiBold; family: "Noto Sans CJK SC" }
                             }
                         }
@@ -2581,10 +2606,7 @@ Item {
                             anchors.fill: parent
                             hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                panel.close()
-                                PlatformClient.request("settings.open", { module: "kcm_nightcolor" })
-                            }
+                            onClicked: ControlCenterService.toggleNightLight()
                         }
                     }
                 }
@@ -2620,10 +2642,7 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        panel.close()
-                        PlatformClient.request("settings.open", { module: "kcm_kscreen" })
-                    }
+                    onClicked: panel.openSettingsModule("kcm_kscreen")
                 }
             }
         }

--- a/shell/desktop/modules/bar/ControlCenterPanel.qml
+++ b/shell/desktop/modules/bar/ControlCenterPanel.qml
@@ -69,7 +69,7 @@ Item {
         panel.close()
         PlatformClient.request("settings.open", { module: module }, function(response) {
             if (!response?.ok) {
-                Quickshell.execDetached(["systemsettings", module])
+                Quickshell.execDetached(["kcmshell6", module])
             }
         })
     }

--- a/shell/desktop/modules/bar/ControlCenterService.qml
+++ b/shell/desktop/modules/bar/ControlCenterService.qml
@@ -12,6 +12,9 @@ QtObject {
     property bool audioAvailable: false
     property int volumePercent: 0
     property bool audioMuted: false
+    property var audioApplications: []
+    property bool audioApplicationsAvailable: false
+    property bool audioApplicationsRefreshInProgress: false
     property bool volumeChangeInProgress: false
     property bool brightnessAvailable: false
     property int brightnessPercent: 0
@@ -89,6 +92,7 @@ QtObject {
                 audioAvailable = false
             }
         })
+        refreshAudioApplications()
         PlatformClient.request("bluetooth.list", {}, function(response) {
             if (response?.ok) {
                 const value = response.result || ({})
@@ -126,6 +130,23 @@ QtObject {
         })
     }
 
+    function refreshAudioApplications() {
+        if (audioApplicationsRefreshInProgress)
+            return
+        audioApplicationsRefreshInProgress = true
+        PlatformClient.request("audio.applications", {}, function(response) {
+            audioApplicationsRefreshInProgress = false
+            if (response?.ok) {
+                const value = response.result || ({})
+                audioApplicationsAvailable = value.available !== false
+                audioApplications = Array.isArray(value.applications) ? value.applications : []
+            } else {
+                audioApplicationsAvailable = false
+                audioApplications = []
+            }
+        })
+    }
+
     function setVolume(percent) {
         const value = Math.round(Math.max(0, Math.min(100, Number(percent) || 0)))
         if (!audioAvailable || volumeChangeInProgress)
@@ -150,6 +171,23 @@ QtObject {
             if (response?.ok)
                 audioMuted = desired
             refresh()
+        })
+        return true
+    }
+
+    function setApplicationVolume(id, percent) {
+        const value = Math.round(Math.max(0, Math.min(150, Number(percent) || 0)))
+        PlatformClient.request("audio.application.set-volume", { id: id, percent: value }, function(response) {
+            if (response?.ok)
+                refreshAudioApplications()
+        })
+        return true
+    }
+
+    function setApplicationMuted(id, muted) {
+        PlatformClient.request("audio.application.set-mute", { id: id, muted: !!muted }, function(response) {
+            if (response?.ok)
+                refreshAudioApplications()
         })
         return true
     }
@@ -324,6 +362,12 @@ QtObject {
         repeat: true
         running: true
         onTriggered: service.refresh()
+    }
+    property Timer audioApplicationsTimer: Timer {
+        interval: 1800
+        repeat: true
+        running: true
+        onTriggered: service.refreshAudioApplications()
     }
     property Connections platformTransport: Connections {
         target: PlatformClient

--- a/shell/desktop/modules/bar/ControlCenterService.qml
+++ b/shell/desktop/modules/bar/ControlCenterService.qml
@@ -37,6 +37,9 @@ QtObject {
     property bool canSuspend: true
     property bool canHibernate: false
     property bool themeChangeInProgress: false
+    property bool nightLightAvailable: true
+    property bool nightLightActive: false
+    property bool nightLightChangeInProgress: false
     signal toggleRequested()
 
     function rebuildHistoryGroups() {
@@ -111,6 +114,14 @@ QtObject {
             } else {
                 brightnessAvailable = false
                 brightnessBacklightName = ""
+            }
+        })
+        PlatformClient.request("nightlight.get", {}, function(response) {
+            if (response?.ok) {
+                const value = response.result || ({})
+                nightLightAvailable = value.available !== false
+                if (!nightLightChangeInProgress)
+                    nightLightActive = !!value.running
             }
         })
     }
@@ -289,6 +300,23 @@ QtObject {
     function toggleDoNotDisturb() {
         doNotDisturbEnabled = !doNotDisturbEnabled
         return doNotDisturbEnabled
+    }
+
+    function toggleNightLight() {
+        if (!nightLightAvailable || nightLightChangeInProgress)
+            return false
+        nightLightChangeInProgress = true
+        nightLightActive = !nightLightActive
+        PlatformClient.request("nightlight.toggle", {}, function(response) {
+            nightLightChangeInProgress = false
+            if (response?.ok) {
+                nightLightActive = !!response.result?.running
+            } else {
+                Quickshell.execDetached(["qdbus6", "org.kde.kglobalaccel", "/component/kwin",
+                    "org.kde.kglobalaccel.Component.invokeShortcut", "Toggle Night Color"])
+            }
+        })
+        return true
     }
 
     property Timer refreshTimer: Timer {

--- a/shell/desktop/modules/bar/SysTray.qml
+++ b/shell/desktop/modules/bar/SysTray.qml
@@ -31,46 +31,35 @@ Item {
     // implicitHeight avoids a height/row-count binding cycle.
     property real availableHeight: 24
     readonly property int itemSize: iconSize + 8
-    // UntypedObjectModel intentionally has no length/get API; Repeater.count
-    // is the supported reactive item count for layout calculations.
-    readonly property int itemCount: trayRepeater.count
-        + (trailingComponents ? trailingComponents.length : 0)
-    readonly property int twoRowThreshold: itemSize * 2
-    readonly property bool twoRows: dockHosted && itemCount > 1
-        && availableHeight >= twoRowThreshold
-    readonly property int rowCount: twoRows ? 2 : 1
-    readonly property real singleRowImplicitWidth: itemCount > 0
-        ? itemCount * itemSize + (itemCount - 1) * iconSpacing : 0
 
-    // ═══════════════════════════════════════════════════════════════
-    // Alt+drag reorder
-    //
-    // Native tray items and the trailing shell cells come from two
-    // different, differently-owned models (SystemTray.items has no array
-    // API to resort; trailingComponents is a fixed literal). Rather than
-    // merging them into one sorted model, every delegate keeps its natural
-    // declaration-order slot for layout purposes and a persisted, purely
-    // visual `transform: Translate` offset carries it to its preferred
-    // slot — at rest as much as while another item is being dragged past
-    // it. Only the actively dragged item ever changes its own base slot,
-    // and only on release, once the reorder is committed.
-    // ═══════════════════════════════════════════════════════════════
+    property int trayRevision: 0
+    function notifyTrayChanged() { trayRevision++ }
 
-    // Native tray items have no stable index of their own outside the
-    // Repeater; a fallback slot key keeps a still-unresolved item from
-    // breaking the key list rather than crashing on a missing id.
+    // Native tray keys are collected only from valid, active delegates so
+    // dead or crashed StatusNotifierItems do not allocate phantom slots.
     readonly property var nativeKeys: {
+        const _rev = root.trayRevision
         const keys = []
         for (let i = 0; i < trayRepeater.count; i++) {
             const item = trayRepeater.itemAt(i)
-            const id = item?.modelData?.id
-            keys.push("tray:" + (id && id.length > 0 ? id : ("#" + i)))
+            if (!item || !item.isValid || !item.trayKey)
+                continue
+            if (keys.indexOf(item.trayKey) < 0)
+                keys.push(item.trayKey)
         }
         return keys
     }
     readonly property var trailingCellKeys: (root.trailingKeys || []).map(key => "cell:" + key)
     readonly property var allKeys: root.nativeKeys.concat(root.trailingCellKeys)
     readonly property var arrangedKeys: SysTrayOrderService.arrange(root.allKeys)
+
+    readonly property int itemCount: root.allKeys.length
+    readonly property int twoRowThreshold: itemSize * 2
+    readonly property bool twoRows: dockHosted && itemCount > 1
+        && availableHeight >= twoRowThreshold
+    readonly property int rowCount: twoRows ? 2 : 1
+    readonly property real singleRowImplicitWidth: itemCount > 0
+        ? itemCount * itemSize + (itemCount - 1) * iconSpacing : 0
 
     // Let the order service see every key as it appears, so an icon that
     // shows up later is recognisably new and lands at the head of the row
@@ -105,6 +94,8 @@ Item {
     property real dragTranslationY: 0
 
     function slotOrigin(flowIndex) {
+        if (flowIndex < 0)
+            return Qt.point(0, 0)
         const rows = Math.max(1, root.rowCount)
         const column = Math.floor(flowIndex / rows)
         const row = flowIndex % rows
@@ -172,15 +163,40 @@ Item {
                 id: trayItem
                 required property var modelData
                 required property int index
-                readonly property string trayKey: root.nativeKeys[index] ?? ("tray:#" + index)
-                readonly property int naturalIndex: index
-                readonly property int targetIndex: root.targetIndexFor(trayKey)
+
+                readonly property bool isValid: Boolean(modelData && (modelData.icon || modelData.id || modelData.title))
+                readonly property string trayKey: {
+                    if (!isValid) return ""
+                    if (modelData.id && modelData.id.length > 0) {
+                        if (modelData.id.indexOf("chrome_status_icon") === 0 && (modelData.tooltipTitle || modelData.title)) {
+                            const sub = (modelData.tooltipTitle || modelData.title).trim().split("\n")[0].slice(0, 20)
+                            return "tray:" + modelData.id + ":" + sub
+                        }
+                        return "tray:" + modelData.id
+                    }
+                    if (modelData.title && modelData.title.length > 0)
+                        return "tray:" + modelData.title
+                    return "tray:#" + index
+                }
+                readonly property int naturalIndex: isValid ? root.allKeys.indexOf(trayKey) : -1
+                readonly property int targetIndex: isValid ? root.targetIndexFor(trayKey) : -1
                 readonly property bool isDraggedItem: root.draggedKey !== ""
                     && root.draggedKey === trayKey
+
+                Connections {
+                    target: trayItem.modelData
+                    function onIdChanged() { root.notifyTrayChanged() }
+                    function onIconChanged() { root.notifyTrayChanged() }
+                    function onTitleChanged() { root.notifyTrayChanged() }
+                    function onTooltipTitleChanged() { root.notifyTrayChanged() }
+                }
+                Component.onCompleted: root.notifyTrayChanged()
+                Component.onDestruction: root.notifyTrayChanged()
+
                 // Shift by exactly one slot when another item's live drag
                 // insertion point is passing over this item's resting slot.
                 readonly property int reorderSlots: {
-                    if (isDraggedItem || root.draggedKey === "" || root.dragInsertIndex < 0)
+                    if (!isValid || isDraggedItem || root.draggedKey === "" || root.dragInsertIndex < 0)
                         return 0
                     const source = root.targetIndexFor(root.draggedKey)
                     const destination = root.dragInsertIndex
@@ -197,8 +213,9 @@ Item {
                 // Dropping it would teleport any item whose arranged slot
                 // differs from its natural one, leaving the icon trailing
                 // the cursor by exactly that gap.
-                readonly property point reorderOffset:
-                    root.reorderOffsetFor(naturalIndex, targetIndex + reorderSlots)
+                readonly property point reorderOffset: isValid
+                    ? root.reorderOffsetFor(naturalIndex, targetIndex + reorderSlots)
+                    : Qt.point(0, 0)
                 property real offsetX: reorderOffset.x + (isDraggedItem ? root.dragTranslationX : 0)
                 property real offsetY: reorderOffset.y + (isDraggedItem ? root.dragTranslationY : 0)
                 Behavior on offsetX {
@@ -214,14 +231,15 @@ Item {
                 scale: isDraggedItem ? 1.08 : 1.0
                 Behavior on scale { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
 
+                visible: isValid
                 x: root.slotOrigin(naturalIndex).x
                 y: root.slotOrigin(naturalIndex).y
-                width: root.itemSize
-                height: root.itemSize
-                readonly property string tooltip: modelData.tooltipTitle
-                    || modelData.title || modelData.id
-                readonly property bool isSymbolicMask: Boolean(modelData.isMask)
-                    || (typeof modelData.icon === "string" && (
+                width: isValid ? root.itemSize : 0
+                height: isValid ? root.itemSize : 0
+                readonly property string tooltip: modelData ? (modelData.tooltipTitle
+                    || modelData.title || modelData.id || "") : ""
+                readonly property bool isSymbolicMask: Boolean(modelData?.isMask)
+                    || (typeof modelData?.icon === "string" && (
                         modelData.icon.indexOf("symbolic") !== -1
                         || modelData.icon.indexOf("-mask") !== -1
                     ))
@@ -394,7 +412,7 @@ Item {
                 readonly property alias loader: trailingLoader
                 readonly property string trayKey: root.trailingCellKeys[index]
                     ?? ("cell:#" + index)
-                readonly property int naturalIndex: trayRepeater.count + index
+                readonly property int naturalIndex: root.allKeys.indexOf(trayKey)
                 readonly property int targetIndex: root.targetIndexFor(trayKey)
                 readonly property bool isDraggedItem: root.draggedKey !== ""
                     && root.draggedKey === trayKey

--- a/shell/desktop/modules/bar/SysTrayOrderService.qml
+++ b/shell/desktop/modules/bar/SysTrayOrderService.qml
@@ -30,29 +30,53 @@ QtObject {
     // has never seen are new arrivals: a native tray icon takes the leading
     // slots, so an app launched now shows up at the left edge of the row
     // rather than behind the shell's own cells, while an unrecognised shell
-    // cell stays at the tail where it is declared. On a first run nothing is
-    // known yet, so this reduces to the natural declaration order.
+    // cell stays at the tail where it is declared.
+    //
+    // Partitioning guarantees third-party tray icons stay strictly to the
+    // left of the shell's own system control cells, with controlcenter as
+    // the fixed trailing anchor at the rightmost edge.
     function arrange(keys) {
-        const known = []
-        const seen = ({})
+        const liveTrayKeys = (keys || []).filter(k => svc.isTrayKey(k))
+        const liveCellKeys = (keys || []).filter(k => !svc.isTrayKey(k))
+
+        // 1. Arrange native tray keys according to saved preference
+        const knownTray = []
+        const seenTray = ({})
         for (let i = 0; i < svc.order.length; i++) {
             const key = svc.order[i]
-            if (keys.indexOf(key) >= 0 && !seen[key]) {
-                known.push(key)
-                seen[key] = true
+            if (svc.isTrayKey(key) && liveTrayKeys.indexOf(key) >= 0 && !seenTray[key]) {
+                knownTray.push(key)
+                seenTray[key] = true
             }
         }
-        const head = keys.filter(key => !seen[key] && svc.isTrayKey(key))
-        const tail = keys.filter(key => !seen[key] && !svc.isTrayKey(key))
-        return head.concat(known, tail)
+        const unseenTray = liveTrayKeys.filter(k => !seenTray[k])
+        const arrangedTray = unseenTray.concat(knownTray)
+
+        // 2. Arrange shell control cells according to saved preference
+        const knownCell = []
+        const seenCell = ({})
+        for (let i = 0; i < svc.order.length; i++) {
+            const key = svc.order[i]
+            if (!svc.isTrayKey(key) && liveCellKeys.indexOf(key) >= 0 && !seenCell[key]) {
+                knownCell.push(key)
+                seenCell[key] = true
+            }
+        }
+        const unseenCell = liveCellKeys.filter(k => !seenCell[k])
+        const arrangedCell = knownCell.concat(unseenCell)
+
+        // Pin cell:controlcenter as the permanent rightmost trailing anchor
+        const ccIndex = arrangedCell.indexOf("cell:controlcenter")
+        if (ccIndex >= 0 && ccIndex !== arrangedCell.length - 1) {
+            arrangedCell.splice(ccIndex, 1)
+            arrangedCell.push("cell:controlcenter")
+        }
+
+        return arrangedTray.concat(arrangedCell)
     }
 
     // Folds keys the saved order has never seen into it — tray icons at the
-    // head, shell cells at the tail, matching arrange(). Recording a key on
-    // sight rather than only when it is dragged is what lets "new" mean
-    // "never seen before": without it every never-reordered icon stays
-    // unknown, and the one that just appeared would sort among them in
-    // SystemTray's own append order, i.e. last instead of first.
+    // head of the tray section, shell cells at the tail of the cell section.
     function register(keys) {
         if (!svc.ready)
             return
@@ -73,7 +97,9 @@ QtObject {
         }
         if (head.length === 0 && tail.length === 0)
             return
-        svc.order = head.concat(svc.order, tail)
+        const currentTray = svc.order.filter(k => svc.isTrayKey(k))
+        const currentCell = svc.order.filter(k => !svc.isTrayKey(k))
+        svc.order = head.concat(currentTray, currentCell, tail)
         scheduleSave()
     }
 
@@ -85,7 +111,26 @@ QtObject {
         const sourceIndex = arranged.indexOf(key)
         if (sourceIndex < 0)
             return
-        const destination = Math.max(0, Math.min(arranged.length - 1, Math.round(targetIndex)))
+
+        // Control Center is pinned to the far right trailing edge
+        if (key === "cell:controlcenter")
+            return
+
+        const trayCount = arranged.filter(k => svc.isTrayKey(k)).length
+        let minDest = 0
+        let maxDest = arranged.length - 1
+
+        if (svc.isTrayKey(key)) {
+            // Tray items can only be reordered within the tray section
+            minDest = 0
+            maxDest = Math.max(0, trayCount - 1)
+        } else {
+            // Shell cells can only be reordered within the cells section
+            minDest = trayCount
+            maxDest = Math.max(minDest, arranged.length - 2)
+        }
+
+        const destination = Math.max(minDest, Math.min(maxDest, Math.round(targetIndex)))
         if (sourceIndex === destination)
             return
         const moved = arranged.splice(sourceIndex, 1)[0]
@@ -129,8 +174,12 @@ QtObject {
             if (code === 0 && output) {
                 try {
                     const obj = JSON.parse(output)
-                    if (Array.isArray(obj.order))
-                        svc.order = obj.order.filter(key => typeof key === "string")
+                    if (Array.isArray(obj.order)) {
+                        const raw = obj.order.filter(key => typeof key === "string")
+                        const trayPart = raw.filter(k => svc.isTrayKey(k))
+                        const cellPart = raw.filter(k => !svc.isTrayKey(k))
+                        svc.order = trayPart.concat(cellPart)
+                    }
                 } catch (e) {
                     console.warn("[SysTrayOrder] parse error: " + e)
                 }


### PR DESCRIPTION
## Summary

This PR implements macOS-style secondary navigation menus, individual per-application audio mixing, night light quick-toggle, and strict system tray partitioning:

1. **Native macOS-style Submenus**:
   - Implemented native slide-in submenus inside Control Center for Wi-Fi, Bluetooth, and Sound with back navigation breadcrumbs.
   - Wi-Fi submenu displays available networks and active connection status.
   - Bluetooth submenu displays paired/available devices with direct connect toggles.
   - Sound submenu provides output device selection and per-app volume mixer.

2. **PipeWire / PulseAudio Per-App Audio Mixer**:
   - Integrated `PlatformServer` with PulseAudio/PipeWire sink-input queries.
   - Dynamically displays currently playing audio applications with independent volume sliders (0%–150%) and mute toggles.

3. **Display & Night Light Polish**:
   - Simplified Display card into a direct brightness slider.
   - Added a 52×52 circular "Night Light" tile next to Do Not Disturb with warm amber (`#ff9f0a`) highlight and immediate color temperature transition (3500K).
   - Unified the top control row into a clean, uniform 5-circle grid.
   - Settings buttons now invoke `kcmshell6` directly to prevent launch dropouts.

4. **Bar Tray Partitioning & Ghost Slot Filtering**:
   - Filtered out empty / dead StatusNotifierItem tray slots.
   - Enforced strict partitioning in `SysTrayOrderService` to anchor the Control Center toggle permanently at the far right.

5. **Test Verification**:
   - Validated against `shared/qml/test_visual_contract.mjs` (all checks passed).