### PR TITLE
fix(kwin): build against both KWin 6.6 and 6.7 APIs

### DIFF
--- a/integrations/kwin/dock-window-animation/CMakeLists.txt
+++ b/integrations/kwin/dock-window-animation/CMakeLists.txt
@@ -30,6 +30,31 @@ target_link_libraries(kos_dock_window_animation PRIVATE
     KWin::kwin
 )
 
+# Since KWin 6.7 (master), presentTime was dropped from the prePaintScreen /
+# prePaintWindow hooks and TimeLine::advance(RenderView*) replaced
+# TimeLine::advance(std::chrono::milliseconds). Detect which API the installed
+# KWin headers provide so the effect builds on both 6.6.x and 6.7+.
+set(_kwin_effecthandler "")
+get_target_property(_kwin_include_dirs KWin::kwin INTERFACE_INCLUDE_DIRECTORIES)
+foreach(_dir ${_kwin_include_dirs})
+    if(EXISTS "${_dir}/effect/effecthandler.h")
+        set(_kwin_effecthandler "${_dir}/effect/effecthandler.h")
+        break()
+    endif()
+endforeach()
+if(NOT _kwin_effecthandler AND EXISTS "/usr/include/kwin/effect/effecthandler.h")
+    set(_kwin_effecthandler "/usr/include/kwin/effect/effecthandler.h")
+endif()
+if(_kwin_effecthandler)
+    file(READ "${_kwin_effecthandler}" _kwin_effecthandler_src)
+    if(_kwin_effecthandler_src MATCHES "prePaintScreen\\(ScreenPrePaintData[^;]*std::chrono::milliseconds")
+        message(STATUS "KWin API: prePaint hooks take presentTime (6.6-style)")
+        target_compile_definitions(kos_dock_window_animation PRIVATE KOS_KWIN_PAINT_TIME_API)
+    else()
+        message(STATUS "KWin API: prePaint hooks without presentTime (6.7-style)")
+    endif()
+endif()
+
 install(TARGETS kos_dock_window_animation
     DESTINATION ${KDE_INSTALL_PLUGINDIR}/kwin/effects/plugins
     COMPONENT kwin_plugins)

--- a/integrations/kwin/dock-window-animation/dockwindowanimationeffect.cpp
+++ b/integrations/kwin/dock-window-animation/dockwindowanimationeffect.cpp
@@ -640,6 +640,18 @@ void DockWindowAnimationEffect::apply(EffectWindow *window, int mask,
         applyDockMorph(window, *it, quads);
 }
 
+#ifdef KOS_KWIN_PAINT_TIME_API
+void DockWindowAnimationEffect::prePaintScreen(ScreenPrePaintData &data,
+                                               std::chrono::milliseconds presentTime)
+{
+    // Match KWin's Magic Lamp exactly. Minimize/unminimize signals can arrive
+    // on a paint-cycle boundary; setting this only after m_animations becomes
+    // non-empty leaves that boundary frame with a partial damage region and
+    // can expose wallpaper blocks or tearing at animation start/end.
+    data.mask |= PAINT_SCREEN_WITH_TRANSFORMED_WINDOWS;
+    effects->prePaintScreen(data, presentTime);
+}
+#else
 void DockWindowAnimationEffect::prePaintScreen(ScreenPrePaintData &data)
 {
     // Match KWin's Magic Lamp exactly. Minimize/unminimize signals can arrive
@@ -649,7 +661,22 @@ void DockWindowAnimationEffect::prePaintScreen(ScreenPrePaintData &data)
     data.mask |= PAINT_SCREEN_WITH_TRANSFORMED_WINDOWS;
     effects->prePaintScreen(data);
 }
+#endif
 
+#ifdef KOS_KWIN_PAINT_TIME_API
+void DockWindowAnimationEffect::prePaintWindow(RenderView *view,
+                                                EffectWindow *window,
+                                                WindowPrePaintData &data,
+                                                std::chrono::milliseconds presentTime)
+{
+    auto it = m_animations.find(window);
+    if (it != m_animations.end()) {
+        it->timeLine.advance(presentTime);
+        data.setTransformed();
+    }
+    effects->prePaintWindow(view, window, data, presentTime);
+}
+#else
 void DockWindowAnimationEffect::prePaintWindow(RenderView *view,
                                                 EffectWindow *window,
                                                 WindowPrePaintData &data)
@@ -661,6 +688,7 @@ void DockWindowAnimationEffect::prePaintWindow(RenderView *view,
     }
     effects->prePaintWindow(view, window, data);
 }
+#endif
 
 void DockWindowAnimationEffect::postPaintScreen()
 {

--- a/integrations/kwin/dock-window-animation/dockwindowanimationeffect.h
+++ b/integrations/kwin/dock-window-animation/dockwindowanimationeffect.h
@@ -23,9 +23,16 @@ public:
     ~DockWindowAnimationEffect() override;
 
     void reconfigure(ReconfigureFlags flags) override;
+#ifdef KOS_KWIN_PAINT_TIME_API
+    void prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
+    void prePaintWindow(RenderView *view, EffectWindow *window,
+                        WindowPrePaintData &data,
+                        std::chrono::milliseconds presentTime) override;
+#else
     void prePaintScreen(ScreenPrePaintData &data) override;
     void prePaintWindow(RenderView *view, EffectWindow *window,
                         WindowPrePaintData &data) override;
+#endif
     void postPaintScreen() override;
     bool isActive() const override;
 

--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -540,6 +540,7 @@ void BlurEffect::updateBlurRegion(EffectWindow *w)
         // an application that paints nothing gets the full pane.
 #ifndef GLASS_X11
         if (SurfaceInterface *surface = w->surface()) {
+#ifdef GLASS_KWIN_67
             const RegionF opaque = surface->opaque();
             if (!opaque.isEmpty()) {
                 // surface->opaque() is surface-local; contentsRect() places the
@@ -551,6 +552,19 @@ void BlurEffect::updateBlurRegion(EffectWindow *w)
                 }
                 glass -= opaqueInFrame;
             }
+#else
+            const Region opaque = surface->opaque();
+            if (!opaque.isEmpty()) {
+                // surface->opaque() is surface-local; contentsRect() places the
+                // client area inside the frame the region above is built in.
+                const QPoint clientOffset = w->contentsRect().topLeft().toPoint();
+                Region opaqueInFrame;
+                for (const Rect &rect : opaque.rects()) {
+                    opaqueInFrame += rect.translated(clientOffset);
+                }
+                glass -= opaqueInFrame;
+            }
+#endif
         }
 #endif
 


### PR DESCRIPTION
# fix(kwin): build against both KWin 6.6 and 6.7 APIs

## 问题

KWin 集成插件目前按 **KWin 6.7（master）** 的 API 编写，在仍提供旧 API 的 KWin 6.6.x（如 Ubuntu 26.04 的 kwin 6.6.6）上无法编译，默认配置直接失败：

1. `dock-window-animation`：
   - `prePaintScreen` / `prePaintWindow` 在 6.6 的签名带 `std::chrono::milliseconds presentTime`，6.7 已移除
   - `TimeLine::advance` 在 6.6 接受 `std::chrono::milliseconds`，6.7 是 `advance(const RenderView*)`
2. vendored `kwin-effects-glass`：`SurfaceInterface::opaque()` 在 6.6 返回 `Region`，6.7 返回 `RegionF`。`blurRegion` 路径已有 `GLASS_KWIN_67` 守卫，但 `opaque` 扣除那段漏了守卫

## 方案

- **dock-window-animation**：CMake 配置阶段从 `KWin::kwin` 的 include 目录解析 `effect/effecthandler.h`，用正则检测 `prePaintScreen(ScreenPrePaintData… std::chrono::milliseconds` 是否存在，据此定义 `KOS_KWIN_PAINT_TIME_API`；源码用 `#ifdef` 提供两套签名与 `TimeLine::advance` 调用。6.6 分支的写法对齐 KDE 6.6.6 自带的 MagicLamp 特效（`timeLine.advance(presentTime)` + 调用链多传 `presentTime`）
- **kwin-effects-glass**：沿用项目现有的 `GLASS_KWIN_67` 宏，给 `opaque` 段补上 6.6 分支（迭代 `Region::rects()` 并对每个 `Rect` 做 `translated()`）

## 验证

- Ubuntu 26.04（kwin 6.6.6）：默认配置全量构建通过，三个 KWin 插件 + glass + 装饰均编译链接成功
- 6.7/Arch 环境：宏未定义时走原有代码路径，行为无变化（API 检测对 KWin master 头文件返回 6.7 分支）

## 附注

这是在 Ubuntu 26.04 实机迁移 KOS 时发现的；相关的依赖清单与 Ubuntu 适配讨论见 issue（提完 PR 后补链接）。
