### PR TITLE
docs: add Ubuntu 26.04 (resolute) dependency guide

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,6 +46,60 @@ must be listed explicitly. KWin also exports Wayland, libdrm, and libepoxy
 development interfaces, but those are hard dependencies of Arch's `kwin`
 package and do not need to be repeated here.
 
+### Ubuntu 26.04 (resolute)
+
+`kosctl` installs missing build packages automatically on Arch and NixOS only.
+On Ubuntu, install them manually. The list below has been verified with a full
+default build on 26.04.
+
+Quickshell 0.3.x is not in the Ubuntu archive yet; use the PPA recommended by
+the [Quickshell documentation](https://quickshell.org/docs/), which provides a
+`resolute` series:
+
+```sh
+sudo add-apt-repository ppa:avengemedia/danklinux
+sudo apt update
+sudo apt install quickshell
+```
+
+Core and KWin plugin build dependencies:
+
+```sh
+sudo apt install \
+  git cmake ninja-build g++ golang-go \
+  qt6-base-dev qt6-declarative-dev \
+  libkf6windowsystem-dev libkf6iconthemes-dev libkf6globalaccel-dev \
+  extra-cmake-modules kwin-dev libkf6config-dev libkf6i18n-dev \
+  libkf6guiaddons-dev libkf6kcmutils-dev libkf6coreaddons-dev \
+  libkdecorations3-dev gettext libvulkan-dev libplasma-dev \
+  libkf6kio-dev libkf6calendarcore-dev \
+  libxcb1-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-res0-dev \
+  libxcb-shm0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-damage0-dev \
+  libxcb-render0-dev libxcb-shape0-dev libxcb-cursor-dev \
+  libxcb-keysyms1-dev libxcb-icccm4-dev libxcb-image0-dev \
+  libxcb-util-dev libxkbcommon-x11-dev
+```
+
+Optional runtime integrations (mirroring the Arch list above):
+
+```sh
+sudo apt install \
+  network-manager wireplumber bluez brightnessctl \
+  wl-clipboard cliphist xdg-utils kde-spectacle \
+  libglib2.0-0 qml6-module-qtquick-dialogs libqt6sql6-sqlite
+```
+
+Key naming differences versus Arch: `kdecoration` is `libkdecorations3-dev`,
+`vulkan-headers` is `libvulkan-dev`, and `spectacle` is `kde-spectacle`.
+Also note: `libplasma-dev` provides `Plasma/plasma_version.h` used by the
+glass effect; `libkf6kio-dev` and `libkf6calendarcore-dev` are direct CMake
+dependencies of the platform service and Settings (on Arch they arrive
+through the dependency chain); the xcb extension headers required by KWin's
+exported headers (composite, randr, res, shm, sync) are not pulled in by
+`kwin-dev` and must be installed explicitly; `qml6-module-qtquick-dialogs`
+and `libqt6sql6-sqlite` are runtime dependencies of QuickDialogs2 and the
+data service.
+
 Calendar, Todo, Weather, and Music are separate optional applications and are
 not built by `kosctl install`. They have additional Qt/KF6, GStreamer, TagLib,
 or Go dependencies; read [apps/README.md](apps/README.md) and each app's own

--- a/README.md
+++ b/README.md
@@ -41,6 +41,57 @@ sudo pacman -S --needed \
 `vulkan-headers`，因此这里必须显式列出。KWin 同时需要 Wayland、libdrm 和
 libepoxy 的开发文件，但这些已是 Arch `kwin` 包的硬依赖，无需重复安装。
 
+### Ubuntu 26.04 (resolute)
+
+`kosctl` 的自动依赖安装目前仅在 Arch 与 NixOS 上生效；Ubuntu 用户请手动安装
+对应软件包（以下清单已在 26.04 上完成全量构建验证）。
+
+Quickshell 0.3.x 尚未进入 Ubuntu 官方仓库，可使用
+[Quickshell 官方文档](https://quickshell.org/docs/)推荐的 PPA（已提供
+resolute 软件源）：
+
+```sh
+sudo add-apt-repository ppa:avengemedia/danklinux
+sudo apt update
+sudo apt install quickshell
+```
+
+基础与 KWin 插件构建依赖：
+
+```sh
+sudo apt install \
+  git cmake ninja-build g++ golang-go \
+  qt6-base-dev qt6-declarative-dev \
+  libkf6windowsystem-dev libkf6iconthemes-dev libkf6globalaccel-dev \
+  extra-cmake-modules kwin-dev libkf6config-dev libkf6i18n-dev \
+  libkf6guiaddons-dev libkf6kcmutils-dev libkf6coreaddons-dev \
+  libkdecorations3-dev gettext libvulkan-dev libplasma-dev \
+  libkf6kio-dev libkf6calendarcore-dev \
+  libxcb1-dev libxcb-composite0-dev libxcb-randr0-dev libxcb-res0-dev \
+  libxcb-shm0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-damage0-dev \
+  libxcb-render0-dev libxcb-shape0-dev libxcb-cursor-dev \
+  libxcb-keysyms1-dev libxcb-icccm4-dev libxcb-image0-dev \
+  libxcb-util-dev libxkbcommon-x11-dev
+```
+
+运行时集成（可选，与上文 Arch 清单对应）：
+
+```sh
+sudo apt install \
+  network-manager wireplumber bluez brightnessctl \
+  wl-clipboard cliphist xdg-utils kde-spectacle \
+  libglib2.0-0 qml6-module-qtquick-dialogs libqt6sql6-sqlite
+```
+
+与 Arch 包名的主要差异：`kdecoration` 对应 `libkdecorations3-dev`，
+`vulkan-headers` 对应 `libvulkan-dev`，`spectacle` 对应 `kde-spectacle`。
+另外需要注意：`libplasma-dev` 提供 glass 特效引用的 `Plasma/plasma_version.h`；
+`libkf6kio-dev`、`libkf6calendarcore-dev` 是平台服务与设置应用 CMake 的直接
+依赖（Arch 上由依赖链自动带入）；KWin 导出所需的 xcb 扩展开发头文件
+（composite、randr、res、shm、sync）不会被 `kwin-dev` 自动带入，需显式安装；
+`qml6-module-qtquick-dialogs` 与 `libqt6sql6-sqlite` 是 QuickDialogs2 和
+数据服务的运行时依赖。
+
 Calendar、Todo、Weather 和 Music 是独立的可选应用，不由 `kosctl install` 构建；
 它们需要额外的 Qt/KF6、GStreamer、TagLib 或 Go 依赖。安装前请阅读
 [apps/README.zh-CN.md](apps/README.zh-CN.md) 及各应用目录的说明，再运行


### PR DESCRIPTION
# docs: add Ubuntu 26.04 (resolute) dependency guide

Follow-up to #46 and the author's request in
[#46 (comment)](https://github.com/SuceV587/NextKde/issues/46#issuecomment-5627929634).

`kosctl` 的自动依赖安装目前仅覆盖 Arch 与 NixOS。本 PR 在两个 README 的
「准备环境」小节中新增 Ubuntu 26.04 (resolute) 小节，给出 Debian 系发行版
手动安装的对应包名，让该平台的用户也能完成默认构建。

## 内容

- **Quickshell 安装**：官方文档推荐的 PPA `ppa:avengemedia/danklinux`
  （已提供 resolute 软件源）
- **apt 包名对照**：基础构建、KWin 插件构建、可选运行时三组，已在
  Ubuntu 26.04.1 / KWin 6.6.6 上完成全量默认构建验证（含 KWin 插件与
  glass 特效）
- **命名差异提示**：
  - `kdecoration` → `libkdecorations3-dev`
  - `vulkan-headers` → `libvulkan-dev`
  - `spectacle` → `kde-spectacle`
- **Arch 清单覆盖不到的额外包**（在 Arch 上由依赖链自动带入）：
  - `libplasma-dev`（glass 引用 `Plasma/plasma_version.h`）
  - `libkf6kio-dev`、`libkf6calendarcore-dev`（平台服务与设置应用的 CMake 直接依赖）
  - KWin 导出所需的 xcb 扩展开发头文件（composite、randr、res、shm、sync），
    `kwin-dev` 不会自动带入
  - 运行时：`qml6-module-qtquick-dialogs`、`libqt6sql6-sqlite`

双语改动（README.md / README.en.md 各一节），不影响 Arch/NixOS 既有说明。
