### PR TITLE
feat: 新增柔光玻璃与轻透磨砂两套玻璃材质风格

### DIFF
--- a/apps/settings/main.qml
+++ b/apps/settings/main.qml
@@ -60,11 +60,7 @@ ApplicationWindow {
     }
     readonly property var contentByPage: [
         {
-            subtitle: "显示",
-            groups: []
-        },
-        {
-            subtitle: "主题",
+            subtitle: "外观",
             groups: []
         },
         {
@@ -1347,281 +1343,6 @@ ApplicationWindow {
         }
     }
 
-    component DisplaySettingsPage: ColumnLayout {
-        id: displayPage
-
-        Layout.fillWidth: true
-        spacing: 7
-
-        property var bridge: (typeof settingsBridge !== "undefined")
-            ? settingsBridge : null
-        property real blurStrength: 0.42
-        property real liquidStrength: 1.0
-        property bool blurDirty: false
-        property bool liquidDirty: false
-        property string errorText: ""
-
-        function percentage(value) {
-            return Math.round(value * 100) + "%"
-        }
-
-        function applyState(state) {
-            if (!state)
-                return
-            const rawBlur = state.globalBlurStrength !== undefined
-                ? state.globalBlurStrength : state.blurStrength
-            const rawLiquid = state.globalLiquidStrength !== undefined
-                ? state.globalLiquidStrength : state.liquidStrength
-            if (rawBlur === undefined || rawLiquid === undefined)
-                return
-            blurStrength = Math.max(0, Math.min(1, Number(rawBlur)))
-            liquidStrength = Math.max(0, Math.min(1, Number(rawLiquid)))
-            blurDirty = false
-            liquidDirty = false
-            errorText = ""
-        }
-
-        function refresh() {
-            if (!bridge) {
-                errorText = "尚未构建 Settings 桥接程序"
-                return
-            }
-            applyState(bridge.appearanceSnapshot())
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        Timer {
-            id: liveBlurDebounce
-            interval: 60
-            repeat: false
-            onTriggered: {
-                if (displayPage.bridge && displayPage.blurDirty) {
-                    displayPage.bridge.updateGlobalBlurStrength(displayPage.blurStrength)
-                }
-            }
-        }
-
-        Timer {
-            id: liveLiquidDebounce
-            interval: 60
-            repeat: false
-            onTriggered: {
-                if (displayPage.bridge && displayPage.liquidDirty) {
-                    displayPage.bridge.updateGlobalLiquidStrength(displayPage.liquidStrength)
-                }
-            }
-        }
-
-        function previewBlur(value) {
-            const clamped = Math.max(0, Math.min(1, value))
-            if (Math.abs(blurStrength - clamped) < 0.005)
-                return
-            blurStrength = clamped
-            blurDirty = true
-            liveBlurDebounce.restart()
-        }
-
-        function commitBlur() {
-            liveBlurDebounce.stop()
-            if (!blurDirty || !bridge)
-                return
-            blurDirty = false
-            applyState(bridge.updateGlobalBlurStrength(blurStrength))
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        function previewLiquid(value) {
-            const clamped = Math.max(0, Math.min(1, value))
-            if (Math.abs(liquidStrength - clamped) < 0.005)
-                return
-            liquidStrength = clamped
-            liquidDirty = true
-            liveLiquidDebounce.restart()
-        }
-
-        function commitLiquid() {
-            liveLiquidDebounce.stop()
-            if (!liquidDirty || !bridge)
-                return
-            liquidDirty = false
-            applyState(bridge.updateGlobalLiquidStrength(liquidStrength))
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        function setSystemAppearance(index) {
-            if (!bridge) {
-                errorText = "尚未构建 Settings 桥接程序"
-                return
-            }
-            if (!bridge.applySystemAppearance(index === 1)) {
-                errorText = bridge.lastError
-                return
-            }
-            errorText = ""
-        }
-
-        Component.onCompleted: refresh()
-
-        Text {
-            text: "系统外观".toUpperCase()
-            color: theme.secondaryText
-            font.pixelSize: 12
-            font.weight: Font.DemiBold
-            Layout.leftMargin: 13
-        }
-
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: 54
-            radius: 18
-            color: theme.card
-
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 16
-                anchors.rightMargin: 16
-                spacing: 12
-
-                SettingIcon { symbol: "◐"; tint: "#5ac8fa" }
-                Text {
-                    text: "色彩模式"
-                    color: theme.primaryText
-                    font.pixelSize: 15
-                    font.weight: Font.DemiBold
-                }
-                Item { Layout.fillWidth: true }
-                SettingsNavBar {
-                    id: systemAppearanceNavBar
-                    model: [
-                        { id: "light", label: "明亮" },
-                        { id: "dark", label: "暗色" }
-                    ]
-                    currentIndex: theme.dark ? 1 : 0
-                    onSelectionChanged: function(index) {
-                        displayPage.setSystemAppearance(index)
-                    }
-                }
-            }
-        }
-
-        Text {
-            text: "液态玻璃".toUpperCase()
-            color: theme.secondaryText
-            font.pixelSize: 12
-            font.weight: Font.DemiBold
-            Layout.leftMargin: 13
-        }
-
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: 97
-            radius: 18
-            color: theme.card
-
-            Column {
-                anchors.fill: parent
-
-                Item {
-                    width: parent.width
-                    height: 48
-
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 16
-                        anchors.rightMargin: 16
-                        spacing: 12
-
-                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
-                        Text {
-                            text: "模糊强度"
-                            color: theme.primaryText
-                            font.pixelSize: 14
-                        }
-                        Item { Layout.fillWidth: true }
-                        Text {
-                            text: displayPage.percentage(displayPage.blurStrength)
-                            color: theme.secondaryText
-                            font.pixelSize: 12
-                            Layout.preferredWidth: 38
-                            horizontalAlignment: Text.AlignRight
-                        }
-                        LiquidControls.LiquidSlider {
-                            Layout.preferredWidth: 190
-                            value: displayPage.blurStrength
-                            trackColor: theme.divider
-                            onPreviewChanged: function(position) {
-                                displayPage.previewBlur(position)
-                            }
-                            onCommitRequested: displayPage.commitBlur()
-                        }
-                    }
-                }
-
-                Rectangle {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.leftMargin: 53
-                    height: 1
-                    color: theme.separator
-                }
-
-                Item {
-                    width: parent.width
-                    height: 48
-
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 16
-                        anchors.rightMargin: 16
-                        spacing: 12
-
-                        SettingIcon { symbol: "≈"; tint: "#af52de" }
-                        Text {
-                            text: "液态强度"
-                            color: theme.primaryText
-                            font.pixelSize: 14
-                        }
-                        Item { Layout.fillWidth: true }
-                        Text {
-                            text: displayPage.percentage(displayPage.liquidStrength)
-                            color: theme.secondaryText
-                            font.pixelSize: 12
-                            Layout.preferredWidth: 38
-                            horizontalAlignment: Text.AlignRight
-                        }
-                        LiquidControls.LiquidSlider {
-                            Layout.preferredWidth: 190
-                            value: displayPage.liquidStrength
-                            trackColor: theme.divider
-                            onPreviewChanged: function(position) {
-                                displayPage.previewLiquid(position)
-                            }
-                            onCommitRequested: displayPage.commitLiquid()
-                        }
-                    }
-                }
-            }
-        }
-
-        IconAppearanceSection {
-            bridge: displayPage.bridge
-        }
-
-        Text {
-            Layout.fillWidth: true
-            Layout.leftMargin: 13
-            Layout.rightMargin: 13
-            visible: displayPage.errorText.length > 0
-            text: displayPage.errorText
-            color: "#ff453a"
-            font.pixelSize: 12
-            wrapMode: Text.Wrap
-        }
-    }
-
     component IconAppearanceSection: ColumnLayout {
         id: iconAppearance
 
@@ -1826,8 +1547,51 @@ ApplicationWindow {
         property var bridge: (typeof settingsBridge !== "undefined")
             ? settingsBridge : null
         property string shellStyle: "macos"
+        property string materialStyle: "liquid"
+        property real blurStrength: 0.42
+        property real liquidStrength: 1.0
+        property bool blurDirty: false
+        property bool liquidDirty: false
         property string dockWindowAnimationStyle: "scale"
         property string errorText: ""
+        property string tuningErrorText: ""
+        // 材质微调（柔光玻璃 / 轻透磨砂）——只在对应材质下写入生效
+        property real bionicRefract: 4.0
+        property real bionicEdgeLight: 1.4
+        property real bionicSoftEdgePx: 1.5
+        property real bionicHsvv: 1.0
+        property real classicRefract: 1.5
+        property real classicReflect: 0.06
+        property real classicEdgeLight: 0.1
+        property real classicSoftEdgePx: 1.5
+        property real bionicTransparency: 1.0
+        property real bionicRefractMin: 1.0
+        property real bionicRefractMax: 5.0
+        property real bionicEdgeLightMin: 0.0
+        property real bionicEdgeLightMax: 3.0
+        property real bionicSoftEdgePxMin: 0.1
+        property real bionicSoftEdgePxMax: 25.0
+        property real bionicHsvvMin: 0.0
+        property real bionicHsvvMax: 2.0
+        property real bionicTransparencyMin: 0.0
+        property real bionicTransparencyMax: 1.0
+        property real classicRefractMin: 1.0
+        property real classicRefractMax: 2.0
+        property real classicReflectMin: 0.0
+        property real classicReflectMax: 1.5
+        property real classicEdgeLightMin: 0.0
+        property real classicEdgeLightMax: 0.5
+        property real classicSoftEdgePxMin: 0.5
+        property real classicSoftEdgePxMax: 25.0
+        property real bionicRefractPreview: -1
+        property real bionicEdgeLightPreview: -1
+        property real bionicSoftEdgePxPreview: -1
+        property real bionicHsvvPreview: -1
+        property real bionicTransparencyPreview: -1
+        property real classicRefractPreview: -1
+        property real classicReflectPreview: -1
+        property real classicEdgeLightPreview: -1
+        property real classicSoftEdgePxPreview: -1
         readonly property var styles: [
             {
                 id: "windows12",
@@ -1862,10 +1626,253 @@ ApplicationWindow {
             if (!state || !isValidStyle(state.shellStyle))
                 return
             shellStyle = state.shellStyle
+            if (state.materialStyle === "liquid" || state.materialStyle === "bionic"
+                    || state.materialStyle === "classic")
+                materialStyle = state.materialStyle
             if (isValidDockWindowAnimationStyle(state.dockWindowAnimationStyle))
                 dockWindowAnimationStyle = state.dockWindowAnimationStyle
+            if (isFinite(state.globalBlurStrength))
+                blurStrength = Math.max(0, Math.min(1, Number(state.globalBlurStrength)))
+            if (isFinite(state.globalLiquidStrength))
+                liquidStrength = Math.max(0, Math.min(1, Number(state.globalLiquidStrength)))
+            // 材质微调字段
+            if (isFinite(state.bionicRefract)) bionicRefract = state.bionicRefract
+            if (isFinite(state.bionicEdgeLight)) bionicEdgeLight = state.bionicEdgeLight
+            if (isFinite(state.bionicSoftEdgePx)) bionicSoftEdgePx = state.bionicSoftEdgePx
+            if (isFinite(state.bionicHsvv)) bionicHsvv = state.bionicHsvv
+            if (isFinite(state.bionicTransparency)) bionicTransparency = state.bionicTransparency
+            if (isFinite(state.bionicTransparencyMin)) bionicTransparencyMin = state.bionicTransparencyMin
+            if (isFinite(state.bionicTransparencyMax)) bionicTransparencyMax = state.bionicTransparencyMax
+            if (isFinite(state.classicRefract)) classicRefract = state.classicRefract
+            if (isFinite(state.classicReflect)) classicReflect = state.classicReflect
+            if (isFinite(state.classicEdgeLight)) classicEdgeLight = state.classicEdgeLight
+            if (isFinite(state.classicSoftEdgePx)) classicSoftEdgePx = state.classicSoftEdgePx
+            if (isFinite(state.bionicRefractMin)) bionicRefractMin = state.bionicRefractMin
+            if (isFinite(state.bionicRefractMax)) bionicRefractMax = state.bionicRefractMax
+            if (isFinite(state.bionicEdgeLightMin)) bionicEdgeLightMin = state.bionicEdgeLightMin
+            if (isFinite(state.bionicEdgeLightMax)) bionicEdgeLightMax = state.bionicEdgeLightMax
+            if (isFinite(state.bionicSoftEdgePxMin)) bionicSoftEdgePxMin = state.bionicSoftEdgePxMin
+            if (isFinite(state.bionicSoftEdgePxMax)) bionicSoftEdgePxMax = state.bionicSoftEdgePxMax
+            if (isFinite(state.bionicHsvvMin)) bionicHsvvMin = state.bionicHsvvMin
+            if (isFinite(state.bionicHsvvMax)) bionicHsvvMax = state.bionicHsvvMax
+            if (isFinite(state.classicRefractMin)) classicRefractMin = state.classicRefractMin
+            if (isFinite(state.classicRefractMax)) classicRefractMax = state.classicRefractMax
+            if (isFinite(state.classicReflectMin)) classicReflectMin = state.classicReflectMin
+            if (isFinite(state.classicReflectMax)) classicReflectMax = state.classicReflectMax
+            if (isFinite(state.classicEdgeLightMin)) classicEdgeLightMin = state.classicEdgeLightMin
+            if (isFinite(state.classicEdgeLightMax)) classicEdgeLightMax = state.classicEdgeLightMax
+            if (isFinite(state.classicSoftEdgePxMin)) classicSoftEdgePxMin = state.classicSoftEdgePxMin
+            if (isFinite(state.classicSoftEdgePxMax)) classicSoftEdgePxMax = state.classicSoftEdgePxMax
             errorText = ""
         }
+
+
+        function applyTuningState(state) {
+            if (!state || !isFinite(state.bionicRefract)) {
+                tuningErrorText = bridge ? "外观设置返回的数据不完整" : ""
+                return
+            }
+            // Reuse the one parser so the two groups can never drift apart.
+            applyState(state)
+            tuningErrorText = ""
+        }
+
+
+        Timer {
+            id: liveBlurDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (themePage.bridge && themePage.blurDirty) {
+                    themePage.bridge.updateGlobalBlurStrength(themePage.blurStrength)
+                }
+            }
+        }
+
+        Timer {
+            id: liveLiquidDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (themePage.bridge && themePage.liquidDirty) {
+                    themePage.bridge.updateGlobalLiquidStrength(themePage.liquidStrength)
+                }
+            }
+        }
+
+        function previewBlur(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(blurStrength - clamped) < 0.005)
+                return
+            blurStrength = clamped
+            blurDirty = true
+            liveBlurDebounce.restart()
+        }
+
+        function commitBlur() {
+            liveBlurDebounce.stop()
+            if (!blurDirty || !bridge)
+                return
+            blurDirty = false
+            applyState(bridge.updateGlobalBlurStrength(blurStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function previewLiquid(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(liquidStrength - clamped) < 0.005)
+                return
+            liquidStrength = clamped
+            liquidDirty = true
+            liveLiquidDebounce.restart()
+        }
+
+        function commitLiquid() {
+            liveLiquidDebounce.stop()
+            if (!liquidDirty || !bridge)
+                return
+            liquidDirty = false
+            applyState(bridge.updateGlobalLiquidStrength(liquidStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+
+        function setSystemAppearance(index) {
+            if (!bridge) {
+                errorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            if (!bridge.applySystemAppearance(index === 1)) {
+                errorText = bridge.lastError
+                return
+            }
+            errorText = ""
+        }
+
+
+        function setMaterialStyle(style) {
+            if (!bridge || (style !== "liquid" && style !== "bionic" && style !== "classic")) {
+                errorText = bridge ? "未知的材质风格" : "尚未构建 Settings 桥接程序"
+                return
+            }
+            // 立即本地更新（橙色框即时反馈），随后与 Shell 回传对齐
+            materialStyle = style
+            applyState(bridge.updateMaterialStyle(style))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function setBionicRefract(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            bionicRefract = value
+            applyTuningState(bridge.updateBionicRefract(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setBionicEdgeLight(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            bionicEdgeLight = value
+            applyTuningState(bridge.updateBionicEdgeLight(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setBionicSoftEdgePx(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            bionicSoftEdgePx = value
+            applyTuningState(bridge.updateBionicSoftEdgePx(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setBionicHsvv(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            bionicHsvv = value
+            applyTuningState(bridge.updateBionicHsvv(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setClassicRefract(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            classicRefract = value
+            applyTuningState(bridge.updateClassicRefract(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setClassicReflect(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            classicReflect = value
+            applyTuningState(bridge.updateClassicReflect(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setClassicEdgeLight(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            classicEdgeLight = value
+            applyTuningState(bridge.updateClassicEdgeLight(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setClassicSoftEdgePx(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            classicSoftEdgePx = value
+            applyTuningState(bridge.updateClassicSoftEdgePx(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setBionicTransparency(value) {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            bionicTransparency = value
+            applyTuningState(bridge.updateBionicTransparency(value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function resetMaterialTuning() {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            applyTuningState(bridge.resetMaterialTuning())
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
 
         function refresh() {
             if (!bridge) {
@@ -1897,6 +1904,54 @@ ApplicationWindow {
                 errorText = bridge.lastError
         }
         Component.onCompleted: refresh()
+
+        Text {
+            text: "系统外观".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: 54
+            radius: 18
+            color: theme.card
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                spacing: 12
+
+                SettingIcon { symbol: "◐"; tint: "#5ac8fa" }
+                Text {
+                    text: "色彩模式"
+                    color: theme.primaryText
+                    font.pixelSize: 15
+                    font.weight: Font.DemiBold
+                }
+                Item { Layout.fillWidth: true }
+                SettingsNavBar {
+                    id: systemAppearanceNavBar
+                    model: [
+                        { id: "light", label: "明亮" },
+                        { id: "dark", label: "暗色" }
+                    ]
+                    currentIndex: theme.dark ? 1 : 0
+                    onSelectionChanged: function(index) {
+                        themePage.setSystemAppearance(index)
+                    }
+                }
+            }
+        }
+
+
+        IconAppearanceSection {
+            bridge: themePage.bridge
+        }
+
 
         Text {
             text: "界面形态".toUpperCase()
@@ -2056,6 +2111,765 @@ ApplicationWindow {
             font.pixelSize: 12
             wrapMode: Text.Wrap
         }
+
+        // ── 材质风格（柔光玻璃 / 轻透磨砂 · 对标澎湃材质风格）──
+        Text {
+            text: "材质风格".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+            Layout.topMargin: 8
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+            Repeater {
+                model: [
+                    { id: "liquid", name: "液态玻璃", desc: "KOS 经典玻璃效果" },
+                    { id: "bionic", name: "柔光玻璃", desc: "更高通透，光影流动" },
+                    { id: "classic", name: "轻透磨砂", desc: "经典磨砂，沉稳内敛" }
+                ]
+                delegate: Rectangle {
+                    required property var modelData
+                    Layout.fillWidth: true
+                    implicitHeight: 92
+                    radius: 18
+                    color: theme.card
+                    border.width: themePage.materialStyle === modelData.id ? 2 : 1
+                    border.color: themePage.materialStyle === modelData.id
+                        ? "#ff6900" : theme.floatingBorder
+
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: 5
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: modelData.name
+                            color: theme.primaryText
+                            font.pixelSize: 15
+                            font.weight: Font.Bold
+                        }
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: modelData.desc
+                            color: theme.secondaryText
+                            font.pixelSize: 11
+                        }
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: themePage.setMaterialStyle(modelData.id)
+                    }
+                }
+            }
+        }
+
+        Text {
+            Layout.fillWidth: true
+            Layout.leftMargin: 13
+            Layout.rightMargin: 13
+            Layout.topMargin: 8
+            text: themePage.materialStyle === "bionic" ? "柔光玻璃微调"
+                : themePage.materialStyle === "classic" ? "轻透磨砂微调"
+                : themePage.materialStyle === "liquid" ? "液态玻璃微调"
+                : "材质微调"
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+        }
+
+        // ════════════════════════════════════════════════════════════
+
+        Rectangle {
+            id: materialTuningCard
+            Layout.fillWidth: true
+            implicitHeight: materialTuningColumn.implicitHeight + 32
+            radius: 18
+            color: theme.card
+            visible: themePage.materialStyle === "bionic" || themePage.materialStyle === "classic" || themePage.materialStyle === "liquid"
+
+            ColumnLayout {
+                id: materialTuningColumn
+                anchors.fill: parent
+                anchors.margins: 16
+                spacing: 14
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "liquid"
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "模糊强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "液态玻璃背景的模糊程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Math.round(themePage.blurStrength * 100) + "%"
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: themePage.blurStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.previewBlur(position)
+                            }
+                            onCommitRequested: themePage.commitBlur()
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◍"; tint: "#5ac8fa" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "液态强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "液态玻璃的流动感强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Math.round(themePage.liquidStrength * 100) + "%"
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: themePage.liquidStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.previewLiquid(position)
+                            }
+                            onCommitRequested: themePage.commitLiquid()
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "bionic"
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◈"; tint: "#af52de" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "折射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的光线弯折程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.bionicRefractPreview >= 0 ? themePage.bionicRefractPreview : themePage.bionicRefract).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.bionicRefractPreview >= 0
+                                    ? themePage.bionicRefractPreview : themePage.bionicRefract
+                                return themePage.bionicRefractMax <= themePage.bionicRefractMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.bionicRefractMin)
+                                        / (themePage.bionicRefractMax - themePage.bionicRefractMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.bionicRefractPreview = themePage.bionicRefractMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.bionicRefractMax - themePage.bionicRefractMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.bionicRefractMin
+                                    + clamped * (themePage.bionicRefractMax - themePage.bionicRefractMin)
+                                themePage.bionicRefractPreview = -1
+                                themePage.setBionicRefract(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◉"; tint: "#ff9500" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "鼠标靠近时点亮的边缘光强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.bionicEdgeLightPreview >= 0 ? themePage.bionicEdgeLightPreview : themePage.bionicEdgeLight).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.bionicEdgeLightPreview >= 0
+                                    ? themePage.bionicEdgeLightPreview : themePage.bionicEdgeLight
+                                return themePage.bionicEdgeLightMax <= themePage.bionicEdgeLightMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.bionicEdgeLightMin)
+                                        / (themePage.bionicEdgeLightMax - themePage.bionicEdgeLightMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.bionicEdgeLightPreview = themePage.bionicEdgeLightMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.bionicEdgeLightMax - themePage.bionicEdgeLightMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.bionicEdgeLightMin
+                                    + clamped * (themePage.bionicEdgeLightMax - themePage.bionicEdgeLightMin)
+                                themePage.bionicEdgeLightPreview = -1
+                                themePage.setBionicEdgeLight(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "☀"; tint: "#ffcc00" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "柔光强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "柔光提亮的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.bionicHsvvPreview >= 0 ? themePage.bionicHsvvPreview : themePage.bionicHsvv).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.bionicHsvvPreview >= 0
+                                    ? themePage.bionicHsvvPreview : themePage.bionicHsvv
+                                return themePage.bionicHsvvMax <= themePage.bionicHsvvMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.bionicHsvvMin)
+                                        / (themePage.bionicHsvvMax - themePage.bionicHsvvMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.bionicHsvvPreview = themePage.bionicHsvvMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.bionicHsvvMax - themePage.bionicHsvvMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.bionicHsvvMin
+                                    + clamped * (themePage.bionicHsvvMax - themePage.bionicHsvvMin)
+                                themePage.bionicHsvvPreview = -1
+                                themePage.setBionicHsvv(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◭"; tint: "#5ac8fa" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘软边"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的柔和过渡宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Math.round((themePage.bionicSoftEdgePxPreview >= 0 ? themePage.bionicSoftEdgePxPreview : themePage.bionicSoftEdgePx) * 10) / 10 + " px"
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.bionicSoftEdgePxPreview >= 0
+                                    ? themePage.bionicSoftEdgePxPreview : themePage.bionicSoftEdgePx
+                                return themePage.bionicSoftEdgePxMax <= themePage.bionicSoftEdgePxMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.bionicSoftEdgePxMin)
+                                        / (themePage.bionicSoftEdgePxMax - themePage.bionicSoftEdgePxMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.bionicSoftEdgePxPreview = themePage.bionicSoftEdgePxMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.bionicSoftEdgePxMax - themePage.bionicSoftEdgePxMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.bionicSoftEdgePxMin
+                                    + clamped * (themePage.bionicSoftEdgePxMax - themePage.bionicSoftEdgePxMin)
+                                themePage.bionicSoftEdgePxPreview = -1
+                                themePage.setBionicSoftEdgePx(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◐"; tint: "#ff375f" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "透明度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃整体的透明程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.bionicTransparencyPreview >= 0
+                                ? themePage.bionicTransparencyPreview
+                                : themePage.bionicTransparency).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.bionicTransparencyPreview >= 0
+                                    ? themePage.bionicTransparencyPreview : themePage.bionicTransparency
+                                return themePage.bionicTransparencyMax <= themePage.bionicTransparencyMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.bionicTransparencyMin)
+                                        / (themePage.bionicTransparencyMax - themePage.bionicTransparencyMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.bionicTransparencyPreview = themePage.bionicTransparencyMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.bionicTransparencyMax - themePage.bionicTransparencyMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.bionicTransparencyMin
+                                    + clamped * (themePage.bionicTransparencyMax - themePage.bionicTransparencyMin)
+                                themePage.bionicTransparencyPreview = -1
+                                themePage.setBionicTransparency(v)
+                            }
+                        }
+                    }
+
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "classic"
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◈"; tint: "#af52de" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "折射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的透镜折射"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.classicRefractPreview >= 0 ? themePage.classicRefractPreview : themePage.classicRefract).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.classicRefractPreview >= 0
+                                    ? themePage.classicRefractPreview : themePage.classicRefract
+                                return themePage.classicRefractMax <= themePage.classicRefractMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.classicRefractMin)
+                                        / (themePage.classicRefractMax - themePage.classicRefractMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.classicRefractPreview = themePage.classicRefractMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.classicRefractMax - themePage.classicRefractMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.classicRefractMin
+                                    + clamped * (themePage.classicRefractMax - themePage.classicRefractMin)
+                                themePage.classicRefractPreview = -1
+                                themePage.setClassicRefract(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◍"; tint: "#5e5ce6" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "边缘反射的提亮强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.classicReflectPreview >= 0 ? themePage.classicReflectPreview : themePage.classicReflect).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.classicReflectPreview >= 0
+                                    ? themePage.classicReflectPreview : themePage.classicReflect
+                                return themePage.classicReflectMax <= themePage.classicReflectMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.classicReflectMin)
+                                        / (themePage.classicReflectMax - themePage.classicReflectMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.classicReflectPreview = themePage.classicReflectMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.classicReflectMax - themePage.classicReflectMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.classicReflectMin
+                                    + clamped * (themePage.classicReflectMax - themePage.classicReflectMin)
+                                themePage.classicReflectPreview = -1
+                                themePage.setClassicReflect(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◉"; tint: "#ff9500" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃描边的亮度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Number(themePage.classicEdgeLightPreview >= 0 ? themePage.classicEdgeLightPreview : themePage.classicEdgeLight).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.classicEdgeLightPreview >= 0
+                                    ? themePage.classicEdgeLightPreview : themePage.classicEdgeLight
+                                return themePage.classicEdgeLightMax <= themePage.classicEdgeLightMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.classicEdgeLightMin)
+                                        / (themePage.classicEdgeLightMax - themePage.classicEdgeLightMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.classicEdgeLightPreview = themePage.classicEdgeLightMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.classicEdgeLightMax - themePage.classicEdgeLightMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.classicEdgeLightMin
+                                    + clamped * (themePage.classicEdgeLightMax - themePage.classicEdgeLightMin)
+                                themePage.classicEdgeLightPreview = -1
+                                themePage.setClassicEdgeLight(v)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+
+                        SettingIcon { symbol: "◭"; tint: "#5ac8fa" }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘软边"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的柔和过渡宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+
+                        Text {
+                            text: Math.round((themePage.classicSoftEdgePxPreview >= 0 ? themePage.classicSoftEdgePxPreview : themePage.classicSoftEdgePx) * 10) / 10 + " px"
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: {
+                                const shown = themePage.classicSoftEdgePxPreview >= 0
+                                    ? themePage.classicSoftEdgePxPreview : themePage.classicSoftEdgePx
+                                return themePage.classicSoftEdgePxMax <= themePage.classicSoftEdgePxMin
+                                    ? 0
+                                    : Math.max(0, Math.min(1,
+                                        (shown - themePage.classicSoftEdgePxMin)
+                                        / (themePage.classicSoftEdgePxMax - themePage.classicSoftEdgePxMin)))
+                            }
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.classicSoftEdgePxPreview = themePage.classicSoftEdgePxMin
+                                    + Math.max(0, Math.min(1, position))
+                                        * (themePage.classicSoftEdgePxMax - themePage.classicSoftEdgePxMin)
+                            }
+                            onCommitRequested: function(position) {
+                                const clamped = Math.max(0, Math.min(1, position))
+                                const v = themePage.classicSoftEdgePxMin
+                                    + clamped * (themePage.classicSoftEdgePxMax - themePage.classicSoftEdgePxMin)
+                                themePage.classicSoftEdgePxPreview = -1
+                                themePage.setClassicSoftEdgePx(v)
+                            }
+                        }
+                    }
+
+                }
+
+
+                // 恢复默认 → OS4 原生值（柔光玻璃：1.2 / 1.4 / 1.0 / 1.5px；
+                // 轻透磨砂：1.5 / 0.6 / 0.1 / 1.5px）
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: 2
+                    Item { Layout.fillWidth: true }
+                    Text {
+                        text: "恢复默认"
+                        color: theme.selected
+                        font.pixelSize: 12
+                        font.weight: Font.Medium
+
+                        MouseArea {
+                            anchors.fill: parent
+                            anchors.margins: -6
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: themePage.resetMaterialTuning()
+                        }
+                    }
+                }
+            }
+        }
+
 
         Text {
             text: "窗口动画"
@@ -3283,17 +4097,9 @@ ApplicationWindow {
 
                 SidebarEntry {
                     Layout.fillWidth: true
-                    pageIndex: 0
-                    label: "显示"
-                    navSymbol: "▱"
-                    navTint: "#34c759"
-                }
-
-                SidebarEntry {
-                    Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 1
-                    label: "主题"
+                    pageIndex: 0
+                    label: "外观"
                     navSymbol: "◈"
                     navTint: "#af52de"
                 }
@@ -3301,7 +4107,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 2
+                    pageIndex: 1
                     label: "顶栏"
                     navSymbol: "⎍"
                     navTint: "#5ac8fa"
@@ -3310,7 +4116,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 3
+                    pageIndex: 2
                     label: "Dock"
                     navSymbol: "▰"
                     navTint: "#0a84ff"
@@ -3319,7 +4125,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 4
+                    pageIndex: 3
                     label: "启动台"
                     navSymbol: "❖"
                     navTint: "#ff9500"
@@ -3328,7 +4134,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 5
+                    pageIndex: 4
                     label: "快捷键"
                     navSymbol: "⌘"
                     navTint: "#5856d6"
@@ -3337,7 +4143,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 6
+                    pageIndex: 5
                     label: "接入状态"
                     navSymbol: "✓"
                     navTint: "#30d158"
@@ -3385,7 +4191,7 @@ ApplicationWindow {
                         Layout.bottomMargin: 18
                     }
                     Repeater {
-                        model: (window.currentPage >= 0 && window.currentPage <= 6)
+                        model: (window.currentPage >= 0 && window.currentPage <= 5)
                             ? [] : window.contentByPage[window.currentPage].groups
                         delegate: ColumnLayout {
                             required property var modelData
@@ -3417,30 +4223,26 @@ ApplicationWindow {
                     }
 
                     LauncherSettingsPage {
-                        visible: window.currentPage === 4
-                    }
-
-                    ShortcutsSettingsPage {
-                        visible: window.currentPage === 5
-                    }
-
-                    IntegrationStatusPage {
-                        visible: window.currentPage === 6
-                    }
-
-                    DockSettingsPage {
                         visible: window.currentPage === 3
                     }
 
-                    BarSettingsPage {
+                    ShortcutsSettingsPage {
+                        visible: window.currentPage === 4
+                    }
+
+                    IntegrationStatusPage {
+                        visible: window.currentPage === 5
+                    }
+
+                    DockSettingsPage {
                         visible: window.currentPage === 2
                     }
 
-                    ThemeSettingsPage {
+                    BarSettingsPage {
                         visible: window.currentPage === 1
                     }
 
-                    DisplaySettingsPage {
+                    ThemeSettingsPage {
                         visible: window.currentPage === 0
                     }
                 }

--- a/apps/settings/src/main.cpp
+++ b/apps/settings/src/main.cpp
@@ -108,6 +108,71 @@ public:
             QStringLiteral("updateShellStyle"), style}));
     }
 
+    Q_INVOKABLE QVariantMap updateMaterialStyle(const QString &style) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateMaterialStyle"), style}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicRefract(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicRefract"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicEdgeLight(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicEdgeLight"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicSoftEdgePx(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicSoftEdgePx"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicHsvv(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicHsvv"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicRefract(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicRefract"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicReflect(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicReflect"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicEdgeLight(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicEdgeLight"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicSoftEdgePx(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicSoftEdgePx"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicTransparency(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicTransparency"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap resetMaterialTuning() {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("resetMaterialTuning")}));
+    }
+
+
     Q_INVOKABLE QVariantMap updateBarIntegratedWithDock(bool enabled) {
         return appearanceSnapshotFromReply(callAppearance({
             QStringLiteral("updateBarIntegratedWithDock"),
@@ -337,6 +402,8 @@ private:
             {QStringLiteral("iconOpacity"), object.value(QStringLiteral("iconOpacity")).toDouble(0.5)},
             {QStringLiteral("iconTintColor"), object.value(QStringLiteral("iconTintColor")).toString(QStringLiteral("#a855f7"))},
             {QStringLiteral("shellStyle"), object.value(QStringLiteral("shellStyle")).toString()},
+            {QStringLiteral("materialStyle"),
+                object.value(QStringLiteral("materialStyle")).toString(QStringLiteral("liquid"))},
             {QStringLiteral("barIntegratedWithDock"),
                 object.value(QStringLiteral("barIntegratedWithDock")).toBool()},
             {QStringLiteral("barVisibilityMode"),
@@ -345,6 +412,61 @@ private:
                 object.value(QStringLiteral("barLayoutMode")).toString(QStringLiteral("transparent"))},
             {QStringLiteral("dockWindowAnimationStyle"),
                 object.value(QStringLiteral("dockWindowAnimationStyle")).toString()},
+            // 材质微调（柔光玻璃 / 轻透磨砂）
+            {QStringLiteral("bionicRefract"),
+                object.value(QStringLiteral("bionicRefract")).toDouble(4.0)},
+            {QStringLiteral("bionicEdgeLight"),
+                object.value(QStringLiteral("bionicEdgeLight")).toDouble(1.4)},
+            {QStringLiteral("bionicSoftEdgePx"),
+                object.value(QStringLiteral("bionicSoftEdgePx")).toDouble(1.5)},
+            {QStringLiteral("bionicHsvv"),
+                object.value(QStringLiteral("bionicHsvv")).toDouble(1.0)},
+            {QStringLiteral("classicRefract"),
+                object.value(QStringLiteral("classicRefract")).toDouble(1.5)},
+            {QStringLiteral("classicReflect"),
+                object.value(QStringLiteral("classicReflect")).toDouble(0.06)},
+            {QStringLiteral("classicEdgeLight"),
+                object.value(QStringLiteral("classicEdgeLight")).toDouble(0.1)},
+            {QStringLiteral("classicSoftEdgePx"),
+                object.value(QStringLiteral("classicSoftEdgePx")).toDouble(1.5)},
+            {QStringLiteral("bionicRefractMin"),
+                object.value(QStringLiteral("bionicRefractMin")).toDouble(1.0)},
+            {QStringLiteral("bionicRefractMax"),
+                object.value(QStringLiteral("bionicRefractMax")).toDouble(5.0)},
+            {QStringLiteral("bionicEdgeLightMin"),
+                object.value(QStringLiteral("bionicEdgeLightMin")).toDouble(0.0)},
+            {QStringLiteral("bionicEdgeLightMax"),
+                object.value(QStringLiteral("bionicEdgeLightMax")).toDouble(3.0)},
+            {QStringLiteral("bionicSoftEdgePxMin"),
+                object.value(QStringLiteral("bionicSoftEdgePxMin")).toDouble(0.1)},
+            {QStringLiteral("bionicSoftEdgePxMax"),
+                object.value(QStringLiteral("bionicSoftEdgePxMax")).toDouble(25.0)},
+            {QStringLiteral("bionicHsvvMin"),
+                object.value(QStringLiteral("bionicHsvvMin")).toDouble(0.0)},
+            {QStringLiteral("bionicHsvvMax"),
+                object.value(QStringLiteral("bionicHsvvMax")).toDouble(2.0)},
+            {QStringLiteral("classicRefractMin"),
+                object.value(QStringLiteral("classicRefractMin")).toDouble(1.0)},
+            {QStringLiteral("classicRefractMax"),
+                object.value(QStringLiteral("classicRefractMax")).toDouble(2.0)},
+            {QStringLiteral("classicReflectMin"),
+                object.value(QStringLiteral("classicReflectMin")).toDouble(0.0)},
+            {QStringLiteral("classicReflectMax"),
+                object.value(QStringLiteral("classicReflectMax")).toDouble(1.5)},
+            {QStringLiteral("classicEdgeLightMin"),
+                object.value(QStringLiteral("classicEdgeLightMin")).toDouble(0.0)},
+            {QStringLiteral("classicEdgeLightMax"),
+                object.value(QStringLiteral("classicEdgeLightMax")).toDouble(0.5)},
+            {QStringLiteral("classicSoftEdgePxMin"),
+                object.value(QStringLiteral("classicSoftEdgePxMin")).toDouble(0.5)},
+            {QStringLiteral("classicSoftEdgePxMax"),
+                object.value(QStringLiteral("classicSoftEdgePxMax")).toDouble(25.0)},
+            {QStringLiteral("bionicTransparency"),
+                object.value(QStringLiteral("bionicTransparency")).toDouble(1.0)},
+            {QStringLiteral("bionicTransparencyMin"),
+                object.value(QStringLiteral("bionicTransparencyMin")).toDouble(0.0)},
+            {QStringLiteral("bionicTransparencyMax"),
+                object.value(QStringLiteral("bionicTransparencyMax")).toDouble(1.0)},
             {QStringLiteral("tokenVersion"), object.value(QStringLiteral("tokenVersion")).toInt()},
         };
     }

--- a/shell/desktop/DesktopEnvironment.qml
+++ b/shell/desktop/DesktopEnvironment.qml
@@ -143,12 +143,53 @@ Item {
                 // the value as an object and fall back to its previous tint.
                 iconTintColor: IconAppearanceService.tintColor.toString(),
                 shellStyle: AppearanceConfigService.shellStyle,
+                materialStyle: AppearanceConfigService.materialStyle,
                 barIntegratedWithDock:
                     AppearanceConfigService.barIntegratedWithDock,
                 barVisibilityMode: AppearanceConfigService.barVisibilityMode,
                 barLayoutMode: AppearanceConfigService.barLayoutMode,
                 dockWindowAnimationStyle:
                     AppearanceConfigService.dockWindowAnimationStyle,
+                // Dock surface tuning (DDE-derived). The Dock resolves these
+                // against the active shell style; the Settings app round-trips
+                // the raw multipliers so its sliders stay where the user left
+                // them instead of snapping to a recomputed absolute.
+                bionicRefract: AppearanceConfigService.bionicRefract,
+                bionicEdgeLight: AppearanceConfigService.bionicEdgeLight,
+                bionicSoftEdgePx: AppearanceConfigService.bionicSoftEdgePx,
+                bionicHsvv: AppearanceConfigService.bionicHsvv,
+                classicRefract: AppearanceConfigService.classicRefract,
+                classicReflect: AppearanceConfigService.classicReflect,
+                classicEdgeLight: AppearanceConfigService.classicEdgeLight,
+                classicSoftEdgePx: AppearanceConfigService.classicSoftEdgePx,
+                bionicRefractMin: AppearanceConfigService.bionicRefractMin,
+                bionicRefractMax: AppearanceConfigService.bionicRefractMax,
+                bionicEdgeLightMin: AppearanceConfigService.bionicEdgeLightMin,
+                bionicEdgeLightMax: AppearanceConfigService.bionicEdgeLightMax,
+                bionicSoftEdgePxMin: AppearanceConfigService.bionicSoftEdgePxMin,
+                bionicSoftEdgePxMax: AppearanceConfigService.bionicSoftEdgePxMax,
+                bionicHsvvMin: AppearanceConfigService.bionicHsvvMin,
+                bionicHsvvMax: AppearanceConfigService.bionicHsvvMax,
+                classicRefractMin: AppearanceConfigService.classicRefractMin,
+                classicRefractMax: AppearanceConfigService.classicRefractMax,
+                classicReflectMin: AppearanceConfigService.classicReflectMin,
+                classicReflectMax: AppearanceConfigService.classicReflectMax,
+                classicEdgeLightMin: AppearanceConfigService.classicEdgeLightMin,
+                classicEdgeLightMax: AppearanceConfigService.classicEdgeLightMax,
+                classicSoftEdgePxMin: AppearanceConfigService.classicSoftEdgePxMin,
+                classicSoftEdgePxMax: AppearanceConfigService.classicSoftEdgePxMax,
+                bionicTransparency: AppearanceConfigService.bionicTransparency,
+                bionicTransparencyMin: AppearanceConfigService.bionicTransparencyMin,
+                bionicTransparencyMax: AppearanceConfigService.bionicTransparencyMax,
+                // What the tuning currently resolves to, so Settings can show
+                // the user a concrete pixel/alpha readout rather than the
+                // opaque multiplier alone.
+                resolvedDockRadius: AppearanceTokens.resolvedDockRadius,
+                resolvedDockDarkAlpha: AppearanceTokens.resolvedDockDarkAlpha,
+                resolvedDockBorderTopAlpha:
+                    AppearanceTokens.resolvedDockBorderTopAlpha,
+                resolvedDockBorderBottomAlpha:
+                    AppearanceTokens.resolvedDockBorderBottomAlpha,
                 tokenVersion: AppearanceTokens.version,
             })
         }
@@ -193,6 +234,11 @@ Item {
             return snapshot()
         }
 
+        function updateMaterialStyle(style: string): string {
+            AppearanceConfigService.updateMaterialStyle(style)
+            return snapshot()
+        }
+
         function updateBarIntegratedWithDock(enabled: bool): string {
             AppearanceConfigService.updateBarIntegratedWithDock(enabled)
             return snapshot()
@@ -210,6 +256,76 @@ Item {
 
         function updateDockWindowAnimationStyle(style: string): string {
             AppearanceConfigService.updateDockWindowAnimationStyle(style)
+            return snapshot()
+        }
+
+        function updateDockRadiusScale(value: real): string {
+            AppearanceConfigService.updateDockRadiusScale(value)
+            return snapshot()
+        }
+
+        function updateDockDarkDensity(value: real): string {
+            AppearanceConfigService.updateDockDarkDensity(value)
+            return snapshot()
+        }
+
+        function updateDockEdgeStrength(value: real): string {
+            AppearanceConfigService.updateDockEdgeStrength(value)
+            return snapshot()
+        }
+
+        function updateBionicRefract(value: real): string {
+            AppearanceConfigService.updateBionicRefract(value)
+            return snapshot()
+        }
+
+        function updateBionicEdgeLight(value: real): string {
+            AppearanceConfigService.updateBionicEdgeLight(value)
+            return snapshot()
+        }
+
+        function updateBionicSoftEdgePx(value: real): string {
+            AppearanceConfigService.updateBionicSoftEdgePx(value)
+            return snapshot()
+        }
+
+        function updateBionicHsvv(value: real): string {
+            AppearanceConfigService.updateBionicHsvv(value)
+            return snapshot()
+        }
+
+        function updateClassicRefract(value: real): string {
+            AppearanceConfigService.updateClassicRefract(value)
+            return snapshot()
+        }
+
+        function updateClassicReflect(value: real): string {
+            AppearanceConfigService.updateClassicReflect(value)
+            return snapshot()
+        }
+
+        function updateClassicEdgeLight(value: real): string {
+            AppearanceConfigService.updateClassicEdgeLight(value)
+            return snapshot()
+        }
+
+        function updateClassicSoftEdgePx(value: real): string {
+            AppearanceConfigService.updateClassicSoftEdgePx(value)
+            return snapshot()
+        }
+
+        function updateBionicTransparency(value: real): string {
+            AppearanceConfigService.updateBionicTransparency(value)
+            return snapshot()
+        }
+
+        function resetMaterialTuning(): string {
+            AppearanceConfigService.resetMaterialTuning()
+            return snapshot()
+        }
+
+        function resetDockSurfaceTuning(): string {
+            AppearanceConfigService.resetDockSurfaceTuning()
             return snapshot()
         }
 

--- a/shell/desktop/modules/common/AppearanceConfigService.qml
+++ b/shell/desktop/modules/common/AppearanceConfigService.qml
@@ -33,28 +33,69 @@ QtObject {
 
     // "macos" matches the shell geometry that predates selectable styles,
     // so upgrading an existing installation does not unexpectedly reshape it.
-    property string shellStyle: "macos"
-    // Global colour-scheme preference shared by every shell style. The Dock
-    // settings page historically persisted this value in DockConfigService;
-    // that service mirrors the legacy value here during migration.
+    // Global colour-scheme preference shared by every shell style (mainline v10).
     property string themeMode: "system" // "system" | "light" | "dark"
-    // AppearanceTokens' wallpaper bridge persists this once the shared
-    // WallpaperColorSource reports a sampled seed; AppearanceTokens falls back
-    // to the KDE accent until then.
     property color wallpaperSeedColor: "transparent"
+    property string shellStyle: "macos"
+    // 材质风格（对标澎湃 HyperOS 4「材质风格」）
+    // "bionic" = 柔光玻璃 | "classic" = 轻透磨砂
+    property string materialStyle: "liquid"
     property bool barIntegratedWithDock: false
     property string barVisibilityMode: "always" // "always" | "smart" | "persistent"
     property string barLayoutMode: "transparent" // "full" | "floating" | "transparent"
     property string dockWindowAnimationStyle: "scale"
     property bool ready: false
 
-    function isValidShellStyle(value) {
-        return value === "windows12" || value === "macos"
-            || value === "material"
-    }
+    // ── 材质专属微调（柔光玻璃 / 轻透磨砂）───────────────────────────
+    // 每组只在对应材质激活时写入 kwinrc 的 [Effect-blurplus] 键；
+    // 材质切换时由 _syncMaterialTuning() 按 materialStyle 分支落盘。
+    // bionic（柔光玻璃）
+    property real bionicRefract: 4.0        // → BionicIOR（包值 refractIOR=4.0）
+    property real bionicEdgeLight: 1.4      // → BionicActivatedDirIntensity（悬停点亮强度）
+    property real bionicSoftEdgePx: 1.5     // → BionicShapeEdgePx（×5）
+    property real bionicHsvv: 1.0           // → BionicHsvvBoost（柔光提亮强度，1.0 = 原生）
+    // classic（轻透磨砂）
+    property real classicRefract: 1.5       // → ClassicRefractIOR
+    property real classicReflect: 0.06     // → ClassicReflStrength
+    property real classicEdgeLight: 0.1     // → ClassicStrokeStrength（描边强度）
+    property real classicSoftEdgePx: 1.5    // → ClassicMaskSoft
+    property real bionicTransparency: 1.0  // → BionicOverallAlpha（1.0=标准；调低更透）
+    readonly property real bionicRefractMin: 1.0
+    readonly property real bionicRefractMax: 5.0
+    readonly property real bionicEdgeLightMin: 0.0
+    readonly property real bionicEdgeLightMax: 3.0
+    readonly property real bionicSoftEdgePxMin: 0.1
+    readonly property real bionicSoftEdgePxMax: 25.0
+    readonly property real bionicHsvvMin: 0.0
+    readonly property real bionicHsvvMax: 2.0
+    readonly property real bionicTransparencyMin: 0.0
+    readonly property real bionicTransparencyMax: 1.0
+    readonly property real classicRefractMin: 1.0
+    readonly property real classicRefractMax: 2.0
+    readonly property real classicReflectMin: 0.0
+    readonly property real classicReflectMax: 1.5
+    readonly property real classicEdgeLightMin: 0.0
+    readonly property real classicEdgeLightMax: 0.5
+    readonly property real classicSoftEdgePxMin: 0.5
+    readonly property real classicSoftEdgePxMax: 25.0
 
     function isValidThemeMode(value) {
         return value === "system" || value === "light" || value === "dark"
+    }
+
+    function updateThemeMode(rawMode) {
+        const mode = String(rawMode)
+        if (!isValidThemeMode(mode) || themeMode === mode)
+            return false
+        themeMode = mode
+        saveTimer.restart()
+        return true
+    }
+
+    function isValidShellStyle(value) {
+        return value === "windows12" || value === "macos"
+            || value === "material" || value === "dde"
+            || value === "hyperos"
     }
 
     function isValidBarVisibilityMode(value) {
@@ -133,13 +174,93 @@ QtObject {
         return true
     }
 
-    function updateThemeMode(rawMode) {
-        const mode = String(rawMode)
-        if (!isValidThemeMode(mode) || themeMode === mode)
+    // ── 材质风格（液态玻璃[KOS原有] / 柔光玻璃 / 轻透磨砂）──
+    function isValidMaterialStyle(value) {
+        return value === "liquid" || value === "bionic" || value === "classic"
+    }
+
+    function updateMaterialStyle(rawStyle) {
+        const style = String(rawStyle)
+        if (!isValidMaterialStyle(style))
             return false
-        themeMode = mode
+        materialStyle = style
+        _applyKwinGlass(style)
+        materialTuningSyncTimer.restart()
         saveTimer.restart()
         return true
+    }
+
+    // 材质风格 → KWin 玻璃特效完整参数
+    //   liquid  = KOS 原有液态玻璃（默认）
+    //   bionic  = 柔光玻璃（物理光场全开：斯涅尔折射 + 色散 + 边缘光 + 双向色调）
+    //   classic = 轻透磨砂（物理关，经典磨砂）
+    // 参数映射自 18 Fold 的 BionicToken 37 参数配方
+    function _materialKwinParams(style) {
+        if (style === "bionic")
+            return {
+                BionicMode: "true",
+                ClassicMode: "false",
+                BlurStrength: "12",
+                RefractionStrength: "14",
+                PhysicallyBasedRefraction: "true",
+                RefractionRGBFringing: "0.7",
+                RefractionEdgeSize: "28",
+                RefractionBevelIntensity: "14",
+                HighlightWidthPx: "4",
+                EdgeLightingDock: "true",
+                AutoTintAlpha: "true",
+                TintColor: "#281c1c1e",
+                NoiseStrength: "3",
+            }
+        if (style === "classic")
+            return {
+                BionicMode: "false",
+                ClassicMode: "true",
+                BlurStrength: "6",
+                RefractionStrength: "3",
+                PhysicallyBasedRefraction: "false",
+                RefractionRGBFringing: "0.3",
+                RefractionEdgeSize: "12",
+                RefractionBevelIntensity: "10",
+                HighlightWidthPx: "3",
+                EdgeLightingDock: "false",
+                AutoTintAlpha: "false",
+                TintColor: "#3c0a0a0a",
+                NoiseStrength: "5",
+            }
+        // liquid（KOS 原有）
+        return {
+            BionicMode: "false",
+            ClassicMode: "false",
+            BlurStrength: "3",
+            RefractionStrength: "8",
+            PhysicallyBasedRefraction: "false",
+            RefractionRGBFringing: "1.0",
+            RefractionEdgeSize: "20",
+            RefractionBevelIntensity: "10",
+            HighlightWidthPx: "3",
+            EdgeLightingDock: "false",
+            AutoTintAlpha: "false",
+            TintColor: "#3c0a0a0a",
+            NoiseStrength: "5",
+        }
+    }
+
+    function _applyKwinGlass(style) {
+        const params = _materialKwinParams(style)
+        let cmd = ""
+        for (const key in params) {
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key " + key
+                + " '" + params[key] + "'; "
+        }
+        cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key DecorationBlurStrength " + params.BlurStrength
+            + "; kwriteconfig6 --file kwinrc --group Effect-blurplus --key DockBlurStrength " + params.BlurStrength
+            + "; qdbus6 org.kde.KWin /KWin reconfigure 2>/dev/null || true; "
+            // BionicMode 切换的是渲染路径，需要重载已加载的玻璃特效才会生效
+            + "for e in glass glass5 glass6 glass7 glass8 glass10; do if qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.isEffectLoaded \"$e\" 2>/dev/null | grep -q true; then qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect \"$e\"; sleep 0.3; qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect \"$e\"; fi; done"
+        const process = _makeProcess(["bash", "-c", cmd])
+        if (process)
+            process.running = true
     }
 
     function updateBarIntegratedWithDock(rawValue) {
@@ -198,6 +319,160 @@ QtObject {
         return changed
     }
 
+    // ── 材质微调 updaters（每个参数只在对应材质生效）─────────────────
+    function updateBionicRefract(rawValue) {
+        const value = _clampInRange(rawValue, bionicRefractMin, bionicRefractMax)
+        if (!Number.isFinite(value) || Math.abs(bionicRefract - value) <= 0.001)
+            return false
+        bionicRefract = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicEdgeLight(rawValue) {
+        const value = _clampInRange(rawValue, bionicEdgeLightMin, bionicEdgeLightMax)
+        if (!Number.isFinite(value) || Math.abs(bionicEdgeLight - value) <= 0.001)
+            return false
+        bionicEdgeLight = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicSoftEdgePx(rawValue) {
+        const value = _clampInRange(rawValue, bionicSoftEdgePxMin, bionicSoftEdgePxMax)
+        if (!Number.isFinite(value) || Math.abs(bionicSoftEdgePx - value) <= 0.001)
+            return false
+        bionicSoftEdgePx = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicHsvv(rawValue) {
+        const value = _clampInRange(rawValue, bionicHsvvMin, bionicHsvvMax)
+        if (!Number.isFinite(value) || Math.abs(bionicHsvv - value) <= 0.001)
+            return false
+        bionicHsvv = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicRefract(rawValue) {
+        const value = _clampInRange(rawValue, classicRefractMin, classicRefractMax)
+        if (!Number.isFinite(value) || Math.abs(classicRefract - value) <= 0.001)
+            return false
+        classicRefract = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicReflect(rawValue) {
+        const value = _clampInRange(rawValue, classicReflectMin, classicReflectMax)
+        if (!Number.isFinite(value) || Math.abs(classicReflect - value) <= 0.001)
+            return false
+        classicReflect = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicEdgeLight(rawValue) {
+        const value = _clampInRange(rawValue, classicEdgeLightMin, classicEdgeLightMax)
+        if (!Number.isFinite(value) || Math.abs(classicEdgeLight - value) <= 0.001)
+            return false
+        classicEdgeLight = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicSoftEdgePx(rawValue) {
+        const value = _clampInRange(rawValue, classicSoftEdgePxMin, classicSoftEdgePxMax)
+        if (!Number.isFinite(value) || Math.abs(classicSoftEdgePx - value) <= 0.001)
+            return false
+        classicSoftEdgePx = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicTransparency(rawValue) {
+        const value = _clampInRange(rawValue, bionicTransparencyMin, bionicTransparencyMax)
+        if (!Number.isFinite(value) || Math.abs(bionicTransparency - value) <= 0.001)
+            return false
+        bionicTransparency = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function resetMaterialTuning() {
+        const changed = Math.abs(bionicRefract - 4.0) > 0.001
+            || Math.abs(bionicEdgeLight - 1.4) > 0.001
+            || Math.abs(bionicSoftEdgePx - 1.5) > 0.001
+            || Math.abs(bionicHsvv - 1.0) > 0.001
+            || Math.abs(classicRefract - 1.5) > 0.001
+            || Math.abs(classicReflect - 0.06) > 0.001
+            || Math.abs(classicEdgeLight - 0.1) > 0.001
+            || Math.abs(classicSoftEdgePx - 1.5) > 0.001
+            || Math.abs(bionicTransparency - 1.0) > 0.001
+        bionicRefract = 4.0
+        bionicEdgeLight = 1.4
+        bionicSoftEdgePx = 1.5
+        bionicHsvv = 1.0
+        classicRefract = 1.5
+        classicReflect = 0.06
+        classicEdgeLight = 0.1
+        classicSoftEdgePx = 1.5
+        bionicTransparency = 1.0
+        if (changed) {
+            saveTimer.restart()
+            materialTuningSyncTimer.restart()
+        }
+        return changed
+    }
+
+    // 材质专属参数 → kwinrc（materialStyle 门控：只写当前材质的键）
+    function _syncMaterialTuning() {
+        let cmd = ""
+        if (service.materialStyle === "bionic") {
+            cmd = "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicIOR '" + service.bionicRefract + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDirIntensity '" + service.bionicEdgeLight + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDirOppositeIntensity '" + (service.bionicEdgeLight * 0.5) + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicShapeEdgePx '" + (service.bionicSoftEdgePx * 5.0) + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicHsvvBoost '" + service.bionicHsvv + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicOverallAlpha '" + service.bionicTransparency + "'; "
+        } else if (service.materialStyle === "classic") {
+            cmd = "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicRefractIOR '" + service.classicRefract + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicReflStrength '" + service.classicReflect + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicStrokeStrength '" + service.classicEdgeLight + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicMaskSoft '" + service.classicSoftEdgePx + "'; "
+        } else {
+            return
+        }
+        cmd += "qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect glass 2>/dev/null || true"
+        const process = _makeProcess(["bash", "-c", cmd])
+        if (process)
+            process.running = true
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Dock surface tuning updaters
+    // ────────────────────────────────────────────────────────────────
+    // Each returns false when the value is rejected (non-finite or outside the
+    // documented range) so the Settings UI can tell a no-op from a real change.
+    function _clampInRange(rawValue, min, max) {
+        const number = Number(rawValue)
+        if (!Number.isFinite(number))
+            return NaN
+        return Math.max(min, Math.min(max, number))
+    }
+    // Restore the DDE-derived surface defaults without touching the selected
+    // shell style, blur or liquid strengths.
     property Timer saveTimer: Timer {
         interval: 350
         repeat: false
@@ -213,6 +488,13 @@ QtObject {
         interval: 80
         repeat: false
         onTriggered: service._syncGlassEffect()
+    }
+
+    // 材质微调专用（延迟稍长，避开 _applyKwinGlass 的并行写入）
+    property Timer materialTuningSyncTimer: Timer {
+        interval: 250
+        repeat: false
+        onTriggered: service._syncMaterialTuning()
     }
 
     property Timer dockAnimationEffectSyncTimer: Timer {
@@ -239,17 +521,27 @@ QtObject {
 
     function _save() {
         const payload = JSON.stringify({
-            version: 10,
+            version: 12,
             globalBlurStrength: service.globalBlurStrength,
             globalLiquidStrength: service.globalLiquidStrength,
             blurStrength: service.globalBlurStrength,
             liquidStrength: service.globalLiquidStrength,
             shellStyle: service.shellStyle,
+            materialStyle: service.materialStyle,
             themeMode: service.themeMode,
             barIntegratedWithDock: service.barIntegratedWithDock,
             barVisibilityMode: service.barVisibilityMode,
             barLayoutMode: service.barLayoutMode,
             dockWindowAnimationStyle: service.dockWindowAnimationStyle,
+            bionicRefract: service.bionicRefract,
+            bionicEdgeLight: service.bionicEdgeLight,
+            bionicSoftEdgePx: service.bionicSoftEdgePx,
+            bionicHsvv: service.bionicHsvv,
+            classicRefract: service.classicRefract,
+            classicReflect: service.classicReflect,
+            classicEdgeLight: service.classicEdgeLight,
+            classicSoftEdgePx: service.classicSoftEdgePx,
+            bionicTransparency: service.bionicTransparency,
         }, null, 2)
         const process = _makeProcess([
             "sh", "-c",
@@ -269,7 +561,34 @@ QtObject {
         process.running = true
     }
 
+    // 材质风格专属的玻璃参数（非 liquid 时接管，忽略用户滑条）
+    function _materialGlassParams(style) {
+        if (style === "bionic")
+            return { blur: 12, refr: 14 }
+        if (style === "classic")
+            return { blur: 6, refr: 3 }
+        return null
+    }
+
     function _syncGlassEffect() {
+        // 材质模式：强制模式参数，用户滑条不参与
+        const materialParams = service._materialGlassParams(service.materialStyle)
+        if (materialParams) {
+            PlatformClient.request("theme.sync-glass", {
+                contentBlurLevel: materialParams.blur,
+                dockBlurLevel: materialParams.blur,
+                refractionLevel: materialParams.refr,
+            }, function(response) {
+                if (!response?.ok)
+                    console.warn("[AppearanceConfig] Material glass sync failed: "
+                        + (response?.error?.message || "platform unavailable"))
+                else
+                    console.log("[AppearanceConfig] Material glass=" + service.materialStyle
+                        + " blur=" + materialParams.blur + " refr=" + materialParams.refr)
+            })
+            return
+        }
+        // liquid（KOS 原有）：用户滑条逻辑
         const dockBlurLevel = service._compositorBlurLevel(
             service.globalBlurStrength)
         const contentBlurLevel = service._compositorBlurLevel(
@@ -330,7 +649,6 @@ QtObject {
                     const barVisibility = String(object.barVisibilityMode ?? "")
                     const barLayout = String(object.barLayoutMode ?? "")
                     const animationStyle = String(object.dockWindowAnimationStyle ?? "")
-
                     if (Number.isFinite(globalBlur)) {
                         service.globalBlurStrength = globalBlur
                         service.blurStrength = globalBlur
@@ -339,10 +657,10 @@ QtObject {
                         service.globalLiquidStrength = globalLiquid
                         service.liquidStrength = globalLiquid
                     }
-                    if (service.isValidShellStyle(style))
-                        service.shellStyle = style
                     if (service.isValidThemeMode(themeMode))
                         service.themeMode = themeMode
+                    if (service.isValidShellStyle(style))
+                        service.shellStyle = style
                     if (hasBarIntegration)
                         service.barIntegratedWithDock = object.barIntegratedWithDock
                     if (service.isValidBarVisibilityMode(barVisibility))
@@ -351,14 +669,61 @@ QtObject {
                         service.barLayoutMode = barLayout
                     if (service.isValidDockWindowAnimationStyle(animationStyle))
                         service.dockWindowAnimationStyle = animationStyle
+                    // v11 adds material-specific tuning (bionic/classic).
+                    const bRefract = service._clampInRange(
+                        object.bionicRefract ?? 1.2, service.bionicRefractMin, service.bionicRefractMax)
+                    const bEdge = service._clampInRange(
+                        object.bionicEdgeLight ?? 1.4, service.bionicEdgeLightMin, service.bionicEdgeLightMax)
+                    const bSoft = service._clampInRange(
+                        object.bionicSoftEdgePx ?? 1.5, service.bionicSoftEdgePxMin, service.bionicSoftEdgePxMax)
+                    const bHsvv = service._clampInRange(
+                        object.bionicHsvv ?? 1.0, service.bionicHsvvMin, service.bionicHsvvMax)
+                    if (Number.isFinite(bHsvv))
+                        service.bionicHsvv = bHsvv
+                    const bTrans = service._clampInRange(
+                        object.bionicTransparency ?? 1.0, service.bionicTransparencyMin, service.bionicTransparencyMax)
+                    const cRefract = service._clampInRange(
+                        object.classicRefract ?? 1.5, service.classicRefractMin, service.classicRefractMax)
+                    const cReflect = service._clampInRange(
+                        object.classicReflect ?? 0.6, service.classicReflectMin, service.classicReflectMax)
+                    const cEdge = service._clampInRange(
+                        object.classicEdgeLight ?? 0.1, service.classicEdgeLightMin, service.classicEdgeLightMax)
+                    const cSoft = service._clampInRange(
+                        object.classicSoftEdgePx ?? 1.5, service.classicSoftEdgePxMin, service.classicSoftEdgePxMax)
+                    if (Number.isFinite(bRefract))
+                        service.bionicRefract = bRefract
+                    if (Number.isFinite(bEdge))
+                        service.bionicEdgeLight = bEdge
+                    if (Number.isFinite(bSoft))
+                        service.bionicSoftEdgePx = bSoft
+                    if (Number.isFinite(cRefract))
+                        service.classicRefract = cRefract
+                    if (Number.isFinite(cReflect))
+                        service.classicReflect = cReflect
+                    if (Number.isFinite(cEdge))
+                        service.classicEdgeLight = cEdge
+                    if (Number.isFinite(cSoft))
+                        service.classicSoftEdgePx = cSoft
+                    if (Number.isFinite(bTrans))
+                        service.bionicTransparency = bTrans
 
-                    if (Number(object.version) !== 10
+                    if (Number(object.version) !== 12
                             || !service.isValidShellStyle(style)
-                            || !service.isValidThemeMode(themeMode)
                             || !hasBarIntegration
                             || !service.isValidBarVisibilityMode(barVisibility)
                             || !service.isValidBarLayoutMode(barLayout)
-                            || !service.isValidDockWindowAnimationStyle(animationStyle))
+                            || !service.isValidDockWindowAnimationStyle(animationStyle)
+                            || !Number.isFinite(radiusScale)
+                            || !Number.isFinite(darkDensity)
+                            || !Number.isFinite(edgeStrength)
+                            || !Number.isFinite(bRefract)
+                            || !Number.isFinite(bEdge)
+                            || !Number.isFinite(bSoft)
+                            || !Number.isFinite(bHsvv)
+                            || !Number.isFinite(cRefract)
+                            || !Number.isFinite(cReflect)
+                            || !Number.isFinite(cEdge)
+                            || !Number.isFinite(cSoft))
                         service.saveTimer.restart()
                 } catch (error) {
                     console.warn("[AppearanceConfig] parse error: " + error)

--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -148,6 +148,51 @@ BlurEffect::BlurEffect()
         m_roundedOnscreenPass.refractionOffsetStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionOffsetStrength");
         m_roundedOnscreenPass.refractionBevelIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionBevelIntensity");
         m_roundedOnscreenPass.physicallyBasedRefractionLocation = m_roundedOnscreenPass.shader->uniformLocation("physicallyBasedRefraction");
+        m_roundedOnscreenPass.bionicModeLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicMode");
+        m_roundedOnscreenPass.bionicLumValue0Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue0");
+        m_roundedOnscreenPass.bionicLumValue1Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue1");
+        m_roundedOnscreenPass.bionicLumValue2Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue2");
+        m_roundedOnscreenPass.bionicLumValue3Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue3");
+        m_roundedOnscreenPass.bionicLumAmountLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicLumAmount");
+        m_roundedOnscreenPass.bionicBrightnessLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBrightness");
+        m_roundedOnscreenPass.bionicHsvvBoostLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicHsvvBoost");
+        m_roundedOnscreenPass.bionicDarkerLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDarker");
+        m_roundedOnscreenPass.bionicDarkerRange0Location = m_roundedOnscreenPass.shader->uniformLocation("bionicDarkerRange0");
+        m_roundedOnscreenPass.bionicDarkerRange1Location = m_roundedOnscreenPass.shader->uniformLocation("bionicDarkerRange1");
+        m_roundedOnscreenPass.bionicInnerBottomLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerBottom");
+        m_roundedOnscreenPass.bionicInnerColorWhiteLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerColorWhite");
+        m_roundedOnscreenPass.bionicInnerColorMixLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerColorMix");
+        m_roundedOnscreenPass.bionicColorPowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicColorPow");
+        m_roundedOnscreenPass.bionicAlphaLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicAlpha");
+        m_roundedOnscreenPass.bionicOverallAlphaLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicOverallAlpha");
+        m_roundedOnscreenPass.bionicShapeEdgePxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeEdgePx");
+        m_roundedOnscreenPass.bionicShapeEdgePowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeEdgePow");
+        m_roundedOnscreenPass.bionicShapeThicknessPxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeThicknessPx");
+        m_roundedOnscreenPass.bionicShapeReflectOffsetPxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeReflectOffsetPx");
+        m_roundedOnscreenPass.bionicReflLightenLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicReflLighten");
+        m_roundedOnscreenPass.bionicReflStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicReflStrength");
+        m_roundedOnscreenPass.bionicDirXLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirX");
+        m_roundedOnscreenPass.bionicDirYLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirY");
+        m_roundedOnscreenPass.bionicDirZLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirZ");
+        m_roundedOnscreenPass.bionicDirIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirIntensity");
+        m_roundedOnscreenPass.bionicDirOppositeIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirOppositeIntensity");
+        m_roundedOnscreenPass.bionicDirAngleRangeLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirAngleRange");
+        m_roundedOnscreenPass.bionicDirEdgePowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirEdgePow");
+        m_roundedOnscreenPass.bionicIORLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicIOR");
+        m_roundedOnscreenPass.bionicBgColorSaturationLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBgColorSaturation");
+        m_roundedOnscreenPass.bionicBgColorBrightnessLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBgColorBrightness");
+        m_roundedOnscreenPass.classicModeLocation = m_roundedOnscreenPass.shader->uniformLocation("classicMode");
+        m_roundedOnscreenPass.classicDark0Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark0");
+        m_roundedOnscreenPass.classicDark1Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark1");
+        m_roundedOnscreenPass.classicDark2Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark2");
+        m_roundedOnscreenPass.classicLight0Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight0");
+        m_roundedOnscreenPass.classicLight1Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight1");
+        m_roundedOnscreenPass.classicLight2Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight2");
+        m_roundedOnscreenPass.classicStrokeLocation = m_roundedOnscreenPass.shader->uniformLocation("classicStroke");
+        m_roundedOnscreenPass.classicRefractIORLocation = m_roundedOnscreenPass.shader->uniformLocation("classicRefractIOR");
+        m_roundedOnscreenPass.classicReflLightenLocation = m_roundedOnscreenPass.shader->uniformLocation("classicReflLighten");
+        m_roundedOnscreenPass.classicReflStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("classicReflStrength");
+        m_roundedOnscreenPass.classicMaskSoftLocation = m_roundedOnscreenPass.shader->uniformLocation("classicMaskSoft");
         m_roundedOnscreenPass.tintColorLocation = m_roundedOnscreenPass.shader->uniformLocation("tintColor");
         m_roundedOnscreenPass.tintGrayLocation = m_roundedOnscreenPass.shader->uniformLocation("tintGray");
         m_roundedOnscreenPass.tintStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("tintStrength");
@@ -211,6 +256,24 @@ BlurEffect::BlurEffect()
 
     connect(effects, &EffectsHandler::windowAdded, this, &BlurEffect::slotWindowAdded);
     connect(effects, &EffectsHandler::windowDeleted, this, &BlurEffect::slotWindowDeleted);
+    m_lastCursorPos = effects->cursorPos();
+    connect(effects, &EffectsHandler::mouseChanged, this,
+            [this](const QPointF &pos, const QPointF &oldpos,
+                   Qt::MouseButtons, Qt::MouseButtons,
+                   Qt::KeyboardModifiers, Qt::KeyboardModifiers) {
+                Q_UNUSED(oldpos)
+                m_lastCursorPos = pos;
+                if (!m_settings.bionic.enabled) {
+                    return;
+                }
+                // Repaint only when the cursor can affect a glass surface.
+                for (auto it = m_bionicActivation.constBegin(); it != m_bionicActivation.constEnd(); ++it) {
+                    if (it.key()->frameGeometry().adjusted(-80, -80, 80, 80).contains(pos)) {
+                        effects->addRepaintFull();
+                        break;
+                    }
+                }
+            });
 #ifdef GLASS_X11
     connect(effects, &EffectsHandler::screenRemoved, this, &BlurEffect::slotOutputRemoved);
 #else
@@ -342,18 +405,37 @@ void BlurEffect::initBlurStrengthValues()
 
 void BlurEffect::reconfigure(ReconfigureFlags flags)
 {
+    // KConfig keeps an in-memory copy of the effects config, and
+    // BlurConfig::instance() only ever builds a single KConfigSkeleton bound
+    // to that cached copy. A plain read() therefore returns whatever KWin saw
+    // when it started, so runtime appearance changes written by the shell
+    // (material tuning written by the shell) never reached the shader until
+    // the whole compositor was restarted. Reparse the very config object
+    // BlurConfig is bound to before reading it back.
+    if (auto config = effects->config()) {
+        config->reparseConfiguration();
+    }
     m_settings.read();
 
+    // Bionic (HyperOS soft glass) mode owns the blur budget: the shell's
+    // blur-strength knobs are retired while it is active and a single
+    // BionicBlur value drives every surface.
+    const int bionicBlurPick = m_settings.bionic.enabled
+        ? qBound(0, m_settings.bionic.blur - 1, 14)
+        : -1;
+    const auto pickBlur = [&](int value) {
+        return bionicBlurPick >= 0 ? bionicBlurPick : value;
+    };
     m_contentBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.blurStrength,
+        pickBlur(m_settings.general.blurStrength),
         m_settings.general.noiseStrength
     );
     m_decorationBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.decorationBlurStrength,
+        pickBlur(m_settings.general.decorationBlurStrength),
         m_settings.general.decorationNoiseStrength
     );
     m_dockBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.dockBlurStrength,
+        pickBlur(m_settings.general.dockBlurStrength),
         m_settings.general.dockNoiseStrength
     );
     // AppearanceConfig maps 0..1 to 15 stored levels with
@@ -361,7 +443,7 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
     // zero-based pipeline index. 15% therefore maps to index 2.
     constexpr int fullScreenLauncherMinimumBlurIndex = 2;
     m_fullScreenLauncherBlurSettings = pipelineSettingsForStrength(
-        std::max(m_settings.general.blurStrength,
+        std::max(pickBlur(m_settings.general.blurStrength),
                  fullScreenLauncherMinimumBlurIndex),
         m_settings.general.noiseStrength
     );
@@ -654,6 +736,7 @@ void BlurEffect::slotWindowDeleted(EffectWindow *w)
         disconnect(*it);
         windowFrameGeometryChangedConnections.erase(it);
     }
+    m_bionicActivation.remove(w);
     repaintDynamicCorners();
 }
 
@@ -1741,6 +1824,86 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionOffsetStrengthLocation, m_settings.refraction.refractionOffsetStrength);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionBevelIntensityLocation, m_settings.refraction.refractionBevelIntensity);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.physicallyBasedRefractionLocation, m_settings.refraction.physicallyBased ? 1 : 0);
+    // Bionic hover activation (native ACTIVATED token): per-window amount.
+    // NOTE: the ACTIVATED colorPow (0.4) is deliberately NOT applied — pow()
+    // lifts the whole surface (0.1 -> 0.4), reading as "the entire card goes
+    // white". Only the local passes (darker / directional pair) animate.
+    // smoothed per frame; the directional set fades between the default and
+    // activated values.
+    float bionicAct = 0.0f;
+    if (m_settings.bionic.enabled) {
+        const bool hover = w->frameGeometry().contains(m_lastCursorPos);
+        const float target = hover ? 1.0f : 0.0f;
+        float &act = m_bionicActivation[w];
+        act += (target - act) * 0.16f;
+        if (std::abs(target - act) < 0.005f) {
+            act = target;
+        }
+        if (act != target) {
+            effects->addRepaint(w->frameGeometry().toAlignedRect());
+        }
+        bionicAct = act;
+    } else {
+        m_bionicActivation.remove(w);
+    }
+    const auto bionicMix = [bionicAct](float base, float active) {
+        return base + (active - base) * bionicAct;
+    };
+
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicModeLocation, m_settings.bionic.enabled ? 1 : 0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue0Location, m_settings.bionic.lumValue0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue1Location, m_settings.bionic.lumValue1);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue2Location, m_settings.bionic.lumValue2);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue3Location, m_settings.bionic.lumValue3);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumAmountLocation, m_settings.bionic.lumAmount);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBrightnessLocation, m_settings.bionic.brightness);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicHsvvBoostLocation, m_settings.bionic.hsvvBoost);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerLocation, bionicMix(m_settings.bionic.darker, m_settings.bionic.darkerActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerRange0Location, m_settings.bionic.darkerRange0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerRange1Location, m_settings.bionic.darkerRange1);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerBottomLocation, m_settings.bionic.innerBottom);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerColorWhiteLocation, m_settings.bionic.innerColorWhite);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerColorMixLocation, m_settings.bionic.innerColorMix);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicColorPowLocation, bionicMix(m_settings.bionic.colorPow, m_settings.bionic.colorPowActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicAlphaLocation, m_settings.bionic.alpha);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicOverallAlphaLocation, m_settings.bionic.overallAlpha);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeEdgePxLocation, m_settings.bionic.shapeEdgePx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeEdgePowLocation, m_settings.bionic.shapeEdgePow);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeThicknessPxLocation, m_settings.bionic.shapeThicknessPx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeReflectOffsetPxLocation, m_settings.bionic.shapeReflectOffsetPx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicReflLightenLocation, m_settings.bionic.reflLighten);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicReflStrengthLocation, m_settings.bionic.reflStrength);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirXLocation, m_settings.bionic.dirX);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirYLocation, m_settings.bionic.dirY);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirZLocation, m_settings.bionic.dirZ);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirIntensityLocation, bionicMix(m_settings.bionic.dirIntensity, m_settings.bionic.dirIntensityActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirOppositeIntensityLocation, bionicMix(m_settings.bionic.dirOppositeIntensity, m_settings.bionic.dirOppositeIntensityActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirAngleRangeLocation, m_settings.bionic.dirAngleRange);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirEdgePowLocation, m_settings.bionic.dirEdgePow);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicIORLocation, m_settings.bionic.ior);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBgColorSaturationLocation, m_settings.bionic.bgColorSaturation);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBgColorBrightnessLocation, m_settings.bionic.bgColorBrightness);
+
+    const auto classicLayer = [](const QString &spec) {
+        const QColor c(spec);
+        const float a = spec.isEmpty() ? 0.0f : static_cast<float>(c.alphaF());
+        return QVector4D(static_cast<float>(c.redF()), static_cast<float>(c.greenF()),
+                         static_cast<float>(c.blueF()), a);
+    };
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicModeLocation, m_settings.classic.enabled ? 1 : 0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark0Location, classicLayer(m_settings.classic.dark0));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark1Location, classicLayer(m_settings.classic.dark1));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark2Location, classicLayer(m_settings.classic.dark2));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight0Location, classicLayer(m_settings.classic.light0));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight1Location, classicLayer(m_settings.classic.light1));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight2Location, classicLayer(m_settings.classic.light2));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicRefractIORLocation, m_settings.classic.refractIOR);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicReflLightenLocation, m_settings.classic.reflLighten);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicReflStrengthLocation, m_settings.classic.reflStrength);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicMaskSoftLocation, m_settings.classic.maskSoft);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicStrokeLocation,
+        QVector4D(m_settings.classic.strokeSize, m_settings.classic.strokeStrength,
+                  m_settings.classic.strokeDegree, 0.0f));
 
     QColor tint(m_settings.general.tintColor);
     QVector3D tintVec(tint.redF(), tint.greenF(), tint.blueF());

--- a/vendor/kwin-effects-glass/src/blur.h
+++ b/vendor/kwin-effects-glass/src/blur.h
@@ -190,6 +190,53 @@ private:
         int refractionBevelIntensityLocation;
         int physicallyBasedRefractionLocation;
 
+        int bionicModeLocation;
+        int bionicLumValue0Location;
+        int bionicLumValue1Location;
+        int bionicLumValue2Location;
+        int bionicLumValue3Location;
+        int bionicLumAmountLocation;
+        int bionicBrightnessLocation;
+        int bionicHsvvBoostLocation;
+        int bionicDarkerLocation;
+        int bionicDarkerRange0Location;
+        int bionicDarkerRange1Location;
+        int bionicInnerBottomLocation;
+        int bionicInnerColorWhiteLocation;
+        int bionicInnerColorMixLocation;
+        int bionicColorPowLocation;
+        int bionicAlphaLocation;
+        int bionicOverallAlphaLocation;
+        int bionicShapeEdgePxLocation;
+        int bionicShapeEdgePowLocation;
+        int bionicShapeThicknessPxLocation;
+        int bionicShapeReflectOffsetPxLocation;
+        int bionicReflLightenLocation;
+        int bionicReflStrengthLocation;
+        int bionicDirXLocation;
+        int bionicDirYLocation;
+        int bionicDirZLocation;
+        int bionicDirIntensityLocation;
+        int bionicDirOppositeIntensityLocation;
+        int bionicDirAngleRangeLocation;
+        int bionicDirEdgePowLocation;
+        int bionicIORLocation;
+        int bionicBgColorSaturationLocation;
+        int bionicBgColorBrightnessLocation;
+
+        int classicModeLocation;
+        int classicDark0Location;
+        int classicDark1Location;
+        int classicDark2Location;
+        int classicLight0Location;
+        int classicLight1Location;
+        int classicLight2Location;
+        int classicStrokeLocation;
+        int classicRefractIORLocation;
+        int classicReflLightenLocation;
+        int classicReflStrengthLocation;
+        int classicMaskSoftLocation;
+
         int tintColorLocation;
         int tintGrayLocation;
         int tintStrengthLocation;
@@ -241,6 +288,11 @@ private:
     BlurRegion m_paintedDeviceArea; // keeps track of all painted areas (from bottom to top)
     BlurRegion m_currentDeviceBlur; // keeps track of currently blurred area of the windows (from bottom to top)
     BlurOutput *m_currentOutput = nullptr;
+
+    // Per-window bionic activation amount (0..1), driving the native
+    // ACTIVATED parameter set on hover. Smoothed per frame in blur().
+    QHash<EffectWindow *, float> m_bionicActivation;
+    QPointF m_lastCursorPos;
 
     QMatrix4x4 m_colorMatrix;
     int m_expandSize;

--- a/vendor/kwin-effects-glass/src/blur.kcfg
+++ b/vendor/kwin-effects-glass/src/blur.kcfg
@@ -183,5 +183,161 @@
         <entry name="PhysicallyBasedRefraction" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="BionicMode" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="BionicLumValue0" type="Double">
+            <default>0.67</default>
+        </entry>
+        <entry name="BionicLumValue1" type="Double">
+            <default>0.16</default>
+        </entry>
+        <entry name="BionicLumValue2" type="Double">
+            <default>0.09</default>
+        </entry>
+        <entry name="BionicLumValue3" type="Double">
+            <default>0.0</default>
+        </entry>
+        <entry name="BionicLumAmount" type="Double">
+            <default>0.24</default>
+        </entry>
+        <entry name="BionicBrightness" type="Double">
+            <default>-0.02</default>
+        </entry>
+        <entry name="BionicDarker" type="Double">
+            <default>0.3</default>
+        </entry>
+        <entry name="BionicDarkerRange0" type="Double">
+            <default>0.6</default>
+        </entry>
+        <entry name="BionicDarkerRange1" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicInnerBottom" type="Double">
+            <default>0.03</default>
+        </entry>
+        <entry name="BionicInnerColorWhite" type="Double">
+            <default>0.2</default>
+        </entry>
+        <entry name="BionicInnerColorMix" type="Double">
+            <default>0.3</default>
+        </entry>
+        <entry name="BionicColorPow" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicAlpha" type="Double">
+            <default>0.1</default>
+        </entry>
+        <entry name="BionicOverallAlpha" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicShapeEdgePx" type="Double">
+            <default>7.5</default>
+        </entry>
+        <entry name="BionicHsvvBoost" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicShapeEdgePow" type="Double">
+            <default>3.8</default>
+        </entry>
+        <entry name="BionicShapeThicknessPx" type="Double">
+            <default>80.0</default>
+        </entry>
+        <entry name="BionicShapeReflectOffsetPx" type="Double">
+            <default>800.0</default>
+        </entry>
+        <entry name="BionicReflLighten" type="Double">
+            <default>1.2</default>
+        </entry>
+        <entry name="BionicReflStrength" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicDirX" type="Double">
+            <default>-0.4</default>
+        </entry>
+        <entry name="BionicDirY" type="Double">
+            <default>0.6</default>
+        </entry>
+        <entry name="BionicDirZ" type="Double">
+            <default>-0.8</default>
+        </entry>
+        <entry name="BionicDirIntensity" type="Double">
+            <default>1.4</default>
+        </entry>
+        <entry name="BionicDirOppositeIntensity" type="Double">
+            <default>0.7</default>
+        </entry>
+        <entry name="BionicDirAngleRange" type="Double">
+            <default>0.8</default>
+        </entry>
+        <entry name="BionicDirEdgePow" type="Double">
+            <default>1.15</default>
+        </entry>
+        <entry name="BionicBlur" type="Int">
+            <default>12</default>
+        </entry>
+        <entry name="BionicIOR" type="Double">
+            <default>4.0</default>
+        </entry>
+        <entry name="BionicBgColorSaturation" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="BionicBgColorBrightness" type="Double">
+            <default>0.0</default>
+        </entry>
+        <entry name="BionicActivatedDarker" type="Double">
+            <default>0.42</default>
+        </entry>
+        <entry name="BionicActivatedDirIntensity" type="Double">
+            <default>3.0</default>
+        </entry>
+        <entry name="BionicActivatedDirOppositeIntensity" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="BionicActivatedColorPow" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="ClassicMode" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="ClassicDark0" type="String">
+            <default>#1a000000</default>
+        </entry>
+        <entry name="ClassicDark1" type="String">
+            <default>#66565656</default>
+        </entry>
+        <entry name="ClassicDark2" type="String">
+            <default>#993f3f3f</default>
+        </entry>
+        <entry name="ClassicLight0" type="String">
+            <default>#05000000</default>
+        </entry>
+        <entry name="ClassicLight1" type="String">
+            <default>#14ffffff</default>
+        </entry>
+        <entry name="ClassicLight2" type="String">
+            <default>#0affffff</default>
+        </entry>
+        <entry name="ClassicStrokeSize" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="ClassicStrokeStrength" type="Double">
+            <default>0.1</default>
+        </entry>
+        <entry name="ClassicStrokeDegree" type="Double">
+            <default>24.0</default>
+        </entry>
+        <entry name="ClassicRefractIOR" type="Double">
+            <default>1.5</default>
+        </entry>
+        <entry name="ClassicReflLighten" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="ClassicReflStrength" type="Double">
+            <default>0.06</default>
+        </entry>
+        <entry name="ClassicMaskSoft" type="Double">
+            <default>1.5</default>
+        </entry>
     </group>
 </kcfg>

--- a/vendor/kwin-effects-glass/src/settings.cpp
+++ b/vendor/kwin-effects-glass/src/settings.cpp
@@ -100,6 +100,60 @@ void BlurSettings::read()
     refraction.refractionOffsetStrength = BlurConfig::refractionOffsetStrength() / 2.0;
     refraction.refractionBevelIntensity = BlurConfig::refractionBevelIntensity() / 10.0;
     refraction.physicallyBased = BlurConfig::physicallyBasedRefraction();
+
+    bionic.enabled = BlurConfig::bionicMode();
+    bionic.lumValue0 = BlurConfig::bionicLumValue0();
+    bionic.lumValue1 = BlurConfig::bionicLumValue1();
+    bionic.lumValue2 = BlurConfig::bionicLumValue2();
+    bionic.lumValue3 = BlurConfig::bionicLumValue3();
+    bionic.lumAmount = BlurConfig::bionicLumAmount();
+    bionic.brightness = BlurConfig::bionicBrightness();
+    bionic.darker = BlurConfig::bionicDarker();
+    bionic.darkerRange0 = BlurConfig::bionicDarkerRange0();
+    bionic.darkerRange1 = BlurConfig::bionicDarkerRange1();
+    bionic.innerBottom = BlurConfig::bionicInnerBottom();
+    bionic.innerColorWhite = BlurConfig::bionicInnerColorWhite();
+    bionic.innerColorMix = BlurConfig::bionicInnerColorMix();
+    bionic.colorPow = BlurConfig::bionicColorPow();
+    bionic.alpha = BlurConfig::bionicAlpha();
+    bionic.overallAlpha = BlurConfig::bionicOverallAlpha();
+    bionic.shapeEdgePx = BlurConfig::bionicShapeEdgePx();
+    bionic.shapeEdgePow = BlurConfig::bionicShapeEdgePow();
+    bionic.shapeThicknessPx = BlurConfig::bionicShapeThicknessPx();
+    bionic.shapeReflectOffsetPx = BlurConfig::bionicShapeReflectOffsetPx();
+    bionic.reflLighten = BlurConfig::bionicReflLighten();
+    bionic.reflStrength = BlurConfig::bionicReflStrength();
+    bionic.dirX = BlurConfig::bionicDirX();
+    bionic.dirY = BlurConfig::bionicDirY();
+    bionic.dirZ = BlurConfig::bionicDirZ();
+    bionic.dirIntensity = BlurConfig::bionicDirIntensity();
+    bionic.dirOppositeIntensity = BlurConfig::bionicDirOppositeIntensity();
+    bionic.dirAngleRange = BlurConfig::bionicDirAngleRange();
+    bionic.dirEdgePow = BlurConfig::bionicDirEdgePow();
+    bionic.blur = BlurConfig::bionicBlur();
+    bionic.ior = BlurConfig::bionicIOR();
+    bionic.bgColorSaturation = BlurConfig::bionicBgColorSaturation();
+    bionic.bgColorBrightness = BlurConfig::bionicBgColorBrightness();
+    bionic.hsvvBoost = BlurConfig::bionicHsvvBoost();
+    bionic.darkerActivated = BlurConfig::bionicActivatedDarker();
+    bionic.dirIntensityActivated = BlurConfig::bionicActivatedDirIntensity();
+    bionic.dirOppositeIntensityActivated = BlurConfig::bionicActivatedDirOppositeIntensity();
+    bionic.colorPowActivated = BlurConfig::bionicActivatedColorPow();
+
+    classic.enabled = BlurConfig::classicMode();
+    classic.dark0 = BlurConfig::classicDark0();
+    classic.dark1 = BlurConfig::classicDark1();
+    classic.dark2 = BlurConfig::classicDark2();
+    classic.light0 = BlurConfig::classicLight0();
+    classic.light1 = BlurConfig::classicLight1();
+    classic.light2 = BlurConfig::classicLight2();
+    classic.strokeSize = BlurConfig::classicStrokeSize();
+    classic.strokeStrength = BlurConfig::classicStrokeStrength();
+    classic.strokeDegree = BlurConfig::classicStrokeDegree();
+    classic.refractIOR = BlurConfig::classicRefractIOR();
+    classic.reflLighten = BlurConfig::classicReflLighten();
+    classic.reflStrength = BlurConfig::classicReflStrength();
+    classic.maskSoft = BlurConfig::classicMaskSoft();
 }
 
 }

--- a/vendor/kwin-effects-glass/src/settings.h
+++ b/vendor/kwin-effects-glass/src/settings.h
@@ -88,6 +88,66 @@ struct RefractionSettings
     bool physicallyBased;
 };
 
+struct BionicSettings
+{
+    bool enabled;
+    float lumValue0;
+    float lumValue1;
+    float lumValue2;
+    float lumValue3;
+    float lumAmount;
+    float brightness;
+    float darker;
+    float darkerRange0;
+    float darkerRange1;
+    float innerBottom;
+    float innerColorWhite;
+    float innerColorMix;
+    float colorPow;
+    float alpha;
+    float overallAlpha;
+    float shapeEdgePx;
+    float shapeEdgePow;
+    float shapeThicknessPx;
+    float shapeReflectOffsetPx;
+    float reflLighten;
+    float reflStrength;
+    float dirX;
+    float dirY;
+    float dirZ;
+    float dirIntensity;
+    float dirOppositeIntensity;
+    float dirAngleRange;
+    float dirEdgePow;
+    int blur;
+    float ior;
+    float bgColorSaturation;
+    float bgColorBrightness;
+    float hsvvBoost;
+    float darkerActivated;
+    float dirIntensityActivated;
+    float dirOppositeIntensityActivated;
+    float colorPowActivated;
+};
+
+struct ClassicSettings
+{
+    bool enabled;
+    QString dark0;
+    QString dark1;
+    QString dark2;
+    QString light0;
+    QString light1;
+    QString light2;
+    float strokeSize;
+    float strokeStrength;
+    float strokeDegree;
+    float refractIOR;
+    float reflLighten;
+    float reflStrength;
+    float maskSoft;
+};
+
 class BlurSettings
 {
 public:
@@ -95,6 +155,8 @@ public:
     ForceBlurSettings forceBlur{};
     RoundedCornersSettings roundedCorners{};
     RefractionSettings refraction{};
+    BionicSettings bionic{};
+    ClassicSettings classic{};
 
     void read();
 };

--- a/vendor/kwin-effects-glass/src/shaders/glass.glsl
+++ b/vendor/kwin-effects-glass/src/shaders/glass.glsl
@@ -20,6 +20,63 @@ uniform float refractionOffsetStrength;
 uniform float refractionBevelIntensity;
 uniform int physicallyBasedRefraction;
 
+// ── Bionic light-field (HyperOS 4 soft-glass / MaterialMode$Bionics) ──
+// The 37-float DEFAULT_GLASS_TOKEN recipe from MiBackgroundStyle, now with
+// the field<->value alignment re-verified against three independent
+// sources: the BionicsToken constructor iput sequence, the
+// toBionicsParams() array order, and the sibling GlassToken.create()
+// parameter layout (luminanceValues / darkerRange / inner.color /
+// shape.edge / reflect.lighten / blurBg.*). Consumed by bionicGlass().
+uniform int bionicMode;
+uniform float bionicLumValue0;         // luminanceValue0   0.67
+uniform float bionicLumValue1;         // luminanceValue1   0.16
+uniform float bionicLumValue2;         // luminanceValue2   0.09
+uniform float bionicLumValue3;         // luminanceValue3   0.0
+uniform float bionicLumAmount;         // luminanceAmount   0.24
+uniform float bionicBrightness;        // brightness       -0.02
+uniform float bionicHsvvBoost;         // rou guang ti liang qiang du 1.0
+uniform float bionicDarker;            // darker            0.3
+uniform float bionicDarkerRange0;      // darkerRange[0]    0.6
+uniform float bionicDarkerRange1;      // darkerRange[1]    1.0
+uniform float bionicInnerBottom;       // inner.bottom      0.03
+uniform float bionicInnerColorWhite;   // inner.colorWhite  0.2
+uniform float bionicInnerColorMix;     // inner.colorMix    0.3
+uniform float bionicColorPow;          // inner.colorPow    1.0
+uniform float bionicAlpha;             // inner.color alpha 0.1
+uniform float bionicOverallAlpha;      // overallAlpha      1.0
+uniform float bionicShapeEdgePx;       // shape.edge        72.0
+uniform float bionicShapeEdgePow;      // shape.edgePow     3.8
+uniform float bionicShapeThicknessPx;  // shape.thicknessPx 80.0
+uniform float bionicShapeReflectOffsetPx; // shape.reflectOffsetPx 800.0
+uniform float bionicReflLighten;       // reflect.lighten   1.2
+uniform float bionicReflStrength;      // reflect.strength  1.0
+uniform float bionicDirX;              // directionalLight x -0.4
+uniform float bionicDirY;              // directionalLight y  0.6
+uniform float bionicDirZ;              // directionalLight z -0.8
+uniform float bionicDirIntensity;      // directionalLight intensity 1.4
+uniform float bionicDirOppositeIntensity; // oppositeIntensity 0.7
+uniform float bionicDirAngleRange;     // angleRange        0.8
+uniform float bionicDirEdgePow;        // edgePow           1.15
+uniform float bionicIOR;               // refract.ior (visual calibration kept at 1.2)
+uniform float bionicBgColorSaturation; // blurBg.saturation 2.0
+uniform float bionicBgColorBrightness; // blurBg.brightness 0.0
+
+// ── Classic (HyperOS "light frosted glass") ───────────────────────────
+// Model: blur + stacked colour-blend layers + bloom stroke, from the
+// miuix ColorBlendToken / BloomStrokeToken tables (see apply_classic.py).
+uniform int classicMode;
+uniform vec4 classicDark0;    // rgba layer 0 (dark scene)
+uniform vec4 classicDark1;
+uniform vec4 classicDark2;
+uniform vec4 classicLight0;   // rgba layer 0 (light scene)
+uniform vec4 classicLight1;
+uniform vec4 classicLight2;
+uniform vec4 classicStroke;   // x=size(24) y=strength(0.1) z=w unused w unused
+uniform float classicRefractIOR;     // GlassToken$Refract.ior 1.5
+uniform float classicReflLighten;    // GlassToken$Reflect.lighten 2.0
+uniform float classicReflStrength;   // GlassToken$Reflect.strength 0.6
+uniform float classicMaskSoft;       // shape mask feather px (native setMaskBlur 20)
+
 float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)
 {
     float r = p.x > 0.0
@@ -291,8 +348,252 @@ vec3 applyLiquidGlints(vec3 rgb, vec2 position, vec2 halfBlurSize,
     return rgb;
 }
 
+vec4 bionicGlass(vec4 sum, vec4 cornerRadius)
+{
+    vec2 halfBlurSize = blurSize * 0.5;
+    float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
+
+    vec2 position = uv * blurSize - halfBlurSize.xy;
+    float dist = roundedRectangleDist(position, halfBlurSize, cornerRadius);
+    if (dist >= 0.0) {
+        return sum;
+    }
+
+    // Rim normals (shared by refraction and rim lighting).
+    float minR = min(min(cornerRadius.x, cornerRadius.y), min(cornerRadius.z, cornerRadius.w));
+    float gradRadius = min(minR * 1.5, minHalfSize);
+    vec2 gradient = gradSdRoundedBox(position, halfBlurSize, gradRadius);
+    vec2 n2d = length(gradient) > 1e-5 ? -normalize(gradient) : vec2(0.0, 1.0);
+
+    float interiorDist = -dist;   // 0 at the rim, grows inward
+    const vec3 lumaW = vec3(0.299, 0.587, 0.114);
+
+    // 1) Refraction — IOR-driven gentle lens inside the edge band.
+    //    shapeThicknessPx drives the band width (native thicknessPx, the
+    //    *30 scaling was the value-domain of the previous alignment).
+    float refractAmp = clamp((bionicIOR - 1.0) * 0.15, 0.0, 0.4);
+    float bandW = clamp(bionicShapeThicknessPx * 0.3, 8.0, 60.0);
+    float bandT = 1.0 - clamp(interiorDist / bandW, 0.0, 1.0);
+    float lens = circleMap(bandT);
+    vec2 refrUv = clamp(uv + n2d * (refractAmp * lens), 0.0, 1.0);
+    vec3 base = texture(texUnit, refrUv).rgb;
+
+    // 2) Backdrop treatment — NATIVE ONLY.
+    //    The single backdrop transform with a native formula is `darker`
+    //    (verbatim from bloom_stroke.sksl):
+    //      mix(col, vec3(0.07874,0.02848,0.09278),
+    //          mix(0., darker, smoothstep(range.x, range.y, luma)))
+    //    Saturation / brightness / luminance-step passes were OUR
+    //    approximations and are removed — the native pipeline owns its own
+    //    chroma & luma handling; we must not double-apply or invent one.
+    const vec3 kBionicDarkTint = vec3(0.07874, 0.02848, 0.09278);
+    float darkW = smoothstep(bionicDarkerRange0, bionicDarkerRange1, dot(base, lumaW));
+    base = mix(base, kBionicDarkTint, mix(0.0, bionicDarker, darkW));
+
+    vec3 rgb = base;
+
+    // 3) Rim lighting — ported from bloom_stroke.sksl (calculateLighting /
+    //    dynamicAdd / processLighting / hsvv).
+    //    IMPORTANT: edgeK (rim-band mask) multiplies rawLight — the native
+    //    processLighting only runs OUTSIDE the inner box; applying the lift
+    //    across the whole surface floods the glass (overexposed + flat).
+    float zR = clamp(bionicShapeThicknessPx * 0.15, 2.5, 12.0);
+    float edgeK = 1.0 - clamp(interiorDist / zR, 0.0, 1.0);
+    vec3 dirL = normalize(vec3(bionicDirX, bionicDirY, bionicDirZ));
+    vec3 n3 = vec3(n2d.x, -n2d.y, sqrt(max(0.0, 1.0 - dot(n2d, n2d))));
+    float ndl1 = max(dot(n3, dirL), 0.0);
+    float light1 = ndl1 * max(1.0 - acos(clamp(ndl1, -1.0, 1.0))
+                    / (3.14159 * max(bionicDirAngleRange, 0.05)), 0.0) * bionicDirIntensity;
+    vec3 dirL2 = dirL * vec3(-1.0, -1.0, 1.0);
+    float ndl2 = max(dot(n3, dirL2), 0.0);
+    float light2 = ndl2 * max(1.0 - acos(clamp(ndl2, -1.0, 1.0))
+                    / (3.14159 * max(bionicDirAngleRange, 0.05)), 0.0) * bionicDirOppositeIntensity;
+
+    // dynamicAdd(color) + rawLight + knee -> lightenParam (verbatim chain,
+    // restricted to the rim band so the interior stays untouched).
+    float whiteDis = distance(vec3(1.0), rgb);
+    whiteDis = smoothstep(0.2, 1.0, whiteDis);
+    whiteDis = mix(0.2, 1.0, whiteDis);
+    float lumin0 = dot(rgb, lumaW);
+    float lightRatio = mix(0.8, whiteDis, lumin0);
+    float rawLight = (light1 + light2) * lightRatio * edgeK;
+    rawLight = pow(clamp(rawLight, 0.0, 1.0), 0.85);
+    float knee = mix(1.0, 0.7, smoothstep(0.0, 0.5, lumin0));
+    float lightenParam = rawLight / (rawLight + knee);
+
+    // hsvv(col, lighten): centre-gain lift (native soft-light)
+    {
+        float v = dot(rgb, lumaW);
+        float w = smoothstep(0.0, 0.5, v);
+        float k = mix(1.0 - v, v, w);
+        float g = 1.0 + smoothstep(0.0, 1.0, lightenParam) * mix(0.75, 0.4, w) * max(bionicHsvvBoost, 0.0);
+        rgb = (rgb + vec3(k)) * g - vec3(k);
+    }
+    // clamp (native renderGlassShape does clamp(col, 0, 1) after colorPow)
+    rgb = clamp(rgb, 0.0, 1.0);
+
+
+    // Reflection pair / inner-surface passes removed — they were OUR
+    // approximations (no native formula available); keeping them made the
+    // material diverge from OS4.
+
+    // 4) colorPow — native `pow(color, uColorPow)` (bloom_stroke.sksl).
+    rgb = pow(max(rgb, vec3(0.0)), vec3(max(bionicColorPow, 0.05)));
+
+    // 5) transparency (BionicOverallAlpha) — glass-layer opacity multiplier:
+    //    lower = more see-through (background shows); no longer darkens rgb.
+    float alphaScale = clamp(bionicOverallAlpha, 0.0, 1.0);
+
+    // 6) shape.edge — soft edge transition width, clamped to 25 as in the
+    //    native renderer. Applied at a reduced scale (0.2) so the Qt-side
+    //    surfaces keep a crisp inner edge.
+    // Soft edge width: edgePx maps to pixels at 1:5 scale, clamped to the
+    // native 25px ceiling (72 -> 14.4px... too soft; 25 -> 5px; 125 -> 25px).
+    float edgeSoft = clamp(bionicShapeEdgePx / 5.0, 0.1, 25.0);
+    float edgeT = clamp(-dist / max(edgeSoft, 0.1), 0.0, 1.0);
+    return vec4(rgb, smoothstep(0.0, 1.0, edgeT) * alphaScale);
+}
+
+// ── HyperOS light-frosted (Classic) render path ───────────────────────
+// Native composition: the three colour layers are composited with the
+// *blend modes* from the miuix ColorBlendToken tables instead of plain
+// alpha stacking (the alpha stack read as a grey film).
+//   Pured_Thin_Glass Dark : [PLUS_DARKER, LUMINOSITY, OVERLAY]
+//   Pured_Thin_Glass Light: [PLUS_DARKER, SOFT_LIGHT, HARD_LIGHT]
+float blendSoftLight(float a, float b)
+{
+    return (1.0 - 2.0 * b) * a * a + 2.0 * b * a;
+}
+vec3 blendSoftLight(vec3 a, vec3 b)
+{
+    return vec3(blendSoftLight(a.r, b.r), blendSoftLight(a.g, b.g), blendSoftLight(a.b, b.b));
+}
+vec3 blendOverlay(vec3 a, vec3 b)
+{
+    return mix(2.0 * a * b, 1.0 - 2.0 * (1.0 - a) * (1.0 - b), step(0.5, a));
+}
+vec3 blendHardLight(vec3 a, vec3 b)
+{
+    return blendOverlay(b, a);
+}
+vec3 blendPlusDarker(vec3 a, vec3 b)
+{
+    return max(vec3(0.0), a + b - 1.0);
+}
+vec3 blendLuminosity(vec3 a, vec3 b)
+{
+    // Keep the backdrop's chroma, take the layer's luminance.
+    float lb = dot(b, vec3(0.299, 0.587, 0.114));
+    float la = dot(a, vec3(0.299, 0.587, 0.114));
+    return clamp(a + (lb - la), 0.0, 1.0);
+}
+
+vec3 classicDarkLayers(vec3 c, vec4 l0, vec4 l1, vec4 l2)
+{
+    c = mix(c, blendPlusDarker(c, l0.rgb), l0.a);
+    c = mix(c, blendLuminosity(c, l1.rgb), l1.a);
+    c = mix(c, blendOverlay(c, l2.rgb), l2.a);
+    return c;
+}
+vec3 classicLightLayers(vec3 c, vec4 l0, vec4 l1, vec4 l2)
+{
+    c = mix(c, blendPlusDarker(c, l0.rgb), l0.a);
+    c = mix(c, blendSoftLight(c, l1.rgb), l1.a);
+    c = mix(c, blendHardLight(c, l2.rgb), l2.a);
+    return c;
+}
+
+vec4 classicGlass(vec4 sum, vec4 cornerRadius)
+{
+    vec2 halfBlurSize = blurSize * 0.5;
+    float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
+
+    vec2 position = uv * blurSize - halfBlurSize.xy;
+    float dist = roundedRectangleDist(position, halfBlurSize, cornerRadius);
+    if (dist >= 0.0) {
+        return sum;
+    }
+
+    float interiorDist = -dist;
+
+    // Rim normal (used by refraction and the bloom-stroke gradient).
+    float minR = min(min(cornerRadius.x, cornerRadius.y), min(cornerRadius.z, cornerRadius.w));
+    float gradRadius = min(minR * 1.5, minHalfSize);
+    vec2 gradient2 = gradSdRoundedBox(position, halfBlurSize, gradRadius);
+    vec2 n2d = length(gradient2) > 1e-5 ? -normalize(gradient2) : vec2(0.0, 1.0);
+
+    // 1) Refraction — GlassToken$Refract.ior (1.5, thin-glass family):
+    //    gentle lens inside the edge band (band ~= shape.thickness 60 * 0.3).
+    float clRefAmp = clamp((classicRefractIOR - 1.0) * 0.15, 0.0, 0.4);
+    float clBandW = 18.0;
+    float clBandT = 1.0 - clamp(interiorDist / clBandW, 0.0, 1.0);
+    float clLens = circleMap(clBandT);
+    vec2 clRefrUv = clamp(uv + n2d * (clRefAmp * clLens), 0.0, 1.0);
+    vec3 base = texture(texUnit, clRefrUv).rgb;
+
+    // Scene-dependent layer stack (dark scene vs light scene).
+    float bgLum = dot(base, vec3(0.299, 0.587, 0.114));
+    vec3 darkSide = classicDarkLayers(base, classicDark0, classicDark1, classicDark2);
+    vec3 lightSide = classicLightLayers(base, classicLight0, classicLight1, classicLight2);
+    vec3 rgb = mix(darkSide, lightSide, smoothstep(0.25, 0.55, bgLum));
+
+    // ── Bloom stroke (Glass_Stroke_Middle_Light / _Dark, native recipe) ──
+    //   line: width 0.8dp (~2px), colour white @ 10%, 24-degree gradient.
+    //   The previous build mistook the gradient angle (24) for the width,
+    //   which painted a 24px white band -> the halo.
+    float strokePx = max(classicStroke.x, 0.5);
+    float lineT = 1.0 - clamp(interiorDist / strokePx, 0.0, 1.0);
+    float line = lineT * lineT;                       // crisp, thin falloff
+    float gradA = radians(classicStroke.z);
+    vec2 gradDir = normalize(vec2(cos(gradA), -sin(gradA)));
+    float gradFace = 0.5 + 0.5 * dot(-n2d, gradDir);  // 0..1 along rim
+    float grad = mix(0.35, 1.0, gradFace);
+    rgb += vec3(1.0) * line * grad * classicStroke.y;
+
+    // ── Double light sources (BloomStrokeToken native values) ───────────
+    // Light preset:  src1 rgb(1.0,0.5,0.7) a0.8 @(0.2,0.5,0)
+    //                src2 rgb(1,1,1)      a0.3 @(0,1,1)
+    // Dark preset:   src1 rgb(1.0,0.4,0.7) a0.8
+    //                src2 rgb(1,1,1)      a0.2
+    // Scene blend mirrors the colour-layer stack above; positions are the
+    // native XY (screen y down), raking the stroke from the upper side.
+    float srcScene = smoothstep(0.25, 0.55, bgLum);
+    vec3 src1Col = mix(vec3(1.0, 0.4, 0.7), vec3(1.0, 0.5, 0.7), srcScene);
+    float src1A = 0.8;
+    vec3 src2Col = vec3(1.0);
+    float src2A = mix(0.2, 0.3, srcScene);
+    vec2 src1Dir = normalize(vec2(0.2, -0.5));   // native position (0.2, 0.5)
+    vec2 src2Dir = normalize(vec2(0.0, -1.0));   // native position (0.0, 1.0)
+    float beam1 = pow(clamp(dot(-n2d, src1Dir), 0.0, 1.0), 2.0);
+    float beam2 = pow(clamp(dot(-n2d, src2Dir), 0.0, 1.0), 2.0);
+    rgb += (src1Col * (beam1 * src1A) + src2Col * (beam2 * src2A)) * line * 0.35;
+
+    // 2) Reflection — GlassToken$Reflect (lighten 2.0 / strength 0.6):
+    //    the rim brightens where it faces the light.
+    float clFace = max(n2d.y, 0.0) + max(-n2d.y, 0.0) * 0.35;
+    // Gate the reflection to the stroke band: n2d is only meaningful near the
+    // rim; in the flat interior it carries SDF-gradient quantization that the
+    // ×lighten boost amplified into raster lines.
+    float clReflK = clamp(clFace * classicReflStrength * 0.24, 0.0, 1.0) * line;
+    rgb = mix(rgb, rgb * max(classicReflLighten, 0.0), clReflK);
+
+    // ── maskBlur (native setMaskBlur(0x14 = 20)): feather the shape mask ─
+    float maskSoft = max(classicMaskSoft, 0.1);
+    float maskT = clamp(-dist / maskSoft, 0.0, 1.0);
+    return vec4(rgb, smoothstep(0.0, 1.0, maskT));
+}
+
 vec4 glass(vec4 sum, vec4 cornerRadius)
 {
+    if (bionicMode == 1) {
+        // Soft glass (HyperOS): fully independent of the KOS material.
+        return bionicGlass(sum, cornerRadius);
+    }
+    if (classicMode == 1) {
+        // Light frosted (HyperOS Classic): blur + colour layers + stroke.
+        return classicGlass(sum, cornerRadius);
+    }
+
     vec2 halfBlurSize = blurSize * 0.5;
     float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
 


### PR DESCRIPTION
## 新增内容

在主线基础上新增两套玻璃材质风格（来自澎湃OS 4 的材质设计参考）：

- **柔光玻璃**：高通透、带边缘光与光影流动效果
- **轻透磨砂**：经典磨砂质感、沉稳内敛

### 设置选项（外观页）

- **材质风格**三选一：液态玻璃 / 柔光玻璃 / 轻透磨砂
- **材质微调**（各材质独立生效）：
  - 柔光玻璃：折射强度、边缘光、柔光强度、边缘软边、透明度
  - 轻透磨砂：折射、反射、边缘光、边缘软边
  - 液态玻璃：模糊强度、液态强度

### 说明

- **液态玻璃的渲染与行为保持主线原样，未做改动**
- 设置侧将原「显示」与「主题」合并为「外观」页，原显示页的模糊/液态强度归入材质微调（液态玻璃组）
- 改动文件（10 个）：
  - `vendor/kwin-effects-glass/`：材质渲染（blur.kcfg、settings.h/cpp、blur.h/cpp、shaders/glass.glsl）
  - `apps/settings/`：设置界面与桥接（main.qml、src/main.cpp）
  - `shell/desktop/`：配置服务（AppearanceConfigService.qml、DesktopEnvironment.qml）

### 测试

- 三种材质切换正常，各微调即时生效
- 液态玻璃模式与主线行为一致
