### PR TITLE
feat: 新增柔光玻璃与轻透磨砂两套玻璃材质风格

### DIFF
--- a/apps/settings/main.qml
+++ b/apps/settings/main.qml
@@ -60,11 +60,7 @@ ApplicationWindow {
     }
     readonly property var contentByPage: [
         {
-            subtitle: "显示",
-            groups: []
-        },
-        {
-            subtitle: "主题",
+            subtitle: "外观",
             groups: []
         },
         {
@@ -1347,281 +1343,6 @@ ApplicationWindow {
         }
     }
 
-    component DisplaySettingsPage: ColumnLayout {
-        id: displayPage
-
-        Layout.fillWidth: true
-        spacing: 7
-
-        property var bridge: (typeof settingsBridge !== "undefined")
-            ? settingsBridge : null
-        property real blurStrength: 0.42
-        property real liquidStrength: 1.0
-        property bool blurDirty: false
-        property bool liquidDirty: false
-        property string errorText: ""
-
-        function percentage(value) {
-            return Math.round(value * 100) + "%"
-        }
-
-        function applyState(state) {
-            if (!state)
-                return
-            const rawBlur = state.globalBlurStrength !== undefined
-                ? state.globalBlurStrength : state.blurStrength
-            const rawLiquid = state.globalLiquidStrength !== undefined
-                ? state.globalLiquidStrength : state.liquidStrength
-            if (rawBlur === undefined || rawLiquid === undefined)
-                return
-            blurStrength = Math.max(0, Math.min(1, Number(rawBlur)))
-            liquidStrength = Math.max(0, Math.min(1, Number(rawLiquid)))
-            blurDirty = false
-            liquidDirty = false
-            errorText = ""
-        }
-
-        function refresh() {
-            if (!bridge) {
-                errorText = "尚未构建 Settings 桥接程序"
-                return
-            }
-            applyState(bridge.appearanceSnapshot())
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        Timer {
-            id: liveBlurDebounce
-            interval: 60
-            repeat: false
-            onTriggered: {
-                if (displayPage.bridge && displayPage.blurDirty) {
-                    displayPage.bridge.updateGlobalBlurStrength(displayPage.blurStrength)
-                }
-            }
-        }
-
-        Timer {
-            id: liveLiquidDebounce
-            interval: 60
-            repeat: false
-            onTriggered: {
-                if (displayPage.bridge && displayPage.liquidDirty) {
-                    displayPage.bridge.updateGlobalLiquidStrength(displayPage.liquidStrength)
-                }
-            }
-        }
-
-        function previewBlur(value) {
-            const clamped = Math.max(0, Math.min(1, value))
-            if (Math.abs(blurStrength - clamped) < 0.005)
-                return
-            blurStrength = clamped
-            blurDirty = true
-            liveBlurDebounce.restart()
-        }
-
-        function commitBlur() {
-            liveBlurDebounce.stop()
-            if (!blurDirty || !bridge)
-                return
-            blurDirty = false
-            applyState(bridge.updateGlobalBlurStrength(blurStrength))
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        function previewLiquid(value) {
-            const clamped = Math.max(0, Math.min(1, value))
-            if (Math.abs(liquidStrength - clamped) < 0.005)
-                return
-            liquidStrength = clamped
-            liquidDirty = true
-            liveLiquidDebounce.restart()
-        }
-
-        function commitLiquid() {
-            liveLiquidDebounce.stop()
-            if (!liquidDirty || !bridge)
-                return
-            liquidDirty = false
-            applyState(bridge.updateGlobalLiquidStrength(liquidStrength))
-            if (bridge.lastError)
-                errorText = bridge.lastError
-        }
-
-        function setSystemAppearance(index) {
-            if (!bridge) {
-                errorText = "尚未构建 Settings 桥接程序"
-                return
-            }
-            if (!bridge.applySystemAppearance(index === 1)) {
-                errorText = bridge.lastError
-                return
-            }
-            errorText = ""
-        }
-
-        Component.onCompleted: refresh()
-
-        Text {
-            text: "系统外观".toUpperCase()
-            color: theme.secondaryText
-            font.pixelSize: 12
-            font.weight: Font.DemiBold
-            Layout.leftMargin: 13
-        }
-
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: 54
-            radius: 18
-            color: theme.card
-
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: 16
-                anchors.rightMargin: 16
-                spacing: 12
-
-                SettingIcon { symbol: "◐"; tint: "#5ac8fa" }
-                Text {
-                    text: "色彩模式"
-                    color: theme.primaryText
-                    font.pixelSize: 15
-                    font.weight: Font.DemiBold
-                }
-                Item { Layout.fillWidth: true }
-                SettingsNavBar {
-                    id: systemAppearanceNavBar
-                    model: [
-                        { id: "light", label: "明亮" },
-                        { id: "dark", label: "暗色" }
-                    ]
-                    currentIndex: theme.dark ? 1 : 0
-                    onSelectionChanged: function(index) {
-                        displayPage.setSystemAppearance(index)
-                    }
-                }
-            }
-        }
-
-        Text {
-            text: "液态玻璃".toUpperCase()
-            color: theme.secondaryText
-            font.pixelSize: 12
-            font.weight: Font.DemiBold
-            Layout.leftMargin: 13
-        }
-
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: 97
-            radius: 18
-            color: theme.card
-
-            Column {
-                anchors.fill: parent
-
-                Item {
-                    width: parent.width
-                    height: 48
-
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 16
-                        anchors.rightMargin: 16
-                        spacing: 12
-
-                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
-                        Text {
-                            text: "模糊强度"
-                            color: theme.primaryText
-                            font.pixelSize: 14
-                        }
-                        Item { Layout.fillWidth: true }
-                        Text {
-                            text: displayPage.percentage(displayPage.blurStrength)
-                            color: theme.secondaryText
-                            font.pixelSize: 12
-                            Layout.preferredWidth: 38
-                            horizontalAlignment: Text.AlignRight
-                        }
-                        LiquidControls.LiquidSlider {
-                            Layout.preferredWidth: 190
-                            value: displayPage.blurStrength
-                            trackColor: theme.divider
-                            onPreviewChanged: function(position) {
-                                displayPage.previewBlur(position)
-                            }
-                            onCommitRequested: displayPage.commitBlur()
-                        }
-                    }
-                }
-
-                Rectangle {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.leftMargin: 53
-                    height: 1
-                    color: theme.separator
-                }
-
-                Item {
-                    width: parent.width
-                    height: 48
-
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 16
-                        anchors.rightMargin: 16
-                        spacing: 12
-
-                        SettingIcon { symbol: "≈"; tint: "#af52de" }
-                        Text {
-                            text: "液态强度"
-                            color: theme.primaryText
-                            font.pixelSize: 14
-                        }
-                        Item { Layout.fillWidth: true }
-                        Text {
-                            text: displayPage.percentage(displayPage.liquidStrength)
-                            color: theme.secondaryText
-                            font.pixelSize: 12
-                            Layout.preferredWidth: 38
-                            horizontalAlignment: Text.AlignRight
-                        }
-                        LiquidControls.LiquidSlider {
-                            Layout.preferredWidth: 190
-                            value: displayPage.liquidStrength
-                            trackColor: theme.divider
-                            onPreviewChanged: function(position) {
-                                displayPage.previewLiquid(position)
-                            }
-                            onCommitRequested: displayPage.commitLiquid()
-                        }
-                    }
-                }
-            }
-        }
-
-        IconAppearanceSection {
-            bridge: displayPage.bridge
-        }
-
-        Text {
-            Layout.fillWidth: true
-            Layout.leftMargin: 13
-            Layout.rightMargin: 13
-            visible: displayPage.errorText.length > 0
-            text: displayPage.errorText
-            color: "#ff453a"
-            font.pixelSize: 12
-            wrapMode: Text.Wrap
-        }
-    }
-
     component IconAppearanceSection: ColumnLayout {
         id: iconAppearance
 
@@ -1828,6 +1549,71 @@ ApplicationWindow {
         property string shellStyle: "macos"
         property string dockWindowAnimationStyle: "scale"
         property string errorText: ""
+        property string materialStyle: "liquid"
+        property string tuningErrorText: ""
+        property real blurStrength: 0.42
+        property real liquidStrength: 1.0
+        property bool blurDirty: false
+        property bool liquidDirty: false
+        // 材质微调参数（柔光玻璃）
+        property real bionicRefract: 4.0
+        property real bionicEdgeLight: 1.4
+        property real bionicSoftEdgePx: 1.5
+        property real bionicHsvv: 1.0
+        property real bionicTransparency: 1.0
+        property real bionicActDarken: 0.42
+        property real bionicActEdgeLight: 3.0
+        property real bionicActOpposite: 2.0
+        property real bionicActHsvv: 1.6
+        property real bionicActRefl: 1.3
+        property real bionicActRefract: 4.6
+        property real bionicLum0: 0.67
+        property real bionicLum1: 0.16
+        property real bionicLum2: 0.09
+        property real bionicLum3: 0.0
+        property real bionicLumAmount: 0.24
+        property real bionicDarkBase: 0.3
+        property real bionicDarkRange0: 0.6
+        property real bionicDarkRange1: 1.0
+        property real bionicBrightBase: -0.02
+        property real bionicInnerBottom: 0.03
+        property real bionicInnerWhite: 0.2
+        property real bionicInnerMix: 0.3
+        property real bionicColorPow: 1.0
+        property real bionicAlphaLayer: 0.1
+        property real bionicShapeEdgePow: 3.8
+        property real bionicShapeThickness: 80.0
+        property real bionicReflectOffset: 800.0
+        property real bionicReflLighten: 1.2
+        property real bionicReflStrength: 1.0
+        property real bionicDirX: -0.4
+        property real bionicDirY: 0.6
+        property real bionicDirZ: -0.8
+        property real bionicDirInt: 1.4
+        property real bionicDirOpp: 0.7
+        property real bionicDirAngle: 0.8
+        property real bionicDirEdgePow: 1.15
+        property real bionicBgSat: 2.0
+        property real bionicBgBri: 0.0
+        property real bionicActColorPow: 1.0
+        // 材质微调参数（轻透磨砂）
+        property real classicRefract: 1.5
+        property real classicReflect: 0.06
+        property real classicEdgeLight: 0.1
+        property real classicSoftEdgePx: 1.5
+        property real classicStrokeDegree: 24.0
+        property real classicStrokeSize: 2.0
+        property real classicReflLighten: 2.0
+        // 预览值（-1 = 未拖动）
+        property real bionicRefractPreview: -1
+        property real bionicEdgeLightPreview: -1
+        property real bionicSoftEdgePxPreview: -1
+        property real bionicHsvvPreview: -1
+        property real bionicTransparencyPreview: -1
+        property real classicRefractPreview: -1
+        property real classicReflectPreview: -1
+        property real classicEdgeLightPreview: -1
+        property real classicSoftEdgePxPreview: -1
         readonly property var styles: [
             {
                 id: "windows12",
@@ -1862,8 +1648,62 @@ ApplicationWindow {
             if (!state || !isValidStyle(state.shellStyle))
                 return
             shellStyle = state.shellStyle
+            if (state.materialStyle === "liquid" || state.materialStyle === "bionic"
+                    || state.materialStyle === "classic")
+                materialStyle = state.materialStyle
             if (isValidDockWindowAnimationStyle(state.dockWindowAnimationStyle))
                 dockWindowAnimationStyle = state.dockWindowAnimationStyle
+            if (isFinite(state.bionicRefract)) bionicRefract = state.bionicRefract
+            if (isFinite(state.bionicEdgeLight)) bionicEdgeLight = state.bionicEdgeLight
+            if (isFinite(state.bionicSoftEdgePx)) bionicSoftEdgePx = state.bionicSoftEdgePx
+            if (isFinite(state.bionicHsvv)) bionicHsvv = state.bionicHsvv
+            if (isFinite(state.bionicTransparency)) bionicTransparency = state.bionicTransparency
+            if (isFinite(state.classicRefract)) classicRefract = state.classicRefract
+            if (isFinite(state.classicReflect)) classicReflect = state.classicReflect
+            if (isFinite(state.classicEdgeLight)) classicEdgeLight = state.classicEdgeLight
+            if (isFinite(state.classicSoftEdgePx)) classicSoftEdgePx = state.classicSoftEdgePx
+            if (isFinite(state.classicStrokeDegree)) classicStrokeDegree = state.classicStrokeDegree
+            if (isFinite(state.classicStrokeSize)) classicStrokeSize = state.classicStrokeSize
+            if (isFinite(state.classicReflLighten)) classicReflLighten = state.classicReflLighten
+            if (isFinite(state.bionicActDarken)) bionicActDarken = state.bionicActDarken
+            if (isFinite(state.bionicActEdgeLight)) bionicActEdgeLight = state.bionicActEdgeLight
+            if (isFinite(state.bionicActOpposite)) bionicActOpposite = state.bionicActOpposite
+            if (isFinite(state.bionicActHsvv)) bionicActHsvv = state.bionicActHsvv
+            if (isFinite(state.bionicActRefl)) bionicActRefl = state.bionicActRefl
+            if (isFinite(state.bionicActRefract)) bionicActRefract = state.bionicActRefract
+            if (isFinite(state.bionicLum0)) bionicLum0 = state.bionicLum0
+            if (isFinite(state.bionicLum1)) bionicLum1 = state.bionicLum1
+            if (isFinite(state.bionicLum2)) bionicLum2 = state.bionicLum2
+            if (isFinite(state.bionicLum3)) bionicLum3 = state.bionicLum3
+            if (isFinite(state.bionicLumAmount)) bionicLumAmount = state.bionicLumAmount
+            if (isFinite(state.bionicDarkBase)) bionicDarkBase = state.bionicDarkBase
+            if (isFinite(state.bionicDarkRange0)) bionicDarkRange0 = state.bionicDarkRange0
+            if (isFinite(state.bionicDarkRange1)) bionicDarkRange1 = state.bionicDarkRange1
+            if (isFinite(state.bionicBrightBase)) bionicBrightBase = state.bionicBrightBase
+            if (isFinite(state.bionicInnerBottom)) bionicInnerBottom = state.bionicInnerBottom
+            if (isFinite(state.bionicInnerWhite)) bionicInnerWhite = state.bionicInnerWhite
+            if (isFinite(state.bionicInnerMix)) bionicInnerMix = state.bionicInnerMix
+            if (isFinite(state.bionicColorPow)) bionicColorPow = state.bionicColorPow
+            if (isFinite(state.bionicAlphaLayer)) bionicAlphaLayer = state.bionicAlphaLayer
+            if (isFinite(state.bionicShapeEdgePow)) bionicShapeEdgePow = state.bionicShapeEdgePow
+            if (isFinite(state.bionicShapeThickness)) bionicShapeThickness = state.bionicShapeThickness
+            if (isFinite(state.bionicReflectOffset)) bionicReflectOffset = state.bionicReflectOffset
+            if (isFinite(state.bionicReflLighten)) bionicReflLighten = state.bionicReflLighten
+            if (isFinite(state.bionicReflStrength)) bionicReflStrength = state.bionicReflStrength
+            if (isFinite(state.bionicDirX)) bionicDirX = state.bionicDirX
+            if (isFinite(state.bionicDirY)) bionicDirY = state.bionicDirY
+            if (isFinite(state.bionicDirZ)) bionicDirZ = state.bionicDirZ
+            if (isFinite(state.bionicDirInt)) bionicDirInt = state.bionicDirInt
+            if (isFinite(state.bionicDirOpp)) bionicDirOpp = state.bionicDirOpp
+            if (isFinite(state.bionicDirAngle)) bionicDirAngle = state.bionicDirAngle
+            if (isFinite(state.bionicDirEdgePow)) bionicDirEdgePow = state.bionicDirEdgePow
+            if (isFinite(state.bionicBgSat)) bionicBgSat = state.bionicBgSat
+            if (isFinite(state.bionicBgBri)) bionicBgBri = state.bionicBgBri
+            if (isFinite(state.bionicActColorPow)) bionicActColorPow = state.bionicActColorPow
+            if (isFinite(state.globalBlurStrength))
+                blurStrength = Math.max(0, Math.min(1, Number(state.globalBlurStrength)))
+            if (isFinite(state.globalLiquidStrength))
+                liquidStrength = Math.max(0, Math.min(1, Number(state.globalLiquidStrength)))
             errorText = ""
         }
 
@@ -1896,7 +1736,233 @@ ApplicationWindow {
             if (bridge.lastError)
                 errorText = bridge.lastError
         }
+
+        function isValidMaterialStyle(v) {
+            return v === "liquid" || v === "bionic" || v === "classic"
+        }
+
+        function setMaterialStyle(style) {
+            if (!bridge || !isValidMaterialStyle(style)) {
+                errorText = bridge ? "未知的材质风格" : "尚未构建 Settings 桥接程序"
+                return
+            }
+            materialStyle = style
+            applyState(bridge.updateMaterialStyle(style))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function applyTuningState(state) {
+            if (!state) {
+                tuningErrorText = bridge ? "外观设置返回的数据不完整" : ""
+                return
+            }
+            applyState(state)
+            tuningErrorText = ""
+        }
+
+        function setBionicValue(prop, value) {
+            if (!bridge)
+                return
+            const map = {
+                bionicRefract: bridge.updateBionicRefract,
+                bionicEdgeLight: bridge.updateBionicEdgeLight,
+                bionicSoftEdgePx: bridge.updateBionicSoftEdgePx,
+                bionicHsvv: bridge.updateBionicHsvv,
+                bionicTransparency: bridge.updateBionicTransparency,
+                bionicActDarken: bridge.updateBionicActDarken,
+                bionicActEdgeLight: bridge.updateBionicActEdgeLight,
+                bionicActOpposite: bridge.updateBionicActOpposite,
+                bionicActHsvv: bridge.updateBionicActHsvv,
+                bionicActRefl: bridge.updateBionicActRefl,
+                bionicActRefract: bridge.updateBionicActRefract,
+                bionicLum0: bridge.updateBionicLum0,
+                bionicLum1: bridge.updateBionicLum1,
+                bionicLum2: bridge.updateBionicLum2,
+                bionicLum3: bridge.updateBionicLum3,
+                bionicLumAmount: bridge.updateBionicLumAmount,
+                bionicDarkBase: bridge.updateBionicDarkBase,
+                bionicDarkRange0: bridge.updateBionicDarkRange0,
+                bionicDarkRange1: bridge.updateBionicDarkRange1,
+                bionicBrightBase: bridge.updateBionicBrightBase,
+                bionicInnerBottom: bridge.updateBionicInnerBottom,
+                bionicInnerWhite: bridge.updateBionicInnerWhite,
+                bionicInnerMix: bridge.updateBionicInnerMix,
+                bionicColorPow: bridge.updateBionicColorPow,
+                bionicAlphaLayer: bridge.updateBionicAlphaLayer,
+                bionicShapeEdgePow: bridge.updateBionicShapeEdgePow,
+                bionicShapeThickness: bridge.updateBionicShapeThickness,
+                bionicReflectOffset: bridge.updateBionicReflectOffset,
+                bionicReflLighten: bridge.updateBionicReflLighten,
+                bionicReflStrength: bridge.updateBionicReflStrength,
+                bionicDirX: bridge.updateBionicDirX,
+                bionicDirY: bridge.updateBionicDirY,
+                bionicDirZ: bridge.updateBionicDirZ,
+                bionicDirInt: bridge.updateBionicDirInt,
+                bionicDirOpp: bridge.updateBionicDirOpp,
+                bionicDirAngle: bridge.updateBionicDirAngle,
+                bionicDirEdgePow: bridge.updateBionicDirEdgePow,
+                bionicBgSat: bridge.updateBionicBgSat,
+                bionicBgBri: bridge.updateBionicBgBri,
+                bionicActColorPow: bridge.updateBionicActColorPow
+            }
+            if (!map[prop])
+                return
+            themePage[prop] = value
+            applyTuningState(map[prop](value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function setClassicValue(prop, value) {
+            if (!bridge)
+                return
+            const map = {
+                classicStrokeDegree: bridge.updateClassicStrokeDegree,
+                classicStrokeSize: bridge.updateClassicStrokeSize,
+                classicReflLighten: bridge.updateClassicReflLighten
+            }
+            if (!map[prop])
+                return
+            themePage[prop] = value
+            applyTuningState(map[prop](value))
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function resetMaterialTuning() {
+            if (!bridge) {
+                tuningErrorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            applyTuningState(bridge.resetMaterialTuning())
+            if (bridge.lastError)
+                tuningErrorText = bridge.lastError
+        }
+
+        function percentage(value) {
+            return Math.round(value * 100) + "%"
+        }
+
+        Timer {
+            id: liveBlurDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (themePage.bridge && themePage.blurDirty) {
+                    themePage.bridge.updateGlobalBlurStrength(themePage.blurStrength)
+                }
+            }
+        }
+
+        Timer {
+            id: liveLiquidDebounce
+            interval: 60
+            repeat: false
+            onTriggered: {
+                if (themePage.bridge && themePage.liquidDirty) {
+                    themePage.bridge.updateGlobalLiquidStrength(themePage.liquidStrength)
+                }
+            }
+        }
+
+        function previewBlur(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(blurStrength - clamped) < 0.005)
+                return
+            blurStrength = clamped
+            blurDirty = true
+            liveBlurDebounce.restart()
+        }
+
+        function commitBlur() {
+            liveBlurDebounce.stop()
+            if (!blurDirty || !bridge)
+                return
+            blurDirty = false
+            applyState(bridge.updateGlobalBlurStrength(blurStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function previewLiquid(value) {
+            const clamped = Math.max(0, Math.min(1, value))
+            if (Math.abs(liquidStrength - clamped) < 0.005)
+                return
+            liquidStrength = clamped
+            liquidDirty = true
+            liveLiquidDebounce.restart()
+        }
+
+        function commitLiquid() {
+            liveLiquidDebounce.stop()
+            if (!liquidDirty || !bridge)
+                return
+            liquidDirty = false
+            applyState(bridge.updateGlobalLiquidStrength(liquidStrength))
+            if (bridge.lastError)
+                errorText = bridge.lastError
+        }
+
+        function setSystemAppearance(index) {
+            if (!bridge) {
+                errorText = "尚未构建 Settings 桥接程序"
+                return
+            }
+            if (!bridge.applySystemAppearance(index === 1)) {
+                errorText = bridge.lastError
+                return
+            }
+            errorText = ""
+        }
+
         Component.onCompleted: refresh()
+
+        Text {
+            text: "系统外观".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: 54
+            radius: 18
+            color: theme.card
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 16
+                anchors.rightMargin: 16
+                spacing: 12
+
+                SettingIcon { symbol: "◐"; tint: "#5ac8fa" }
+                Text {
+                    text: "色彩模式"
+                    color: theme.primaryText
+                    font.pixelSize: 15
+                    font.weight: Font.DemiBold
+                }
+                Item { Layout.fillWidth: true }
+                SettingsNavBar {
+                    id: systemAppearanceNavBar
+                    model: [
+                        { id: "light", label: "明亮" },
+                        { id: "dark", label: "暗色" }
+                    ]
+                    currentIndex: theme.dark ? 1 : 0
+                    onSelectionChanged: function(index) {
+                        themePage.setSystemAppearance(index)
+                    }
+                }
+            }
+        }
+
+        IconAppearanceSection {
+            bridge: themePage.bridge
+        }
 
         Text {
             text: "界面形态".toUpperCase()
@@ -2056,6 +2122,2154 @@ ApplicationWindow {
             font.pixelSize: 12
             wrapMode: Text.Wrap
         }
+
+        // ── 材质风格（三选一）──
+        Text {
+            visible: themePage.shellStyle !== "material"
+            text: "材质风格".toUpperCase()
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+            Layout.leftMargin: 13
+            Layout.topMargin: 8
+        }
+
+        RowLayout {
+            visible: themePage.shellStyle !== "material"
+            Layout.fillWidth: true
+            spacing: 12
+            Repeater {
+                model: [
+                    { id: "liquid", name: "液态玻璃", desc: "KOS 经典玻璃效果" },
+                    { id: "bionic", name: "柔光玻璃", desc: "更高通透，光影流动" },
+                    { id: "classic", name: "轻透磨砂", desc: "经典磨砂，沉稳内敛" }
+                ]
+                delegate: Rectangle {
+                    required property var modelData
+                    Layout.fillWidth: true
+                    implicitHeight: 92
+                    radius: 18
+                    color: theme.card
+                    border.width: themePage.materialStyle === modelData.id ? 2 : 1
+                    border.color: themePage.materialStyle === modelData.id
+                        ? "#ff6900" : theme.floatingBorder
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: 5
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: modelData.name
+                            color: theme.primaryText
+                            font.pixelSize: 15
+                            font.weight: Font.Bold
+                        }
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: modelData.desc
+                            color: theme.secondaryText
+                            font.pixelSize: 11
+                        }
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: themePage.setMaterialStyle(modelData.id)
+                    }
+                }
+            }
+        }
+
+        // ── 材质微调 ──
+        Text {
+            visible: themePage.shellStyle !== "material"
+            Layout.fillWidth: true
+            Layout.leftMargin: 13
+            Layout.rightMargin: 13
+            Layout.topMargin: 8
+            text: themePage.materialStyle === "bionic" ? "柔光玻璃微调"
+                : themePage.materialStyle === "classic" ? "轻透磨砂微调"
+                : themePage.materialStyle === "liquid" ? "液态玻璃微调"
+                : "材质微调"
+            color: theme.secondaryText
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+        }
+
+        Rectangle {
+            id: materialTuningCard
+            Layout.fillWidth: true
+            implicitHeight: materialTuningColumn.implicitHeight + 32
+            radius: 18
+            color: theme.card
+            visible: themePage.shellStyle !== "material"
+                && (themePage.materialStyle === "bionic" || themePage.materialStyle === "classic"
+                    || themePage.materialStyle === "liquid")
+
+            ColumnLayout {
+                id: materialTuningColumn
+                anchors.fill: parent
+                anchors.margins: 16
+                spacing: 14
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "liquid"
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◌"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "模糊强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "液态玻璃背景的模糊程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: themePage.percentage(themePage.blurStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: themePage.blurStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.previewBlur(position)
+                            }
+                            onCommitRequested: themePage.commitBlur()
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "≈"; tint: "#af52de" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "液态强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "液态玻璃的流动感强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: themePage.percentage(themePage.liquidStrength)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: themePage.liquidStrength
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.previewLiquid(position)
+                            }
+                            onCommitRequested: themePage.commitLiquid()
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "bionic"
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "折射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的光线弯折"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicRefract).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicRefract - (1.0)) / ((5.0) - (1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "鼠标靠近时点亮的边缘光强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicEdgeLight).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicEdgeLight - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "柔光强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "柔光提亮的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicHsvv).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicHsvv - (0.0)) / ((2.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicHsvv", (0.0) + Math.max(0, Math.min(1, position)) * ((2.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicHsvv", (0.0) + Math.max(0, Math.min(1, position)) * ((2.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘软边"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃边缘的柔和过渡宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicSoftEdgePx).toFixed(1)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicSoftEdgePx - (0.1)) / ((25.0) - (0.1))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicSoftEdgePx", (0.1) + Math.max(0, Math.min(1, position)) * ((25.0) - (0.1)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicSoftEdgePx", (0.1) + Math.max(0, Math.min(1, position)) * ((25.0) - (0.1)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "透明度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃层透明度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicTransparency).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicTransparency - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicTransparency", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicTransparency", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活暗部"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时玻璃暗部加深程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActDarken).toFixed(3)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActDarken - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActDarken", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActDarken", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活边缘光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时点亮边缘光的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActEdgeLight).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActEdgeLight - (0.0)) / ((5.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活对向光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时对向补光的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActOpposite).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActOpposite - (0.0)) / ((5.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActOpposite", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActOpposite", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活柔光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时柔光提亮的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActHsvv).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActHsvv - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActHsvv", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActHsvv", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活反射"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时玻璃反射的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActRefl).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActRefl - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActRefl", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActRefl", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活折射"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时折射的增强值"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActRefract).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActRefract - (1.0)) / ((8.0) - (1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((8.0) - (1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((8.0) - (1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "亮度一档"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "阴影区亮度基准"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicLum0).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicLum0 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicLum0", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicLum0", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "亮度二档"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "中间调亮度基准"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicLum1).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicLum1 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicLum1", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicLum1", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "亮度三档"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "亮部亮度基准"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicLum2).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicLum2 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicLum2", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicLum2", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "亮度四档"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "高光区亮度基准"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicLum3).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicLum3 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicLum3", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicLum3", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "亮度自适应"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "亮度自适应强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicLumAmount).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicLumAmount - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicLumAmount", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicLumAmount", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "暗部基础"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃暗部加深程度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDarkBase).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDarkBase - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDarkBase", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDarkBase", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "暗部区间起"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "暗部作用起始亮度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDarkRange0).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDarkRange0 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDarkRange0", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDarkRange0", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "暗部区间止"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "暗部作用结束亮度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDarkRange1).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDarkRange1 - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDarkRange1", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDarkRange1", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "基底亮度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃整体亮度补偿"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicBrightBase).toFixed(3)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicBrightBase - (-0.2)) / ((0.2) - (-0.2))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicBrightBase", (-0.2) + Math.max(0, Math.min(1, position)) * ((0.2) - (-0.2)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicBrightBase", (-0.2) + Math.max(0, Math.min(1, position)) * ((0.2) - (-0.2)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "内表面底部"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "内表面下缘高度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicInnerBottom).toFixed(3)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicInnerBottom - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicInnerBottom", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicInnerBottom", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "内表面白度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "内表面白色强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicInnerWhite).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicInnerWhite - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicInnerWhite", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicInnerWhite", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "内表面混合"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "内表面颜色混合比"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicInnerMix).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicInnerMix - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicInnerMix", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicInnerMix", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "颜色指数"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃颜色幂曲线"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicColorPow).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicColorPow - (0.05)) / ((3.0) - (0.05))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicColorPow", (0.05) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.05)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicColorPow", (0.05) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.05)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "玻璃底透明度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃层基础 alpha"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicAlphaLayer).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicAlphaLayer - (0.0)) / ((1.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicAlphaLayer", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicAlphaLayer", (0.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘过渡指数"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "边缘软化的曲线形状"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicShapeEdgePow).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicShapeEdgePow - (0.5)) / ((10.0) - (0.5))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicShapeEdgePow", (0.5) + Math.max(0, Math.min(1, position)) * ((10.0) - (0.5)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicShapeEdgePow", (0.5) + Math.max(0, Math.min(1, position)) * ((10.0) - (0.5)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "玻璃厚度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "折射带宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicShapeThickness).toFixed(0)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicShapeThickness - (10.0)) / ((200.0) - (10.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicShapeThickness", (10.0) + Math.max(0, Math.min(1, position)) * ((200.0) - (10.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicShapeThickness", (10.0) + Math.max(0, Math.min(1, position)) * ((200.0) - (10.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射偏移"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "反射采样偏移"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicReflectOffset).toFixed(0)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicReflectOffset - (0.0)) / ((1600.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicReflectOffset", (0.0) + Math.max(0, Math.min(1, position)) * ((1600.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicReflectOffset", (0.0) + Math.max(0, Math.min(1, position)) * ((1600.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射提亮"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "反射提亮系数"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicReflLighten).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicReflLighten - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicReflLighten", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicReflLighten", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃反射强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicReflStrength).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicReflStrength - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicReflStrength", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicReflStrength", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "光向量X"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "方向光 X 分量"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirX).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirX - (-1.0)) / ((1.0) - (-1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirX", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirX", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "光向量Y"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "方向光 Y 分量"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirY).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirY - (-1.0)) / ((1.0) - (-1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirY", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirY", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "光向量Z"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "方向光 Z 分量"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirZ).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirZ - (-1.0)) / ((1.0) - (-1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirZ", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirZ", (-1.0) + Math.max(0, Math.min(1, position)) * ((1.0) - (-1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "方向光强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "基础方向光强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirInt).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirInt - (0.0)) / ((5.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirInt", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirInt", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "对向光强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "对向补光强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirOpp).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirOpp - (0.0)) / ((5.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirOpp", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirOpp", (0.0) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "光照角度范围"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "方向光作用角度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirAngle).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirAngle - (0.05)) / ((3.14) - (0.05))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirAngle", (0.05) + Math.max(0, Math.min(1, position)) * ((3.14) - (0.05)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirAngle", (0.05) + Math.max(0, Math.min(1, position)) * ((3.14) - (0.05)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "方向光边缘指数"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "边缘光照曲线"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicDirEdgePow).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicDirEdgePow - (0.1)) / ((5.0) - (0.1))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicDirEdgePow", (0.1) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.1)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicDirEdgePow", (0.1) + Math.max(0, Math.min(1, position)) * ((5.0) - (0.1)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "背景饱和度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "背景色彩饱和"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicBgSat).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicBgSat - (0.0)) / ((3.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicBgSat", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicBgSat", (0.0) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "背景亮度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "背景亮度补偿"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicBgBri).toFixed(3)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicBgBri - (-0.5)) / ((0.5) - (-0.5))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicBgBri", (-0.5) + Math.max(0, Math.min(1, position)) * ((0.5) - (-0.5)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicBgBri", (-0.5) + Math.max(0, Math.min(1, position)) * ((0.5) - (-0.5)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "激活颜色指数"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "悬停时颜色幂"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.bionicActColorPow).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.bionicActColorPow - (0.05)) / ((3.0) - (0.05))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setBionicValue("bionicActColorPow", (0.05) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.05)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setBionicValue("bionicActColorPow", (0.05) + Math.max(0, Math.min(1, position)) * ((3.0) - (0.05)))
+                            }
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 14
+                    visible: themePage.materialStyle === "classic"
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "折射"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "磨砂玻璃的折射率"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicRefract).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicRefract - (1.0)) / ((2.0) - (1.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((2.0) - (1.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicRefract", (1.0) + Math.max(0, Math.min(1, position)) * ((2.0) - (1.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射强度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃反射强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicReflect).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicReflect - (0.0)) / ((1.5) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicReflect", (0.0) + Math.max(0, Math.min(1, position)) * ((1.5) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicReflect", (0.0) + Math.max(0, Math.min(1, position)) * ((1.5) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘光"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "描边光的强度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicEdgeLight).toFixed(2)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicEdgeLight - (0.0)) / ((0.5) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((0.5) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicEdgeLight", (0.0) + Math.max(0, Math.min(1, position)) * ((0.5) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "边缘软边"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "边缘的柔和过渡宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicSoftEdgePx).toFixed(1)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicSoftEdgePx - (0.5)) / ((25.0) - (0.5))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicSoftEdgePx", (0.5) + Math.max(0, Math.min(1, position)) * ((25.0) - (0.5)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicSoftEdgePx", (0.5) + Math.max(0, Math.min(1, position)) * ((25.0) - (0.5)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "描边角度"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃描边的方向角度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicStrokeDegree).toFixed(0)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicStrokeDegree - (0.0)) / ((360.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicStrokeDegree", (0.0) + Math.max(0, Math.min(1, position)) * ((360.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicStrokeDegree", (0.0) + Math.max(0, Math.min(1, position)) * ((360.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "描边尺寸"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "玻璃描边的宽度"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicStrokeSize).toFixed(1)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicStrokeSize - (0.0)) / ((20.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicStrokeSize", (0.0) + Math.max(0, Math.min(1, position)) * ((20.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicStrokeSize", (0.0) + Math.max(0, Math.min(1, position)) * ((20.0) - (0.0)))
+                            }
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 12
+                        SettingIcon { symbol: "◈"; tint: "#5ac8fa" }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 2
+                            Text {
+                                text: "反射提亮"
+                                color: theme.primaryText
+                                font.pixelSize: 14
+                                font.weight: Font.DemiBold
+                            }
+                            Text {
+                                text: "反射的提亮系数"
+                                color: theme.secondaryText
+                                font.pixelSize: 11
+                                wrapMode: Text.Wrap
+                                Layout.fillWidth: true
+                            }
+                        }
+                        Text {
+                            text: Number(themePage.classicReflLighten).toFixed(1)
+                            color: theme.secondaryText
+                            font.pixelSize: 12
+                            Layout.preferredWidth: 56
+                            horizontalAlignment: Text.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+                        LiquidControls.LiquidSlider {
+                            Layout.preferredWidth: 150
+                            value: Math.max(0, Math.min(1, (themePage.classicReflLighten - (0.0)) / ((4.0) - (0.0))))
+                            trackColor: theme.divider
+                            onPreviewChanged: function(position) {
+                                themePage.setClassicValue("classicReflLighten", (0.0) + Math.max(0, Math.min(1, position)) * ((4.0) - (0.0)))
+                            }
+                            onCommitRequested: function(position) {
+                                themePage.setClassicValue("classicReflLighten", (0.0) + Math.max(0, Math.min(1, position)) * ((4.0) - (0.0)))
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.topMargin: 6
+                    implicitHeight: 40
+                    radius: 10
+                    color: resetHover.hovered ? Qt.rgba(1, 0.41, 0, 0.16) : Qt.rgba(1, 0.41, 0, 0.08)
+                    border.width: 1
+                    border.color: "#ff6900"
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "恢复默认"
+                        color: "#ff6900"
+                        font.pixelSize: 13
+                        font.weight: Font.Medium
+                    }
+
+                    HoverHandler {
+                        id: resetHover
+                        cursorShape: Qt.PointingHandCursor
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            console.log("[Reset] >>> clicked!")
+                            themePage.resetMaterialTuning()
+                            console.log("[Reset] >>> done, lastError=" + (bridge ? bridge.lastError : "no-bridge"))
+                        }
+                    }
+                }
+            }
+        }
+
 
         Text {
             text: "窗口动画"
@@ -3283,17 +5497,9 @@ ApplicationWindow {
 
                 SidebarEntry {
                     Layout.fillWidth: true
-                    pageIndex: 0
-                    label: "显示"
-                    navSymbol: "▱"
-                    navTint: "#34c759"
-                }
-
-                SidebarEntry {
-                    Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 1
-                    label: "主题"
+                    pageIndex: 0
+                    label: "外观"
                     navSymbol: "◈"
                     navTint: "#af52de"
                 }
@@ -3301,7 +5507,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 2
+                    pageIndex: 1
                     label: "顶栏"
                     navSymbol: "⎍"
                     navTint: "#5ac8fa"
@@ -3310,7 +5516,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 3
+                    pageIndex: 2
                     label: "Dock"
                     navSymbol: "▰"
                     navTint: "#0a84ff"
@@ -3319,7 +5525,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 4
+                    pageIndex: 3
                     label: "启动台"
                     navSymbol: "❖"
                     navTint: "#ff9500"
@@ -3328,7 +5534,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 5
+                    pageIndex: 4
                     label: "快捷键"
                     navSymbol: "⌘"
                     navTint: "#5856d6"
@@ -3337,7 +5543,7 @@ ApplicationWindow {
                 SidebarEntry {
                     Layout.fillWidth: true
                     Layout.topMargin: 1
-                    pageIndex: 6
+                    pageIndex: 5
                     label: "接入状态"
                     navSymbol: "✓"
                     navTint: "#30d158"
@@ -3385,7 +5591,7 @@ ApplicationWindow {
                         Layout.bottomMargin: 18
                     }
                     Repeater {
-                        model: (window.currentPage >= 0 && window.currentPage <= 6)
+                        model: (window.currentPage >= 0 && window.currentPage <= 5)
                             ? [] : window.contentByPage[window.currentPage].groups
                         delegate: ColumnLayout {
                             required property var modelData
@@ -3417,32 +5623,30 @@ ApplicationWindow {
                     }
 
                     LauncherSettingsPage {
-                        visible: window.currentPage === 4
-                    }
-
-                    ShortcutsSettingsPage {
-                        visible: window.currentPage === 5
-                    }
-
-                    IntegrationStatusPage {
-                        visible: window.currentPage === 6
-                    }
-
-                    DockSettingsPage {
                         visible: window.currentPage === 3
                     }
 
-                    BarSettingsPage {
+                    ShortcutsSettingsPage {
+                        visible: window.currentPage === 4
+                    }
+
+                    IntegrationStatusPage {
+                        visible: window.currentPage === 5
+                    }
+
+                    DockSettingsPage {
                         visible: window.currentPage === 2
                     }
 
-                    ThemeSettingsPage {
+                    BarSettingsPage {
                         visible: window.currentPage === 1
                     }
 
-                    DisplaySettingsPage {
+                    ThemeSettingsPage {
                         visible: window.currentPage === 0
                     }
+
+
                 }
             }
         }

--- a/apps/settings/src/main.cpp
+++ b/apps/settings/src/main.cpp
@@ -108,6 +108,299 @@ public:
             QStringLiteral("updateShellStyle"), style}));
     }
 
+    Q_INVOKABLE QVariantMap updateMaterialStyle(const QString &style) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateMaterialStyle"), style}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicRefract(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicRefract"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicEdgeLight(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicEdgeLight"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicSoftEdgePx(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicSoftEdgePx"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicHsvv(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicHsvv"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicRefract(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicRefract"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicReflect(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicReflect"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicEdgeLight(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicEdgeLight"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicSoftEdgePx(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicSoftEdgePx"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicTransparency(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicTransparency"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActDarken(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActDarken"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActEdgeLight(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActEdgeLight"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActOpposite(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActOpposite"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActHsvv(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActHsvv"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActRefl(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActRefl"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActRefract(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActRefract"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicLum0(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicLum0"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicLum1(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicLum1"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicLum2(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicLum2"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicLum3(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicLum3"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicLumAmount(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicLumAmount"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDarkBase(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDarkBase"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDarkRange0(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDarkRange0"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDarkRange1(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDarkRange1"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicBrightBase(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicBrightBase"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicInnerBottom(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicInnerBottom"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicInnerWhite(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicInnerWhite"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicInnerMix(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicInnerMix"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicColorPow(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicColorPow"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicAlphaLayer(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicAlphaLayer"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicShapeEdgePow(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicShapeEdgePow"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicShapeThickness(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicShapeThickness"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicReflectOffset(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicReflectOffset"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicReflLighten(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicReflLighten"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicReflStrength(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicReflStrength"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirX(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirX"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirY(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirY"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirZ(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirZ"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirInt(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirInt"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirOpp(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirOpp"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirAngle(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirAngle"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicDirEdgePow(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicDirEdgePow"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicBgSat(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicBgSat"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicBgBri(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicBgBri"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateBionicActColorPow(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateBionicActColorPow"),
+            QString::number(value, 'f', 4)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicStrokeDegree(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicStrokeDegree"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicStrokeSize(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicStrokeSize"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap updateClassicReflLighten(double value) {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("updateClassicReflLighten"),
+            QString::number(value, 'f', 3)}));
+    }
+
+    Q_INVOKABLE QVariantMap resetMaterialTuning() {
+        return appearanceSnapshotFromReply(callAppearance({
+            QStringLiteral("resetMaterialTuning")}));
+    }
+
+
     Q_INVOKABLE QVariantMap updateBarIntegratedWithDock(bool enabled) {
         return appearanceSnapshotFromReply(callAppearance({
             QStringLiteral("updateBarIntegratedWithDock"),
@@ -337,6 +630,8 @@ private:
             {QStringLiteral("iconOpacity"), object.value(QStringLiteral("iconOpacity")).toDouble(0.5)},
             {QStringLiteral("iconTintColor"), object.value(QStringLiteral("iconTintColor")).toString(QStringLiteral("#a855f7"))},
             {QStringLiteral("shellStyle"), object.value(QStringLiteral("shellStyle")).toString()},
+            {QStringLiteral("materialStyle"),
+                object.value(QStringLiteral("materialStyle")).toString(QStringLiteral("liquid"))},
             {QStringLiteral("barIntegratedWithDock"),
                 object.value(QStringLiteral("barIntegratedWithDock")).toBool()},
             {QStringLiteral("barVisibilityMode"),
@@ -345,6 +640,137 @@ private:
                 object.value(QStringLiteral("barLayoutMode")).toString(QStringLiteral("transparent"))},
             {QStringLiteral("dockWindowAnimationStyle"),
                 object.value(QStringLiteral("dockWindowAnimationStyle")).toString()},
+            // 材质微调（柔光玻璃 / 轻透磨砂）
+            {QStringLiteral("bionicRefract"),
+                object.value(QStringLiteral("bionicRefract")).toDouble(4.0)},
+            {QStringLiteral("bionicEdgeLight"),
+                object.value(QStringLiteral("bionicEdgeLight")).toDouble(1.4)},
+            {QStringLiteral("bionicSoftEdgePx"),
+                object.value(QStringLiteral("bionicSoftEdgePx")).toDouble(1.5)},
+            {QStringLiteral("bionicHsvv"),
+                object.value(QStringLiteral("bionicHsvv")).toDouble(1.0)},
+            {QStringLiteral("classicRefract"),
+                object.value(QStringLiteral("classicRefract")).toDouble(1.5)},
+            {QStringLiteral("classicReflect"),
+                object.value(QStringLiteral("classicReflect")).toDouble(0.06)},
+            {QStringLiteral("classicEdgeLight"),
+                object.value(QStringLiteral("classicEdgeLight")).toDouble(0.1)},
+            {QStringLiteral("classicSoftEdgePx"),
+                object.value(QStringLiteral("classicSoftEdgePx")).toDouble(1.5)},
+            {QStringLiteral("classicStrokeDegree"),
+                object.value(QStringLiteral("classicStrokeDegree")).toDouble(24.0)},
+            {QStringLiteral("classicStrokeSize"),
+                object.value(QStringLiteral("classicStrokeSize")).toDouble(2.0)},
+            {QStringLiteral("classicReflLighten"),
+                object.value(QStringLiteral("classicReflLighten")).toDouble(2.0)},
+            {QStringLiteral("bionicRefractMin"),
+                object.value(QStringLiteral("bionicRefractMin")).toDouble(1.0)},
+            {QStringLiteral("bionicRefractMax"),
+                object.value(QStringLiteral("bionicRefractMax")).toDouble(5.0)},
+            {QStringLiteral("bionicEdgeLightMin"),
+                object.value(QStringLiteral("bionicEdgeLightMin")).toDouble(0.0)},
+            {QStringLiteral("bionicEdgeLightMax"),
+                object.value(QStringLiteral("bionicEdgeLightMax")).toDouble(3.0)},
+            {QStringLiteral("bionicSoftEdgePxMin"),
+                object.value(QStringLiteral("bionicSoftEdgePxMin")).toDouble(0.1)},
+            {QStringLiteral("bionicSoftEdgePxMax"),
+                object.value(QStringLiteral("bionicSoftEdgePxMax")).toDouble(25.0)},
+            {QStringLiteral("bionicHsvvMin"),
+                object.value(QStringLiteral("bionicHsvvMin")).toDouble(0.0)},
+            {QStringLiteral("bionicHsvvMax"),
+                object.value(QStringLiteral("bionicHsvvMax")).toDouble(2.0)},
+            {QStringLiteral("classicRefractMin"),
+                object.value(QStringLiteral("classicRefractMin")).toDouble(1.0)},
+            {QStringLiteral("classicRefractMax"),
+                object.value(QStringLiteral("classicRefractMax")).toDouble(2.0)},
+            {QStringLiteral("classicReflectMin"),
+                object.value(QStringLiteral("classicReflectMin")).toDouble(0.0)},
+            {QStringLiteral("classicReflectMax"),
+                object.value(QStringLiteral("classicReflectMax")).toDouble(1.5)},
+            {QStringLiteral("classicEdgeLightMin"),
+                object.value(QStringLiteral("classicEdgeLightMin")).toDouble(0.0)},
+            {QStringLiteral("classicEdgeLightMax"),
+                object.value(QStringLiteral("classicEdgeLightMax")).toDouble(0.5)},
+            {QStringLiteral("classicSoftEdgePxMin"),
+                object.value(QStringLiteral("classicSoftEdgePxMin")).toDouble(0.5)},
+            {QStringLiteral("classicSoftEdgePxMax"),
+                object.value(QStringLiteral("classicSoftEdgePxMax")).toDouble(25.0)},
+            {QStringLiteral("bionicTransparency"),
+                object.value(QStringLiteral("bionicTransparency")).toDouble(1.0)},
+            {QStringLiteral("bionicActDarken"),
+                object.value(QStringLiteral("bionicActDarken")).toDouble(0.42)},
+            {QStringLiteral("bionicActEdgeLight"),
+                object.value(QStringLiteral("bionicActEdgeLight")).toDouble(3.0)},
+            {QStringLiteral("bionicActOpposite"),
+                object.value(QStringLiteral("bionicActOpposite")).toDouble(2.0)},
+            {QStringLiteral("bionicActHsvv"),
+                object.value(QStringLiteral("bionicActHsvv")).toDouble(1.6)},
+            {QStringLiteral("bionicActRefl"),
+                object.value(QStringLiteral("bionicActRefl")).toDouble(1.3)},
+            {QStringLiteral("bionicActRefract"),
+                object.value(QStringLiteral("bionicActRefract")).toDouble(4.6)},
+            {QStringLiteral("bionicLum0"),
+                object.value(QStringLiteral("bionicLum0")).toDouble(0.67)},
+            {QStringLiteral("bionicLum1"),
+                object.value(QStringLiteral("bionicLum1")).toDouble(0.16)},
+            {QStringLiteral("bionicLum2"),
+                object.value(QStringLiteral("bionicLum2")).toDouble(0.09)},
+            {QStringLiteral("bionicLum3"),
+                object.value(QStringLiteral("bionicLum3")).toDouble(0.0)},
+            {QStringLiteral("bionicLumAmount"),
+                object.value(QStringLiteral("bionicLumAmount")).toDouble(0.24)},
+            {QStringLiteral("bionicDarkBase"),
+                object.value(QStringLiteral("bionicDarkBase")).toDouble(0.3)},
+            {QStringLiteral("bionicDarkRange0"),
+                object.value(QStringLiteral("bionicDarkRange0")).toDouble(0.6)},
+            {QStringLiteral("bionicDarkRange1"),
+                object.value(QStringLiteral("bionicDarkRange1")).toDouble(1.0)},
+            {QStringLiteral("bionicBrightBase"),
+                object.value(QStringLiteral("bionicBrightBase")).toDouble(-0.02)},
+            {QStringLiteral("bionicInnerBottom"),
+                object.value(QStringLiteral("bionicInnerBottom")).toDouble(0.03)},
+            {QStringLiteral("bionicInnerWhite"),
+                object.value(QStringLiteral("bionicInnerWhite")).toDouble(0.2)},
+            {QStringLiteral("bionicInnerMix"),
+                object.value(QStringLiteral("bionicInnerMix")).toDouble(0.3)},
+            {QStringLiteral("bionicColorPow"),
+                object.value(QStringLiteral("bionicColorPow")).toDouble(1.0)},
+            {QStringLiteral("bionicAlphaLayer"),
+                object.value(QStringLiteral("bionicAlphaLayer")).toDouble(0.1)},
+            {QStringLiteral("bionicShapeEdgePow"),
+                object.value(QStringLiteral("bionicShapeEdgePow")).toDouble(3.8)},
+            {QStringLiteral("bionicShapeThickness"),
+                object.value(QStringLiteral("bionicShapeThickness")).toDouble(80.0)},
+            {QStringLiteral("bionicReflectOffset"),
+                object.value(QStringLiteral("bionicReflectOffset")).toDouble(800.0)},
+            {QStringLiteral("bionicReflLighten"),
+                object.value(QStringLiteral("bionicReflLighten")).toDouble(1.2)},
+            {QStringLiteral("bionicReflStrength"),
+                object.value(QStringLiteral("bionicReflStrength")).toDouble(1.0)},
+            {QStringLiteral("bionicDirX"),
+                object.value(QStringLiteral("bionicDirX")).toDouble(-0.4)},
+            {QStringLiteral("bionicDirY"),
+                object.value(QStringLiteral("bionicDirY")).toDouble(0.6)},
+            {QStringLiteral("bionicDirZ"),
+                object.value(QStringLiteral("bionicDirZ")).toDouble(-0.8)},
+            {QStringLiteral("bionicDirInt"),
+                object.value(QStringLiteral("bionicDirInt")).toDouble(1.4)},
+            {QStringLiteral("bionicDirOpp"),
+                object.value(QStringLiteral("bionicDirOpp")).toDouble(0.7)},
+            {QStringLiteral("bionicDirAngle"),
+                object.value(QStringLiteral("bionicDirAngle")).toDouble(0.8)},
+            {QStringLiteral("bionicDirEdgePow"),
+                object.value(QStringLiteral("bionicDirEdgePow")).toDouble(1.15)},
+            {QStringLiteral("bionicBgSat"),
+                object.value(QStringLiteral("bionicBgSat")).toDouble(2.0)},
+            {QStringLiteral("bionicBgBri"),
+                object.value(QStringLiteral("bionicBgBri")).toDouble(0.0)},
+            {QStringLiteral("bionicActColorPow"),
+                object.value(QStringLiteral("bionicActColorPow")).toDouble(1.0)},
+            {QStringLiteral("bionicTransparencyMin"),
+                object.value(QStringLiteral("bionicTransparencyMin")).toDouble(0.0)},
+            {QStringLiteral("bionicTransparencyMax"),
+                object.value(QStringLiteral("bionicTransparencyMax")).toDouble(1.0)},
             {QStringLiteral("tokenVersion"), object.value(QStringLiteral("tokenVersion")).toInt()},
         };
     }

--- a/shell/desktop/DesktopEnvironment.qml
+++ b/shell/desktop/DesktopEnvironment.qml
@@ -143,12 +143,91 @@ Item {
                 // the value as an object and fall back to its previous tint.
                 iconTintColor: IconAppearanceService.tintColor.toString(),
                 shellStyle: AppearanceConfigService.shellStyle,
+                materialStyle: AppearanceConfigService.materialStyle,
                 barIntegratedWithDock:
                     AppearanceConfigService.barIntegratedWithDock,
                 barVisibilityMode: AppearanceConfigService.barVisibilityMode,
                 barLayoutMode: AppearanceConfigService.barLayoutMode,
                 dockWindowAnimationStyle:
                     AppearanceConfigService.dockWindowAnimationStyle,
+                // Dock surface tuning (DDE-derived). The Dock resolves these
+                // against the active shell style; the Settings app round-trips
+                // the raw multipliers so its sliders stay where the user left
+                // them instead of snapping to a recomputed absolute.
+                bionicRefract: AppearanceConfigService.bionicRefract,
+                bionicEdgeLight: AppearanceConfigService.bionicEdgeLight,
+                bionicSoftEdgePx: AppearanceConfigService.bionicSoftEdgePx,
+                bionicHsvv: AppearanceConfigService.bionicHsvv,
+                classicRefract: AppearanceConfigService.classicRefract,
+                classicReflect: AppearanceConfigService.classicReflect,
+                classicEdgeLight: AppearanceConfigService.classicEdgeLight,
+                classicSoftEdgePx: AppearanceConfigService.classicSoftEdgePx,
+                classicStrokeDegree: AppearanceConfigService.classicStrokeDegree,
+                classicStrokeSize: AppearanceConfigService.classicStrokeSize,
+                classicReflLighten: AppearanceConfigService.classicReflLighten,
+                bionicRefractMin: AppearanceConfigService.bionicRefractMin,
+                bionicRefractMax: AppearanceConfigService.bionicRefractMax,
+                bionicEdgeLightMin: AppearanceConfigService.bionicEdgeLightMin,
+                bionicEdgeLightMax: AppearanceConfigService.bionicEdgeLightMax,
+                bionicSoftEdgePxMin: AppearanceConfigService.bionicSoftEdgePxMin,
+                bionicSoftEdgePxMax: AppearanceConfigService.bionicSoftEdgePxMax,
+                bionicHsvvMin: AppearanceConfigService.bionicHsvvMin,
+                bionicHsvvMax: AppearanceConfigService.bionicHsvvMax,
+                classicRefractMin: AppearanceConfigService.classicRefractMin,
+                classicRefractMax: AppearanceConfigService.classicRefractMax,
+                classicReflectMin: AppearanceConfigService.classicReflectMin,
+                classicReflectMax: AppearanceConfigService.classicReflectMax,
+                classicEdgeLightMin: AppearanceConfigService.classicEdgeLightMin,
+                classicEdgeLightMax: AppearanceConfigService.classicEdgeLightMax,
+                classicSoftEdgePxMin: AppearanceConfigService.classicSoftEdgePxMin,
+                classicSoftEdgePxMax: AppearanceConfigService.classicSoftEdgePxMax,
+                bionicTransparency: AppearanceConfigService.bionicTransparency,
+                bionicActDarken: AppearanceConfigService.bionicActDarken,
+                bionicActEdgeLight: AppearanceConfigService.bionicActEdgeLight,
+                bionicActOpposite: AppearanceConfigService.bionicActOpposite,
+                bionicActHsvv: AppearanceConfigService.bionicActHsvv,
+                bionicActRefl: AppearanceConfigService.bionicActRefl,
+                bionicActRefract: AppearanceConfigService.bionicActRefract,
+                bionicLum0: AppearanceConfigService.bionicLum0,
+                bionicLum1: AppearanceConfigService.bionicLum1,
+                bionicLum2: AppearanceConfigService.bionicLum2,
+                bionicLum3: AppearanceConfigService.bionicLum3,
+                bionicLumAmount: AppearanceConfigService.bionicLumAmount,
+                bionicDarkBase: AppearanceConfigService.bionicDarkBase,
+                bionicDarkRange0: AppearanceConfigService.bionicDarkRange0,
+                bionicDarkRange1: AppearanceConfigService.bionicDarkRange1,
+                bionicBrightBase: AppearanceConfigService.bionicBrightBase,
+                bionicInnerBottom: AppearanceConfigService.bionicInnerBottom,
+                bionicInnerWhite: AppearanceConfigService.bionicInnerWhite,
+                bionicInnerMix: AppearanceConfigService.bionicInnerMix,
+                bionicColorPow: AppearanceConfigService.bionicColorPow,
+                bionicAlphaLayer: AppearanceConfigService.bionicAlphaLayer,
+                bionicShapeEdgePow: AppearanceConfigService.bionicShapeEdgePow,
+                bionicShapeThickness: AppearanceConfigService.bionicShapeThickness,
+                bionicReflectOffset: AppearanceConfigService.bionicReflectOffset,
+                bionicReflLighten: AppearanceConfigService.bionicReflLighten,
+                bionicReflStrength: AppearanceConfigService.bionicReflStrength,
+                bionicDirX: AppearanceConfigService.bionicDirX,
+                bionicDirY: AppearanceConfigService.bionicDirY,
+                bionicDirZ: AppearanceConfigService.bionicDirZ,
+                bionicDirInt: AppearanceConfigService.bionicDirInt,
+                bionicDirOpp: AppearanceConfigService.bionicDirOpp,
+                bionicDirAngle: AppearanceConfigService.bionicDirAngle,
+                bionicDirEdgePow: AppearanceConfigService.bionicDirEdgePow,
+                bionicBgSat: AppearanceConfigService.bionicBgSat,
+                bionicBgBri: AppearanceConfigService.bionicBgBri,
+                bionicActColorPow: AppearanceConfigService.bionicActColorPow,
+                bionicTransparencyMin: AppearanceConfigService.bionicTransparencyMin,
+                bionicTransparencyMax: AppearanceConfigService.bionicTransparencyMax,
+                // What the tuning currently resolves to, so Settings can show
+                // the user a concrete pixel/alpha readout rather than the
+                // opaque multiplier alone.
+                resolvedDockRadius: AppearanceTokens.resolvedDockRadius,
+                resolvedDockDarkAlpha: AppearanceTokens.resolvedDockDarkAlpha,
+                resolvedDockBorderTopAlpha:
+                    AppearanceTokens.resolvedDockBorderTopAlpha,
+                resolvedDockBorderBottomAlpha:
+                    AppearanceTokens.resolvedDockBorderBottomAlpha,
                 tokenVersion: AppearanceTokens.version,
             })
         }
@@ -193,6 +272,11 @@ Item {
             return snapshot()
         }
 
+        function updateMaterialStyle(style: string): string {
+            AppearanceConfigService.updateMaterialStyle(style)
+            return snapshot()
+        }
+
         function updateBarIntegratedWithDock(enabled: bool): string {
             AppearanceConfigService.updateBarIntegratedWithDock(enabled)
             return snapshot()
@@ -210,6 +294,267 @@ Item {
 
         function updateDockWindowAnimationStyle(style: string): string {
             AppearanceConfigService.updateDockWindowAnimationStyle(style)
+            return snapshot()
+        }
+
+        function updateDockRadiusScale(value: real): string {
+            AppearanceConfigService.updateDockRadiusScale(value)
+            return snapshot()
+        }
+
+        function updateDockDarkDensity(value: real): string {
+            AppearanceConfigService.updateDockDarkDensity(value)
+            return snapshot()
+        }
+
+        function updateDockEdgeStrength(value: real): string {
+            AppearanceConfigService.updateDockEdgeStrength(value)
+            return snapshot()
+        }
+
+        function updateBionicRefract(value: real): string {
+            AppearanceConfigService.updateBionicRefract(value)
+            return snapshot()
+        }
+
+        function updateBionicEdgeLight(value: real): string {
+            AppearanceConfigService.updateBionicEdgeLight(value)
+            return snapshot()
+        }
+
+        function updateBionicSoftEdgePx(value: real): string {
+            AppearanceConfigService.updateBionicSoftEdgePx(value)
+            return snapshot()
+        }
+
+        function updateBionicHsvv(value: real): string {
+            AppearanceConfigService.updateBionicHsvv(value)
+            return snapshot()
+        }
+
+        function updateClassicRefract(value: real): string {
+            AppearanceConfigService.updateClassicRefract(value)
+            return snapshot()
+        }
+
+        function updateClassicReflect(value: real): string {
+            AppearanceConfigService.updateClassicReflect(value)
+            return snapshot()
+        }
+
+        function updateClassicEdgeLight(value: real): string {
+            AppearanceConfigService.updateClassicEdgeLight(value)
+            return snapshot()
+        }
+
+        function updateClassicSoftEdgePx(value: real): string {
+            AppearanceConfigService.updateClassicSoftEdgePx(value)
+            return snapshot()
+        }
+
+        function updateClassicStrokeDegree(value: real): string {
+            AppearanceConfigService.updateClassicStrokeDegree(value)
+            return snapshot()
+        }
+
+        function updateClassicStrokeSize(value: real): string {
+            AppearanceConfigService.updateClassicStrokeSize(value)
+            return snapshot()
+        }
+
+        function updateClassicReflLighten(value: real): string {
+            AppearanceConfigService.updateClassicReflLighten(value)
+            return snapshot()
+        }
+
+        function updateBionicTransparency(value: real): string {
+            AppearanceConfigService.updateBionicTransparency(value)
+            return snapshot()
+        }
+
+        function updateBionicActDarken(value: real): string {
+            AppearanceConfigService.updateBionicActDarken(value)
+            return snapshot()
+        }
+
+        function updateBionicActEdgeLight(value: real): string {
+            AppearanceConfigService.updateBionicActEdgeLight(value)
+            return snapshot()
+        }
+
+        function updateBionicActOpposite(value: real): string {
+            AppearanceConfigService.updateBionicActOpposite(value)
+            return snapshot()
+        }
+
+        function updateBionicActHsvv(value: real): string {
+            AppearanceConfigService.updateBionicActHsvv(value)
+            return snapshot()
+        }
+
+        function updateBionicActRefl(value: real): string {
+            AppearanceConfigService.updateBionicActRefl(value)
+            return snapshot()
+        }
+
+        function updateBionicActRefract(value: real): string {
+            AppearanceConfigService.updateBionicActRefract(value)
+            return snapshot()
+        }
+
+        function updateBionicLum0(value: real): string {
+            AppearanceConfigService.updateBionicLum0(value)
+            return snapshot()
+        }
+
+        function updateBionicLum1(value: real): string {
+            AppearanceConfigService.updateBionicLum1(value)
+            return snapshot()
+        }
+
+        function updateBionicLum2(value: real): string {
+            AppearanceConfigService.updateBionicLum2(value)
+            return snapshot()
+        }
+
+        function updateBionicLum3(value: real): string {
+            AppearanceConfigService.updateBionicLum3(value)
+            return snapshot()
+        }
+
+        function updateBionicLumAmount(value: real): string {
+            AppearanceConfigService.updateBionicLumAmount(value)
+            return snapshot()
+        }
+
+        function updateBionicDarkBase(value: real): string {
+            AppearanceConfigService.updateBionicDarkBase(value)
+            return snapshot()
+        }
+
+        function updateBionicDarkRange0(value: real): string {
+            AppearanceConfigService.updateBionicDarkRange0(value)
+            return snapshot()
+        }
+
+        function updateBionicDarkRange1(value: real): string {
+            AppearanceConfigService.updateBionicDarkRange1(value)
+            return snapshot()
+        }
+
+        function updateBionicBrightBase(value: real): string {
+            AppearanceConfigService.updateBionicBrightBase(value)
+            return snapshot()
+        }
+
+        function updateBionicInnerBottom(value: real): string {
+            AppearanceConfigService.updateBionicInnerBottom(value)
+            return snapshot()
+        }
+
+        function updateBionicInnerWhite(value: real): string {
+            AppearanceConfigService.updateBionicInnerWhite(value)
+            return snapshot()
+        }
+
+        function updateBionicInnerMix(value: real): string {
+            AppearanceConfigService.updateBionicInnerMix(value)
+            return snapshot()
+        }
+
+        function updateBionicColorPow(value: real): string {
+            AppearanceConfigService.updateBionicColorPow(value)
+            return snapshot()
+        }
+
+        function updateBionicAlphaLayer(value: real): string {
+            AppearanceConfigService.updateBionicAlphaLayer(value)
+            return snapshot()
+        }
+
+        function updateBionicShapeEdgePow(value: real): string {
+            AppearanceConfigService.updateBionicShapeEdgePow(value)
+            return snapshot()
+        }
+
+        function updateBionicShapeThickness(value: real): string {
+            AppearanceConfigService.updateBionicShapeThickness(value)
+            return snapshot()
+        }
+
+        function updateBionicReflectOffset(value: real): string {
+            AppearanceConfigService.updateBionicReflectOffset(value)
+            return snapshot()
+        }
+
+        function updateBionicReflLighten(value: real): string {
+            AppearanceConfigService.updateBionicReflLighten(value)
+            return snapshot()
+        }
+
+        function updateBionicReflStrength(value: real): string {
+            AppearanceConfigService.updateBionicReflStrength(value)
+            return snapshot()
+        }
+
+        function updateBionicDirX(value: real): string {
+            AppearanceConfigService.updateBionicDirX(value)
+            return snapshot()
+        }
+
+        function updateBionicDirY(value: real): string {
+            AppearanceConfigService.updateBionicDirY(value)
+            return snapshot()
+        }
+
+        function updateBionicDirZ(value: real): string {
+            AppearanceConfigService.updateBionicDirZ(value)
+            return snapshot()
+        }
+
+        function updateBionicDirInt(value: real): string {
+            AppearanceConfigService.updateBionicDirInt(value)
+            return snapshot()
+        }
+
+        function updateBionicDirOpp(value: real): string {
+            AppearanceConfigService.updateBionicDirOpp(value)
+            return snapshot()
+        }
+
+        function updateBionicDirAngle(value: real): string {
+            AppearanceConfigService.updateBionicDirAngle(value)
+            return snapshot()
+        }
+
+        function updateBionicDirEdgePow(value: real): string {
+            AppearanceConfigService.updateBionicDirEdgePow(value)
+            return snapshot()
+        }
+
+        function updateBionicBgSat(value: real): string {
+            AppearanceConfigService.updateBionicBgSat(value)
+            return snapshot()
+        }
+
+        function updateBionicBgBri(value: real): string {
+            AppearanceConfigService.updateBionicBgBri(value)
+            return snapshot()
+        }
+
+        function updateBionicActColorPow(value: real): string {
+            AppearanceConfigService.updateBionicActColorPow(value)
+            return snapshot()
+        }
+
+
+        function resetMaterialTuning(): string {
+            AppearanceConfigService.resetMaterialTuning()
+            return snapshot()
+        }
+
+        function resetDockSurfaceTuning(): string {
+            AppearanceConfigService.resetDockSurfaceTuning()
             return snapshot()
         }
 

--- a/shell/desktop/modules/common/AppearanceConfigService.qml
+++ b/shell/desktop/modules/common/AppearanceConfigService.qml
@@ -34,6 +34,81 @@ QtObject {
     // "macos" matches the shell geometry that predates selectable styles,
     // so upgrading an existing installation does not unexpectedly reshape it.
     property string shellStyle: "macos"
+    // 材质风格（对标澎湃 HyperOS 4「材质风格」）
+    // "bionic" = 柔光玻璃 | "classic" = 轻透磨砂
+    property string materialStyle: "liquid"
+    // ── 材质专属微调（柔光玻璃 / 轻透磨砂）───────────────────────────
+    // 每组只在对应材质激活时写入 kwinrc 的 [Effect-blurplus] 键；
+    // 材质切换时由 _syncMaterialTuning() 按 materialStyle 分支落盘。
+    // bionic（柔光玻璃）
+    property real bionicRefract: 4.0        // → BionicIOR（包值 refractIOR=4.0）
+    property real bionicEdgeLight: 1.4      // → BionicActivatedDirIntensity（悬停点亮强度）
+    property real bionicSoftEdgePx: 1.5     // → BionicShapeEdgePx（×5）
+    property real bionicHsvv: 1.0           // → BionicHsvvBoost（柔光提亮强度，1.0 = 原生）
+    // classic（轻透磨砂）
+    property real classicRefract: 1.5       // → ClassicRefractIOR
+    property real classicReflect: 0.06     // → ClassicReflStrength
+    property real classicEdgeLight: 0.1     // → ClassicStrokeStrength（描边强度）
+    property real classicSoftEdgePx: 1.5    // → ClassicMaskSoft
+    property real classicStrokeDegree: 24.0  // → ClassicStrokeDegree
+    property real classicStrokeSize: 2.0  // → ClassicStrokeSize
+    property real classicReflLighten: 2.0  // → ClassicReflLighten
+    property real bionicTransparency: 1.0  // → BionicOverallAlpha（1.0=标准；调低更透）
+    // ── 原生激活参数（悬停/交互时的目标值，对齐 BionicsToken ACTIVATED 组）──
+    property real bionicActDarken: 0.42      // → BionicActivatedDarker
+    property real bionicActEdgeLight: 3.0    // → BionicActivatedDirIntensity
+    property real bionicActOpposite: 2.0     // → BionicActivatedDirOppositeIntensity
+    property real bionicActHsvv: 1.6         // → BionicActivatedHsvvBoost
+    property real bionicActRefl: 1.3         // → BionicActivatedReflStrength
+    property real bionicActRefract: 4.6      // → BionicActivatedRefract
+    // ── 批1：亮度组（原生 luminanceValue + darker + brightness）──
+    property real bionicLum0: 0.67  // → BionicLumValue0
+    property real bionicLum1: 0.16  // → BionicLumValue1
+    property real bionicLum2: 0.09  // → BionicLumValue2
+    property real bionicLum3: 0.0  // → BionicLumValue3
+    property real bionicLumAmount: 0.24  // → BionicLumAmount
+    property real bionicDarkBase: 0.3  // → BionicDarker
+    property real bionicDarkRange0: 0.6  // → BionicDarkerRange0
+    property real bionicDarkRange1: 1.0  // → BionicDarkerRange1
+    property real bionicBrightBase: -0.02  // → BionicBrightness
+    property real bionicInnerBottom: 0.03  // → BionicInnerBottom
+    property real bionicInnerWhite: 0.2  // → BionicInnerColorWhite
+    property real bionicInnerMix: 0.3  // → BionicInnerColorMix
+    property real bionicColorPow: 1.0  // → BionicColorPow
+    property real bionicAlphaLayer: 0.1  // → BionicAlpha
+    property real bionicShapeEdgePow: 3.8  // → BionicShapeEdgePow
+    property real bionicShapeThickness: 80.0  // → BionicShapeThicknessPx
+    property real bionicReflectOffset: 800.0  // → BionicShapeReflectOffsetPx
+    property real bionicReflLighten: 1.2  // → BionicReflLighten
+    property real bionicReflStrength: 1.0  // → BionicReflStrength
+    property real bionicDirX: -0.4  // → BionicDirX
+    property real bionicDirY: 0.6  // → BionicDirY
+    property real bionicDirZ: -0.8  // → BionicDirZ
+    property real bionicDirInt: 1.4  // → BionicDirIntensity
+    property real bionicDirOpp: 0.7  // → BionicDirOppositeIntensity
+    property real bionicDirAngle: 0.8  // → BionicDirAngleRange
+    property real bionicDirEdgePow: 1.15  // → BionicDirEdgePow
+    property real bionicBgSat: 2.0  // → BionicBgColorSaturation
+    property real bionicBgBri: 0.0  // → BionicBgColorBrightness
+    property real bionicActColorPow: 1.0  // → BionicActivatedColorPow
+    readonly property real bionicRefractMin: 1.0
+    readonly property real bionicRefractMax: 5.0
+    readonly property real bionicEdgeLightMin: 0.0
+    readonly property real bionicEdgeLightMax: 3.0
+    readonly property real bionicSoftEdgePxMin: 0.1
+    readonly property real bionicSoftEdgePxMax: 25.0
+    readonly property real bionicHsvvMin: 0.0
+    readonly property real bionicHsvvMax: 2.0
+    readonly property real bionicTransparencyMin: 0.0
+    readonly property real bionicTransparencyMax: 1.0
+    readonly property real classicRefractMin: 1.0
+    readonly property real classicRefractMax: 2.0
+    readonly property real classicReflectMin: 0.0
+    readonly property real classicReflectMax: 1.5
+    readonly property real classicEdgeLightMin: 0.0
+    readonly property real classicEdgeLightMax: 0.5
+    readonly property real classicSoftEdgePxMin: 0.5
+    readonly property real classicSoftEdgePxMax: 25.0
     // Global colour-scheme preference shared by every shell style. The Dock
     // settings page historically persisted this value in DockConfigService;
     // that service mirrors the legacy value here during migration.
@@ -123,6 +198,744 @@ QtObject {
     function updateLiquidStrength(rawValue) {
         return updateGlobalLiquidStrength(rawValue)
     }
+
+    function isValidMaterialStyle(value) {
+        return value === "liquid" || value === "bionic" || value === "classic"
+    }
+
+    function _clampInRange(rawValue, min, max) {
+        const number = Number(rawValue)
+        if (!Number.isFinite(number))
+            return NaN
+        return Math.max(min, Math.min(max, number))
+    }
+
+    function updateMaterialStyle(rawStyle) {
+        const style = String(rawStyle)
+        if (!isValidMaterialStyle(style))
+            return false
+        materialStyle = style
+        _applyKwinGlass(style)
+        materialTuningSyncTimer.restart()
+        saveTimer.restart()
+        return true
+    }
+
+    function _materialKwinParams(style) {
+        if (style === "bionic")
+            return {
+                BionicMode: "true",
+                ClassicMode: "false",
+                BlurStrength: "12",
+                RefractionStrength: "14",
+                PhysicallyBasedRefraction: "true",
+                RefractionRGBFringing: "0.7",
+                RefractionEdgeSize: "28",
+                RefractionBevelIntensity: "14",
+                HighlightWidthPx: "4",
+                EdgeLightingDock: "true",
+                AutoTintAlpha: "true",
+                TintColor: "#281c1c1e",
+                NoiseStrength: "3",
+            }
+        if (style === "classic")
+            return {
+                BionicMode: "false",
+                ClassicMode: "true",
+                BlurStrength: "6",
+                RefractionStrength: "3",
+                PhysicallyBasedRefraction: "false",
+                RefractionRGBFringing: "0.3",
+                RefractionEdgeSize: "12",
+                RefractionBevelIntensity: "10",
+                HighlightWidthPx: "3",
+                EdgeLightingDock: "false",
+                AutoTintAlpha: "false",
+                TintColor: "#3c0a0a0a",
+                NoiseStrength: "5",
+            }
+        // liquid（KOS 原有）：只关材质开关，不写任何样式键
+        // ——样式键一律删除，让主线默认值生效（避免暗色 tint / 错误模糊）
+        return {
+            BionicMode: "false",
+            ClassicMode: "false",
+        }
+    }
+
+    function _applyKwinGlass(style) {
+        const params = _materialKwinParams(style)
+        let cmd = ""
+        for (const key in params) {
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key " + key
+                + " '" + params[key] + "'; "
+        }
+        if (style === "liquid") {
+            // 切回液态：完整恢复主线用户滑条值与透明 tint
+            const liqBlur = service._compositorBlurLevel(service.globalBlurStrength)
+            const liqRefr = Math.round(service.globalLiquidStrength * 20)
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key TintColor -- '#00000000'; "
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BlurStrength " + liqBlur + "; "
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key DockBlurStrength " + liqBlur + "; "
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key DecorationBlurStrength " + liqBlur + "; "
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key RefractionStrength " + liqRefr + "; "
+        } else {
+            cmd += "kwriteconfig6 --file kwinrc --group Effect-blurplus --key DecorationBlurStrength " + params.BlurStrength
+                + "; kwriteconfig6 --file kwinrc --group Effect-blurplus --key DockBlurStrength " + params.BlurStrength + "; "
+        }
+        cmd += "qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect glass 2>/dev/null; "
+            + "qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect blur 2>/dev/null; "
+            + "qdbus6 org.kde.KWin /KWin reconfigure 2>/dev/null || true; "
+            // BionicMode 切换的是渲染路径，需要重载已加载的玻璃特效才会生效
+            + "for e in glass glass5 glass6 glass7 glass8 glass10; do if qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.isEffectLoaded \"$e\" 2>/dev/null | grep -q true; then qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect \"$e\"; sleep 0.3; qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect \"$e\"; fi; done"
+        console.log("[Material] apply=" + style + " len=" + cmd.length)
+        Quickshell.execDetached(["bash", "-c", cmd])
+        console.log("[Material] apply=" + style)
+        Quickshell.execDetached(["bash", "-c", cmd])
+    }
+
+    function updateBionicRefract(rawValue) {
+        const value = _clampInRange(rawValue, bionicRefractMin, bionicRefractMax)
+        if (!Number.isFinite(value) || Math.abs(bionicRefract - value) <= 0.001)
+            return false
+        bionicRefract = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicEdgeLight(rawValue) {
+        const value = _clampInRange(rawValue, bionicEdgeLightMin, bionicEdgeLightMax)
+        if (!Number.isFinite(value) || Math.abs(bionicEdgeLight - value) <= 0.001)
+            return false
+        bionicEdgeLight = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicSoftEdgePx(rawValue) {
+        const value = _clampInRange(rawValue, bionicSoftEdgePxMin, bionicSoftEdgePxMax)
+        if (!Number.isFinite(value) || Math.abs(bionicSoftEdgePx - value) <= 0.001)
+            return false
+        bionicSoftEdgePx = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicHsvv(rawValue) {
+        const value = _clampInRange(rawValue, bionicHsvvMin, bionicHsvvMax)
+        if (!Number.isFinite(value) || Math.abs(bionicHsvv - value) <= 0.001)
+            return false
+        bionicHsvv = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicRefract(rawValue) {
+        const value = _clampInRange(rawValue, classicRefractMin, classicRefractMax)
+        if (!Number.isFinite(value) || Math.abs(classicRefract - value) <= 0.001)
+            return false
+        classicRefract = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicReflect(rawValue) {
+        const value = _clampInRange(rawValue, classicReflectMin, classicReflectMax)
+        if (!Number.isFinite(value) || Math.abs(classicReflect - value) <= 0.001)
+            return false
+        classicReflect = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicEdgeLight(rawValue) {
+        const value = _clampInRange(rawValue, classicEdgeLightMin, classicEdgeLightMax)
+        if (!Number.isFinite(value) || Math.abs(classicEdgeLight - value) <= 0.001)
+            return false
+        classicEdgeLight = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicSoftEdgePx(rawValue) {
+        const value = _clampInRange(rawValue, classicSoftEdgePxMin, classicSoftEdgePxMax)
+        if (!Number.isFinite(value) || Math.abs(classicSoftEdgePx - value) <= 0.001)
+            return false
+        classicSoftEdgePx = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActDarken(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActDarken - value) <= 0.001)
+            return false
+        bionicActDarken = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActEdgeLight(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 5.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActEdgeLight - value) <= 0.001)
+            return false
+        bionicActEdgeLight = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActOpposite(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 5.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActOpposite - value) <= 0.001)
+            return false
+        bionicActOpposite = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActHsvv(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActHsvv - value) <= 0.001)
+            return false
+        bionicActHsvv = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActRefl(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActRefl - value) <= 0.001)
+            return false
+        bionicActRefl = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActRefract(rawValue) {
+        const value = _clampInRange(rawValue, 1.0, 8.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActRefract - value) <= 0.001)
+            return false
+        bionicActRefract = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicTransparency(rawValue) {
+        const value = _clampInRange(rawValue, bionicTransparencyMin, bionicTransparencyMax)
+        if (!Number.isFinite(value) || Math.abs(bionicTransparency - value) <= 0.001)
+            return false
+        bionicTransparency = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicLum0(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicLum0 - value) <= 0.001)
+            return false
+        bionicLum0 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicLum1(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicLum1 - value) <= 0.001)
+            return false
+        bionicLum1 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicLum2(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicLum2 - value) <= 0.001)
+            return false
+        bionicLum2 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicLum3(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicLum3 - value) <= 0.001)
+            return false
+        bionicLum3 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicLumAmount(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicLumAmount - value) <= 0.001)
+            return false
+        bionicLumAmount = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDarkBase(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDarkBase - value) <= 0.001)
+            return false
+        bionicDarkBase = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDarkRange0(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDarkRange0 - value) <= 0.001)
+            return false
+        bionicDarkRange0 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDarkRange1(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDarkRange1 - value) <= 0.001)
+            return false
+        bionicDarkRange1 = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicBrightBase(rawValue) {
+        const value = _clampInRange(rawValue, -0.2, 0.2)
+        if (!Number.isFinite(value) || Math.abs(bionicBrightBase - value) <= 0.001)
+            return false
+        bionicBrightBase = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicInnerBottom(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicInnerBottom - value) <= 0.001)
+            return false
+        bionicInnerBottom = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicInnerWhite(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicInnerWhite - value) <= 0.001)
+            return false
+        bionicInnerWhite = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicInnerMix(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicInnerMix - value) <= 0.001)
+            return false
+        bionicInnerMix = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicColorPow(rawValue) {
+        const value = _clampInRange(rawValue, 0.05, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicColorPow - value) <= 0.001)
+            return false
+        bionicColorPow = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicAlphaLayer(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicAlphaLayer - value) <= 0.001)
+            return false
+        bionicAlphaLayer = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicShapeEdgePow(rawValue) {
+        const value = _clampInRange(rawValue, 0.5, 10.0)
+        if (!Number.isFinite(value) || Math.abs(bionicShapeEdgePow - value) <= 0.001)
+            return false
+        bionicShapeEdgePow = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicShapeThickness(rawValue) {
+        const value = _clampInRange(rawValue, 10.0, 200.0)
+        if (!Number.isFinite(value) || Math.abs(bionicShapeThickness - value) <= 0.001)
+            return false
+        bionicShapeThickness = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicReflectOffset(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 1600.0)
+        if (!Number.isFinite(value) || Math.abs(bionicReflectOffset - value) <= 0.001)
+            return false
+        bionicReflectOffset = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicReflLighten(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicReflLighten - value) <= 0.001)
+            return false
+        bionicReflLighten = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicReflStrength(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicReflStrength - value) <= 0.001)
+            return false
+        bionicReflStrength = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirX(rawValue) {
+        const value = _clampInRange(rawValue, -1.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirX - value) <= 0.001)
+            return false
+        bionicDirX = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirY(rawValue) {
+        const value = _clampInRange(rawValue, -1.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirY - value) <= 0.001)
+            return false
+        bionicDirY = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirZ(rawValue) {
+        const value = _clampInRange(rawValue, -1.0, 1.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirZ - value) <= 0.001)
+            return false
+        bionicDirZ = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirInt(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 5.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirInt - value) <= 0.001)
+            return false
+        bionicDirInt = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirOpp(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 5.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirOpp - value) <= 0.001)
+            return false
+        bionicDirOpp = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirAngle(rawValue) {
+        const value = _clampInRange(rawValue, 0.05, 3.14)
+        if (!Number.isFinite(value) || Math.abs(bionicDirAngle - value) <= 0.001)
+            return false
+        bionicDirAngle = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicDirEdgePow(rawValue) {
+        const value = _clampInRange(rawValue, 0.1, 5.0)
+        if (!Number.isFinite(value) || Math.abs(bionicDirEdgePow - value) <= 0.001)
+            return false
+        bionicDirEdgePow = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicBgSat(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicBgSat - value) <= 0.001)
+            return false
+        bionicBgSat = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicBgBri(rawValue) {
+        const value = _clampInRange(rawValue, -0.5, 0.5)
+        if (!Number.isFinite(value) || Math.abs(bionicBgBri - value) <= 0.001)
+            return false
+        bionicBgBri = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateBionicActColorPow(rawValue) {
+        const value = _clampInRange(rawValue, 0.05, 3.0)
+        if (!Number.isFinite(value) || Math.abs(bionicActColorPow - value) <= 0.001)
+            return false
+        bionicActColorPow = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicStrokeDegree(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 360.0)
+        if (!Number.isFinite(value) || Math.abs(classicStrokeDegree - value) <= 0.001)
+            return false
+        classicStrokeDegree = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicStrokeSize(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 20.0)
+        if (!Number.isFinite(value) || Math.abs(classicStrokeSize - value) <= 0.001)
+            return false
+        classicStrokeSize = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function updateClassicReflLighten(rawValue) {
+        const value = _clampInRange(rawValue, 0.0, 4.0)
+        if (!Number.isFinite(value) || Math.abs(classicReflLighten - value) <= 0.001)
+            return false
+        classicReflLighten = value
+        saveTimer.restart()
+        materialTuningSyncTimer.restart()
+        return true
+    }
+
+    function resetMaterialTuning() {
+        const changed = Math.abs(bionicRefract - 4.0) > 0.001
+            || Math.abs(bionicEdgeLight - 1.4) > 0.001
+            || Math.abs(bionicSoftEdgePx - 1.5) > 0.001
+            || Math.abs(bionicHsvv - 1.0) > 0.001
+            || Math.abs(classicRefract - 1.5) > 0.001
+            || Math.abs(classicReflect - 0.06) > 0.001
+            || Math.abs(classicEdgeLight - 0.1) > 0.001
+            || Math.abs(classicSoftEdgePx - 1.5) > 0.001
+            || Math.abs(bionicTransparency - 1.0) > 0.001
+            || Math.abs(bionicActDarken - 0.42) > 0.001
+            || Math.abs(bionicActEdgeLight - 3.0) > 0.001
+            || Math.abs(bionicActOpposite - 2.0) > 0.001
+            || Math.abs(bionicActHsvv - 1.6) > 0.001
+            || Math.abs(bionicActRefl - 1.3) > 0.001
+            || Math.abs(bionicActRefract - 4.6) > 0.001
+            || Math.abs(bionicLum0 - (0.67)) > 0.001
+            || Math.abs(bionicLum1 - (0.16)) > 0.001
+            || Math.abs(bionicLum2 - (0.09)) > 0.001
+            || Math.abs(bionicLum3 - (0.0)) > 0.001
+            || Math.abs(bionicLumAmount - (0.24)) > 0.001
+            || Math.abs(bionicDarkBase - (0.3)) > 0.001
+            || Math.abs(bionicDarkRange0 - (0.6)) > 0.001
+            || Math.abs(bionicDarkRange1 - (1.0)) > 0.001
+            || Math.abs(bionicBrightBase - (-0.02)) > 0.001
+            || Math.abs(bionicInnerBottom - (0.03)) > 0.001
+            || Math.abs(bionicInnerWhite - (0.2)) > 0.001
+            || Math.abs(bionicInnerMix - (0.3)) > 0.001
+            || Math.abs(bionicColorPow - (1.0)) > 0.001
+            || Math.abs(bionicAlphaLayer - (0.1)) > 0.001
+            || Math.abs(bionicShapeEdgePow - (3.8)) > 0.001
+            || Math.abs(bionicShapeThickness - (80.0)) > 0.001
+            || Math.abs(bionicReflectOffset - (800.0)) > 0.001
+            || Math.abs(bionicReflLighten - (1.2)) > 0.001
+            || Math.abs(bionicReflStrength - (1.0)) > 0.001
+            || Math.abs(bionicDirX - (-0.4)) > 0.001
+            || Math.abs(bionicDirY - (0.6)) > 0.001
+            || Math.abs(bionicDirZ - (-0.8)) > 0.001
+            || Math.abs(bionicDirInt - (1.4)) > 0.001
+            || Math.abs(bionicDirOpp - (0.7)) > 0.001
+            || Math.abs(bionicDirAngle - (0.8)) > 0.001
+            || Math.abs(bionicDirEdgePow - (1.15)) > 0.001
+            || Math.abs(bionicBgSat - (2.0)) > 0.001
+            || Math.abs(bionicBgBri - (0.0)) > 0.001
+            || Math.abs(bionicActColorPow - (1.0)) > 0.001
+        bionicRefract = 4.0
+        bionicEdgeLight = 1.4
+        bionicSoftEdgePx = 1.5
+        bionicHsvv = 1.0
+        classicRefract = 1.5
+        classicReflect = 0.06
+        classicEdgeLight = 0.1
+        classicSoftEdgePx = 1.5
+        classicStrokeDegree = 24.0
+        classicStrokeSize = 2.0
+        classicReflLighten = 2.0
+        bionicTransparency = 1.0
+        bionicActDarken = 0.42
+        bionicActEdgeLight = 3.0
+        bionicActOpposite = 2.0
+        bionicActHsvv = 1.6
+        bionicActRefl = 1.3
+        bionicActRefract = 4.6
+        bionicLum0 = 0.67
+        bionicLum1 = 0.16
+        bionicLum2 = 0.09
+        bionicLum3 = 0.0
+        bionicLumAmount = 0.24
+        bionicDarkBase = 0.3
+        bionicDarkRange0 = 0.6
+        bionicDarkRange1 = 1.0
+        bionicBrightBase = -0.02
+        bionicInnerBottom = 0.03
+        bionicInnerWhite = 0.2
+        bionicInnerMix = 0.3
+        bionicColorPow = 1.0
+        bionicAlphaLayer = 0.1
+        bionicShapeEdgePow = 3.8
+        bionicShapeThickness = 80.0
+        bionicReflectOffset = 800.0
+        bionicReflLighten = 1.2
+        bionicReflStrength = 1.0
+        bionicDirX = -0.4
+        bionicDirY = 0.6
+        bionicDirZ = -0.8
+        bionicDirInt = 1.4
+        bionicDirOpp = 0.7
+        bionicDirAngle = 0.8
+        bionicDirEdgePow = 1.15
+        bionicBgSat = 2.0
+        bionicBgBri = 0.0
+        bionicActColorPow = 1.0
+        if (changed) {
+            saveTimer.restart()
+            materialTuningSyncTimer.restart()
+        }
+        return changed
+    }
+
+    function _syncMaterialTuning() {
+        let cmd = ""
+        if (service.materialStyle === "bionic") {
+            cmd = "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicIOR -- '" + service.bionicRefract + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirIntensity -- '" + service.bionicEdgeLight + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDirOppositeIntensity -- '" + (service.bionicEdgeLight * 0.5) + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicShapeEdgePx -- '" + (service.bionicSoftEdgePx * 5.0) + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicHsvvBoost -- '" + service.bionicHsvv + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicOverallAlpha -- '" + service.bionicTransparency + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicLumValue0 '" + service.bionicLum0 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicLumValue1 '" + service.bionicLum1 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicLumValue2 '" + service.bionicLum2 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicLumValue3 '" + service.bionicLum3 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicLumAmount -- '" + service.bionicLumAmount + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDarker -- '" + service.bionicDarkBase + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDarkerRange0 '" + service.bionicDarkRange0 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDarkerRange1 '" + service.bionicDarkRange1 + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicBrightness -- '" + service.bionicBrightBase + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicInnerBottom -- '" + service.bionicInnerBottom + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicInnerColorWhite -- '" + service.bionicInnerWhite + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicInnerColorMix -- '" + service.bionicInnerMix + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicColorPow -- '" + service.bionicColorPow + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicAlpha -- '" + service.bionicAlphaLayer + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicShapeEdgePow -- '" + service.bionicShapeEdgePow + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicShapeThicknessPx -- '" + service.bionicShapeThickness + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicShapeReflectOffsetPx -- '" + service.bionicReflectOffset + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicReflLighten -- '" + service.bionicReflLighten + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicReflStrength -- '" + service.bionicReflStrength + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirX -- '" + service.bionicDirX + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirY -- '" + service.bionicDirY + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirZ -- '" + service.bionicDirZ + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirIntensity -- '" + service.bionicDirInt + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirOppositeIntensity -- '" + service.bionicDirOpp + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirAngleRange -- '" + service.bionicDirAngle + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicDirEdgePow -- '" + service.bionicDirEdgePow + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicBgColorSaturation -- '" + service.bionicBgSat + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicBgColorBrightness -- '" + service.bionicBgBri + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedColorPow -- '" + service.bionicActColorPow + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDarker -- '" + service.bionicActDarken + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDirIntensity -- '" + service.bionicActEdgeLight + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedDirOppositeIntensity -- '" + service.bionicActOpposite + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedHsvvBoost -- '" + service.bionicActHsvv + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedReflStrength -- '" + service.bionicActRefl + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key BionicActivatedRefract -- '" + service.bionicActRefract + "'; "
+        } else if (service.materialStyle === "classic") {
+            cmd = "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicRefractIOR -- '" + service.classicRefract + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicReflStrength -- '" + service.classicReflect + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicStrokeStrength -- '" + service.classicEdgeLight + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicMaskSoft -- '" + service.classicSoftEdgePx + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicStrokeDegree -- '" + service.classicStrokeDegree + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicStrokeSize -- '" + service.classicStrokeSize + "'; "
+                + "kwriteconfig6 --file kwinrc --group Effect-blurplus --key ClassicReflLighten -- '" + service.classicReflLighten + "'; "
+        } else {
+            return
+        }
+        cmd += "qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect glass 2>/dev/null || true"
+        Quickshell.execDetached(["bash", "-c", cmd])
+    }
+
+    // 材质微调专用（延迟稍长，避开 _applyKwinGlass 的并行写入）
+    property Timer materialTuningSyncTimer: Timer {
+        interval: 250
+        repeat: false
+        onTriggered: service._syncMaterialTuning()
+    }
+
+    function _materialGlassParams(style) {
+        if (style === "bionic")
+            return { blur: 12, refr: 14 }
+        if (style === "classic")
+            return { blur: 6, refr: 3 }
+        return null
+    }
+
 
     function updateShellStyle(rawStyle) {
         const style = String(rawStyle)
@@ -239,6 +1052,7 @@ QtObject {
 
     function _save() {
         const payload = JSON.stringify({
+            materialStyle: service.materialStyle,
             version: 10,
             globalBlurStrength: service.globalBlurStrength,
             globalLiquidStrength: service.globalLiquidStrength,
@@ -270,6 +1084,23 @@ QtObject {
     }
 
     function _syncGlassEffect() {
+        // 材质模式：强制模式参数，用户滑条不参与
+        const materialParams = service._materialGlassParams(service.materialStyle)
+        if (materialParams) {
+            PlatformClient.request("theme.sync-glass", {
+                contentBlurLevel: materialParams.blur,
+                dockBlurLevel: materialParams.blur,
+                refractionLevel: materialParams.refr,
+            }, function(response) {
+                if (!response?.ok)
+                    console.warn("[AppearanceConfig] Material glass sync failed: "
+                        + (response?.error?.message || "platform unavailable"))
+                else
+                    console.log("[AppearanceConfig] Material glass=" + service.materialStyle
+                        + " blur=" + materialParams.blur + " refr=" + materialParams.refr)
+            })
+            return
+        }
         const dockBlurLevel = service._compositorBlurLevel(
             service.globalBlurStrength)
         const contentBlurLevel = service._compositorBlurLevel(
@@ -341,6 +1172,10 @@ QtObject {
                     }
                     if (service.isValidShellStyle(style))
                         service.shellStyle = style
+                    if (typeof object.materialStyle === "string"
+                            && (object.materialStyle === "liquid" || object.materialStyle === "bionic"
+                                || object.materialStyle === "classic"))
+                        service.materialStyle = object.materialStyle
                     if (service.isValidThemeMode(themeMode))
                         service.themeMode = themeMode
                     if (hasBarIntegration)

--- a/vendor/kwin-effects-glass/src/blur.cpp
+++ b/vendor/kwin-effects-glass/src/blur.cpp
@@ -49,6 +49,7 @@
 #include <QScreen>
 #include <QTime>
 #include <QTimer>
+#include <chrono>
 #include <QWindow>
 #include <algorithm>
 #include <vector>
@@ -148,6 +149,53 @@ BlurEffect::BlurEffect()
         m_roundedOnscreenPass.refractionOffsetStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionOffsetStrength");
         m_roundedOnscreenPass.refractionBevelIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("refractionBevelIntensity");
         m_roundedOnscreenPass.physicallyBasedRefractionLocation = m_roundedOnscreenPass.shader->uniformLocation("physicallyBasedRefraction");
+        m_roundedOnscreenPass.bionicModeLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicMode");
+        m_roundedOnscreenPass.bionicLumValue0Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue0");
+        m_roundedOnscreenPass.bionicLumValue1Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue1");
+        m_roundedOnscreenPass.bionicLumValue2Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue2");
+        m_roundedOnscreenPass.bionicLumValue3Location = m_roundedOnscreenPass.shader->uniformLocation("bionicLumValue3");
+        m_roundedOnscreenPass.bionicLumAmountLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicLumAmount");
+        m_roundedOnscreenPass.bionicBrightnessLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBrightness");
+        m_roundedOnscreenPass.bionicHsvvBoostLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicHsvvBoost");
+        m_roundedOnscreenPass.bionicDarkerLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDarker");
+        m_roundedOnscreenPass.bionicDarkerRange0Location = m_roundedOnscreenPass.shader->uniformLocation("bionicDarkerRange0");
+        m_roundedOnscreenPass.bionicDarkerRange1Location = m_roundedOnscreenPass.shader->uniformLocation("bionicDarkerRange1");
+        m_roundedOnscreenPass.bionicInnerBottomLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerBottom");
+        m_roundedOnscreenPass.bionicInnerColorWhiteLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerColorWhite");
+        m_roundedOnscreenPass.bionicInnerColorMixLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicInnerColorMix");
+        m_roundedOnscreenPass.bionicColorPowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicColorPow");
+        m_roundedOnscreenPass.bionicAlphaLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicAlpha");
+        m_roundedOnscreenPass.bionicOverallAlphaLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicOverallAlpha");
+        m_roundedOnscreenPass.bionicShapeEdgePxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeEdgePx");
+        m_roundedOnscreenPass.bionicShapeEdgePowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeEdgePow");
+        m_roundedOnscreenPass.bionicShapeThicknessPxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeThicknessPx");
+        m_roundedOnscreenPass.bionicShapeReflectOffsetPxLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicShapeReflectOffsetPx");
+        m_roundedOnscreenPass.bionicReflLightenLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicReflLighten");
+        m_roundedOnscreenPass.bionicReflStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicReflStrength");
+        m_roundedOnscreenPass.bionicDirXLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirX");
+        m_roundedOnscreenPass.bionicDirYLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirY");
+        m_roundedOnscreenPass.bionicDirZLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirZ");
+        m_roundedOnscreenPass.bionicDirIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirIntensity");
+        m_roundedOnscreenPass.bionicDirOppositeIntensityLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirOppositeIntensity");
+        m_roundedOnscreenPass.bionicDirAngleRangeLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirAngleRange");
+        m_roundedOnscreenPass.bionicDirEdgePowLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicDirEdgePow");
+        m_roundedOnscreenPass.bionicIORLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicIOR");
+        m_roundedOnscreenPass.bionicFlowTimeLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicFlowTime");
+        m_roundedOnscreenPass.bionicFlowAmpLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicFlowAmp");
+        m_roundedOnscreenPass.bionicBgColorSaturationLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBgColorSaturation");
+        m_roundedOnscreenPass.bionicBgColorBrightnessLocation = m_roundedOnscreenPass.shader->uniformLocation("bionicBgColorBrightness");
+        m_roundedOnscreenPass.classicModeLocation = m_roundedOnscreenPass.shader->uniformLocation("classicMode");
+        m_roundedOnscreenPass.classicDark0Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark0");
+        m_roundedOnscreenPass.classicDark1Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark1");
+        m_roundedOnscreenPass.classicDark2Location = m_roundedOnscreenPass.shader->uniformLocation("classicDark2");
+        m_roundedOnscreenPass.classicLight0Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight0");
+        m_roundedOnscreenPass.classicLight1Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight1");
+        m_roundedOnscreenPass.classicLight2Location = m_roundedOnscreenPass.shader->uniformLocation("classicLight2");
+        m_roundedOnscreenPass.classicStrokeLocation = m_roundedOnscreenPass.shader->uniformLocation("classicStroke");
+        m_roundedOnscreenPass.classicRefractIORLocation = m_roundedOnscreenPass.shader->uniformLocation("classicRefractIOR");
+        m_roundedOnscreenPass.classicReflLightenLocation = m_roundedOnscreenPass.shader->uniformLocation("classicReflLighten");
+        m_roundedOnscreenPass.classicReflStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("classicReflStrength");
+        m_roundedOnscreenPass.classicMaskSoftLocation = m_roundedOnscreenPass.shader->uniformLocation("classicMaskSoft");
         m_roundedOnscreenPass.tintColorLocation = m_roundedOnscreenPass.shader->uniformLocation("tintColor");
         m_roundedOnscreenPass.tintGrayLocation = m_roundedOnscreenPass.shader->uniformLocation("tintGray");
         m_roundedOnscreenPass.tintStrengthLocation = m_roundedOnscreenPass.shader->uniformLocation("tintStrength");
@@ -211,6 +259,24 @@ BlurEffect::BlurEffect()
 
     connect(effects, &EffectsHandler::windowAdded, this, &BlurEffect::slotWindowAdded);
     connect(effects, &EffectsHandler::windowDeleted, this, &BlurEffect::slotWindowDeleted);
+    m_lastCursorPos = effects->cursorPos();
+    connect(effects, &EffectsHandler::mouseChanged, this,
+            [this](const QPointF &pos, const QPointF &oldpos,
+                   Qt::MouseButtons, Qt::MouseButtons,
+                   Qt::KeyboardModifiers, Qt::KeyboardModifiers) {
+                Q_UNUSED(oldpos)
+                m_lastCursorPos = pos;
+                if (!m_settings.bionic.enabled) {
+                    return;
+                }
+                // Repaint only when the cursor can affect a glass surface.
+                for (auto it = m_bionicActivation.constBegin(); it != m_bionicActivation.constEnd(); ++it) {
+                    if (it.key()->frameGeometry().adjusted(-80, -80, 80, 80).contains(pos)) {
+                        effects->addRepaintFull();
+                        break;
+                    }
+                }
+            });
 #ifdef GLASS_X11
     connect(effects, &EffectsHandler::screenRemoved, this, &BlurEffect::slotOutputRemoved);
 #else
@@ -342,18 +408,37 @@ void BlurEffect::initBlurStrengthValues()
 
 void BlurEffect::reconfigure(ReconfigureFlags flags)
 {
+    // KConfig keeps an in-memory copy of the effects config, and
+    // BlurConfig::instance() only ever builds a single KConfigSkeleton bound
+    // to that cached copy. A plain read() therefore returns whatever KWin saw
+    // when it started, so runtime appearance changes written by the shell
+    // (material tuning written by the shell) never reached the shader until
+    // the whole compositor was restarted. Reparse the very config object
+    // BlurConfig is bound to before reading it back.
+    if (auto config = effects->config()) {
+        config->reparseConfiguration();
+    }
     m_settings.read();
 
+    // Bionic (HyperOS soft glass) mode owns the blur budget: the shell's
+    // blur-strength knobs are retired while it is active and a single
+    // BionicBlur value drives every surface.
+    const int bionicBlurPick = m_settings.bionic.enabled
+        ? qBound(0, m_settings.bionic.blur - 1, 14)
+        : -1;
+    const auto pickBlur = [&](int value) {
+        return bionicBlurPick >= 0 ? bionicBlurPick : value;
+    };
     m_contentBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.blurStrength,
+        pickBlur(m_settings.general.blurStrength),
         m_settings.general.noiseStrength
     );
     m_decorationBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.decorationBlurStrength,
+        pickBlur(m_settings.general.decorationBlurStrength),
         m_settings.general.decorationNoiseStrength
     );
     m_dockBlurSettings = pipelineSettingsForStrength(
-        m_settings.general.dockBlurStrength,
+        pickBlur(m_settings.general.dockBlurStrength),
         m_settings.general.dockNoiseStrength
     );
     // AppearanceConfig maps 0..1 to 15 stored levels with
@@ -361,7 +446,7 @@ void BlurEffect::reconfigure(ReconfigureFlags flags)
     // zero-based pipeline index. 15% therefore maps to index 2.
     constexpr int fullScreenLauncherMinimumBlurIndex = 2;
     m_fullScreenLauncherBlurSettings = pipelineSettingsForStrength(
-        std::max(m_settings.general.blurStrength,
+        std::max(pickBlur(m_settings.general.blurStrength),
                  fullScreenLauncherMinimumBlurIndex),
         m_settings.general.noiseStrength
     );
@@ -654,6 +739,7 @@ void BlurEffect::slotWindowDeleted(EffectWindow *w)
         disconnect(*it);
         windowFrameGeometryChangedConnections.erase(it);
     }
+    m_bionicActivation.remove(w);
     repaintDynamicCorners();
 }
 
@@ -1741,6 +1827,110 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionOffsetStrengthLocation, m_settings.refraction.refractionOffsetStrength);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.refractionBevelIntensityLocation, m_settings.refraction.refractionBevelIntensity);
     m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.physicallyBasedRefractionLocation, m_settings.refraction.physicallyBased ? 1 : 0);
+    // Bionic hover activation (native ACTIVATED token): per-window amount.
+    // NOTE: the ACTIVATED colorPow (0.4) is deliberately NOT applied — pow()
+    // lifts the whole surface (0.1 -> 0.4), reading as "the entire card goes
+    // white". Only the local passes (darker / directional pair) animate.
+    // smoothed per frame; the directional set fades between the default and
+    // activated values.
+    float bionicAct = 0.0f;
+    if (m_settings.bionic.enabled) {
+        const bool hover = w->frameGeometry().contains(m_lastCursorPos);
+        const float target = hover ? 1.0f : 0.0f;
+        float &act = m_bionicActivation[w];
+        act += (target - act) * 0.16f;
+        if (std::abs(target - act) < 0.005f) {
+            act = target;
+        }
+        if (act != target) {
+            effects->addRepaint(w->frameGeometry().toAlignedRect());
+        }
+        bionicAct = act;
+    } else {
+        m_bionicActivation.remove(w);
+    }
+    // 液态流动动画：bionic 启用时持续重绘（约 30fps 节流）
+    if (m_settings.bionic.enabled) {
+        static auto s_lastFlowRepaint = std::chrono::steady_clock::now();
+        const auto nowFlow = std::chrono::steady_clock::now();
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(
+                nowFlow - s_lastFlowRepaint).count() >= 33) {
+            s_lastFlowRepaint = nowFlow;
+            effects->addRepaintFull();
+        }
+    }
+    const auto bionicMix = [bionicAct](float base, float active) {
+        return base + (active - base) * bionicAct;
+    };
+
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicModeLocation, m_settings.bionic.enabled ? 1 : 0);
+    {
+        // 液态流动：时间 uniform（秒）
+        static const auto s_flowEpoch = std::chrono::steady_clock::now();
+        const float tSec = std::chrono::duration<float>(
+            std::chrono::steady_clock::now() - s_flowEpoch).count();
+        m_roundedOnscreenPass.shader->setUniform(
+            m_roundedOnscreenPass.bionicFlowTimeLocation, tSec);
+        m_roundedOnscreenPass.shader->setUniform(
+            m_roundedOnscreenPass.bionicFlowAmpLocation,
+            m_settings.bionic.enabled ? 0.008 : 0.0);
+    }
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue0Location, m_settings.bionic.lumValue0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue1Location, m_settings.bionic.lumValue1);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue2Location, m_settings.bionic.lumValue2);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumValue3Location, m_settings.bionic.lumValue3);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicLumAmountLocation, m_settings.bionic.lumAmount);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBrightnessLocation, m_settings.bionic.brightness);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicHsvvBoostLocation, m_settings.bionic.hsvvBoost);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerLocation, bionicMix(m_settings.bionic.darker, m_settings.bionic.darkerActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerRange0Location, m_settings.bionic.darkerRange0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDarkerRange1Location, m_settings.bionic.darkerRange1);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerBottomLocation, m_settings.bionic.innerBottom);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerColorWhiteLocation, m_settings.bionic.innerColorWhite);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicInnerColorMixLocation, m_settings.bionic.innerColorMix);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicColorPowLocation, bionicMix(m_settings.bionic.colorPow, m_settings.bionic.colorPowActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicHsvvBoostLocation, bionicMix(m_settings.bionic.hsvvBoost, m_settings.bionic.hsvvBoostActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicReflStrengthLocation, bionicMix(m_settings.bionic.reflStrength, m_settings.bionic.reflStrengthActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicIORLocation, bionicMix(m_settings.bionic.ior, m_settings.bionic.refractActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicAlphaLocation, m_settings.bionic.alpha);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicOverallAlphaLocation, m_settings.bionic.overallAlpha);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeEdgePxLocation, m_settings.bionic.shapeEdgePx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeEdgePowLocation, m_settings.bionic.shapeEdgePow);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeThicknessPxLocation, m_settings.bionic.shapeThicknessPx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicShapeReflectOffsetPxLocation, m_settings.bionic.shapeReflectOffsetPx);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicReflLightenLocation, m_settings.bionic.reflLighten);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicReflStrengthLocation, m_settings.bionic.reflStrength);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirXLocation, m_settings.bionic.dirX);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirYLocation, m_settings.bionic.dirY);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirZLocation, m_settings.bionic.dirZ);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirIntensityLocation, bionicMix(m_settings.bionic.dirIntensity, m_settings.bionic.dirIntensityActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirOppositeIntensityLocation, bionicMix(m_settings.bionic.dirOppositeIntensity, m_settings.bionic.dirOppositeIntensityActivated));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirAngleRangeLocation, m_settings.bionic.dirAngleRange);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicDirEdgePowLocation, m_settings.bionic.dirEdgePow);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicIORLocation, m_settings.bionic.ior);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBgColorSaturationLocation, m_settings.bionic.bgColorSaturation);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.bionicBgColorBrightnessLocation, m_settings.bionic.bgColorBrightness);
+
+    const auto classicLayer = [](const QString &spec) {
+        const QColor c(spec);
+        const float a = spec.isEmpty() ? 0.0f : static_cast<float>(c.alphaF());
+        return QVector4D(static_cast<float>(c.redF()), static_cast<float>(c.greenF()),
+                         static_cast<float>(c.blueF()), a);
+    };
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicModeLocation, m_settings.classic.enabled ? 1 : 0);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark0Location, classicLayer(m_settings.classic.dark0));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark1Location, classicLayer(m_settings.classic.dark1));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicDark2Location, classicLayer(m_settings.classic.dark2));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight0Location, classicLayer(m_settings.classic.light0));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight1Location, classicLayer(m_settings.classic.light1));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicLight2Location, classicLayer(m_settings.classic.light2));
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicRefractIORLocation, m_settings.classic.refractIOR);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicReflLightenLocation, m_settings.classic.reflLighten);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicReflStrengthLocation, m_settings.classic.reflStrength);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicMaskSoftLocation, m_settings.classic.maskSoft);
+    m_roundedOnscreenPass.shader->setUniform(m_roundedOnscreenPass.classicStrokeLocation,
+        QVector4D(m_settings.classic.strokeSize, m_settings.classic.strokeStrength,
+                  m_settings.classic.strokeDegree, 0.0f));
 
     QColor tint(m_settings.general.tintColor);
     QVector3D tintVec(tint.redF(), tint.greenF(), tint.blueF());

--- a/vendor/kwin-effects-glass/src/blur.h
+++ b/vendor/kwin-effects-glass/src/blur.h
@@ -190,6 +190,55 @@ private:
         int refractionBevelIntensityLocation;
         int physicallyBasedRefractionLocation;
 
+        int bionicModeLocation;
+        int bionicLumValue0Location;
+        int bionicLumValue1Location;
+        int bionicLumValue2Location;
+        int bionicLumValue3Location;
+        int bionicLumAmountLocation;
+        int bionicBrightnessLocation;
+        int bionicHsvvBoostLocation;
+        int bionicDarkerLocation;
+        int bionicDarkerRange0Location;
+        int bionicDarkerRange1Location;
+        int bionicInnerBottomLocation;
+        int bionicInnerColorWhiteLocation;
+        int bionicInnerColorMixLocation;
+        int bionicColorPowLocation;
+        int bionicAlphaLocation;
+        int bionicOverallAlphaLocation;
+        int bionicShapeEdgePxLocation;
+        int bionicShapeEdgePowLocation;
+        int bionicShapeThicknessPxLocation;
+        int bionicShapeReflectOffsetPxLocation;
+        int bionicReflLightenLocation;
+        int bionicReflStrengthLocation;
+        int bionicDirXLocation;
+        int bionicDirYLocation;
+        int bionicDirZLocation;
+        int bionicDirIntensityLocation;
+        int bionicDirOppositeIntensityLocation;
+        int bionicDirAngleRangeLocation;
+        int bionicDirEdgePowLocation;
+        int bionicIORLocation;
+        int bionicFlowTimeLocation;
+        int bionicFlowAmpLocation;
+        int bionicBgColorSaturationLocation;
+        int bionicBgColorBrightnessLocation;
+
+        int classicModeLocation;
+        int classicDark0Location;
+        int classicDark1Location;
+        int classicDark2Location;
+        int classicLight0Location;
+        int classicLight1Location;
+        int classicLight2Location;
+        int classicStrokeLocation;
+        int classicRefractIORLocation;
+        int classicReflLightenLocation;
+        int classicReflStrengthLocation;
+        int classicMaskSoftLocation;
+
         int tintColorLocation;
         int tintGrayLocation;
         int tintStrengthLocation;
@@ -241,6 +290,11 @@ private:
     BlurRegion m_paintedDeviceArea; // keeps track of all painted areas (from bottom to top)
     BlurRegion m_currentDeviceBlur; // keeps track of currently blurred area of the windows (from bottom to top)
     BlurOutput *m_currentOutput = nullptr;
+
+    // Per-window bionic activation amount (0..1), driving the native
+    // ACTIVATED parameter set on hover. Smoothed per frame in blur().
+    QHash<EffectWindow *, float> m_bionicActivation;
+    QPointF m_lastCursorPos;
 
     QMatrix4x4 m_colorMatrix;
     int m_expandSize;

--- a/vendor/kwin-effects-glass/src/blur.kcfg
+++ b/vendor/kwin-effects-glass/src/blur.kcfg
@@ -183,5 +183,170 @@
         <entry name="PhysicallyBasedRefraction" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="BionicMode" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="BionicLumValue0" type="Double">
+            <default>0.67</default>
+        </entry>
+        <entry name="BionicLumValue1" type="Double">
+            <default>0.16</default>
+        </entry>
+        <entry name="BionicLumValue2" type="Double">
+            <default>0.09</default>
+        </entry>
+        <entry name="BionicLumValue3" type="Double">
+            <default>0.0</default>
+        </entry>
+        <entry name="BionicLumAmount" type="Double">
+            <default>0.24</default>
+        </entry>
+        <entry name="BionicBrightness" type="Double">
+            <default>-0.02</default>
+        </entry>
+        <entry name="BionicDarker" type="Double">
+            <default>0.3</default>
+        </entry>
+        <entry name="BionicDarkerRange0" type="Double">
+            <default>0.6</default>
+        </entry>
+        <entry name="BionicDarkerRange1" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicInnerBottom" type="Double">
+            <default>0.03</default>
+        </entry>
+        <entry name="BionicInnerColorWhite" type="Double">
+            <default>0.2</default>
+        </entry>
+        <entry name="BionicInnerColorMix" type="Double">
+            <default>0.3</default>
+        </entry>
+        <entry name="BionicColorPow" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicAlpha" type="Double">
+            <default>0.1</default>
+        </entry>
+        <entry name="BionicOverallAlpha" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicShapeEdgePx" type="Double">
+            <default>7.5</default>
+        </entry>
+        <entry name="BionicHsvvBoost" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicShapeEdgePow" type="Double">
+            <default>3.8</default>
+        </entry>
+        <entry name="BionicShapeThicknessPx" type="Double">
+            <default>80.0</default>
+        </entry>
+        <entry name="BionicShapeReflectOffsetPx" type="Double">
+            <default>800.0</default>
+        </entry>
+        <entry name="BionicReflLighten" type="Double">
+            <default>1.2</default>
+        </entry>
+        <entry name="BionicReflStrength" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicDirX" type="Double">
+            <default>-0.4</default>
+        </entry>
+        <entry name="BionicDirY" type="Double">
+            <default>0.6</default>
+        </entry>
+        <entry name="BionicDirZ" type="Double">
+            <default>-0.8</default>
+        </entry>
+        <entry name="BionicDirIntensity" type="Double">
+            <default>1.4</default>
+        </entry>
+        <entry name="BionicDirOppositeIntensity" type="Double">
+            <default>0.7</default>
+        </entry>
+        <entry name="BionicDirAngleRange" type="Double">
+            <default>0.8</default>
+        </entry>
+        <entry name="BionicDirEdgePow" type="Double">
+            <default>1.15</default>
+        </entry>
+        <entry name="BionicBlur" type="Int">
+            <default>12</default>
+        </entry>
+        <entry name="BionicIOR" type="Double">
+            <default>4.0</default>
+        </entry>
+        <entry name="BionicBgColorSaturation" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="BionicBgColorBrightness" type="Double">
+            <default>0.0</default>
+        </entry>
+        <entry name="BionicActivatedDarker" type="Double">
+            <default>0.42</default>
+        </entry>
+        <entry name="BionicActivatedDirIntensity" type="Double">
+            <default>3.0</default>
+        </entry>
+        <entry name="BionicActivatedDirOppositeIntensity" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="BionicActivatedColorPow" type="Double">
+            <default>1.0</default>
+        </entry>
+        <entry name="BionicActivatedHsvvBoost" type="Double">
+            <default>1.6</default>
+        </entry>
+        <entry name="BionicActivatedReflStrength" type="Double">
+            <default>1.3</default>
+        </entry>
+        <entry name="BionicActivatedRefract" type="Double">
+            <default>4.6</default>
+        </entry>
+        <entry name="ClassicMode" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="ClassicDark0" type="String">
+            <default>#1a000000</default>
+        </entry>
+        <entry name="ClassicDark1" type="String">
+            <default>#66565656</default>
+        </entry>
+        <entry name="ClassicDark2" type="String">
+            <default>#993f3f3f</default>
+        </entry>
+        <entry name="ClassicLight0" type="String">
+            <default>#05000000</default>
+        </entry>
+        <entry name="ClassicLight1" type="String">
+            <default>#14ffffff</default>
+        </entry>
+        <entry name="ClassicLight2" type="String">
+            <default>#0affffff</default>
+        </entry>
+        <entry name="ClassicStrokeSize" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="ClassicStrokeStrength" type="Double">
+            <default>0.1</default>
+        </entry>
+        <entry name="ClassicStrokeDegree" type="Double">
+            <default>24.0</default>
+        </entry>
+        <entry name="ClassicRefractIOR" type="Double">
+            <default>1.5</default>
+        </entry>
+        <entry name="ClassicReflLighten" type="Double">
+            <default>2.0</default>
+        </entry>
+        <entry name="ClassicReflStrength" type="Double">
+            <default>0.06</default>
+        </entry>
+        <entry name="ClassicMaskSoft" type="Double">
+            <default>1.5</default>
+        </entry>
     </group>
 </kcfg>

--- a/vendor/kwin-effects-glass/src/settings.cpp
+++ b/vendor/kwin-effects-glass/src/settings.cpp
@@ -100,6 +100,63 @@ void BlurSettings::read()
     refraction.refractionOffsetStrength = BlurConfig::refractionOffsetStrength() / 2.0;
     refraction.refractionBevelIntensity = BlurConfig::refractionBevelIntensity() / 10.0;
     refraction.physicallyBased = BlurConfig::physicallyBasedRefraction();
+
+    bionic.enabled = BlurConfig::bionicMode();
+    bionic.lumValue0 = BlurConfig::bionicLumValue0();
+    bionic.lumValue1 = BlurConfig::bionicLumValue1();
+    bionic.lumValue2 = BlurConfig::bionicLumValue2();
+    bionic.lumValue3 = BlurConfig::bionicLumValue3();
+    bionic.lumAmount = BlurConfig::bionicLumAmount();
+    bionic.brightness = BlurConfig::bionicBrightness();
+    bionic.darker = BlurConfig::bionicDarker();
+    bionic.darkerRange0 = BlurConfig::bionicDarkerRange0();
+    bionic.darkerRange1 = BlurConfig::bionicDarkerRange1();
+    bionic.innerBottom = BlurConfig::bionicInnerBottom();
+    bionic.innerColorWhite = BlurConfig::bionicInnerColorWhite();
+    bionic.innerColorMix = BlurConfig::bionicInnerColorMix();
+    bionic.colorPow = BlurConfig::bionicColorPow();
+    bionic.alpha = BlurConfig::bionicAlpha();
+    bionic.overallAlpha = BlurConfig::bionicOverallAlpha();
+    bionic.shapeEdgePx = BlurConfig::bionicShapeEdgePx();
+    bionic.shapeEdgePow = BlurConfig::bionicShapeEdgePow();
+    bionic.shapeThicknessPx = BlurConfig::bionicShapeThicknessPx();
+    bionic.shapeReflectOffsetPx = BlurConfig::bionicShapeReflectOffsetPx();
+    bionic.reflLighten = BlurConfig::bionicReflLighten();
+    bionic.reflStrength = BlurConfig::bionicReflStrength();
+    bionic.dirX = BlurConfig::bionicDirX();
+    bionic.dirY = BlurConfig::bionicDirY();
+    bionic.dirZ = BlurConfig::bionicDirZ();
+    bionic.dirIntensity = BlurConfig::bionicDirIntensity();
+    bionic.dirOppositeIntensity = BlurConfig::bionicDirOppositeIntensity();
+    bionic.dirAngleRange = BlurConfig::bionicDirAngleRange();
+    bionic.dirEdgePow = BlurConfig::bionicDirEdgePow();
+    bionic.blur = BlurConfig::bionicBlur();
+    bionic.ior = BlurConfig::bionicIOR();
+    bionic.bgColorSaturation = BlurConfig::bionicBgColorSaturation();
+    bionic.bgColorBrightness = BlurConfig::bionicBgColorBrightness();
+    bionic.hsvvBoost = BlurConfig::bionicHsvvBoost();
+    bionic.darkerActivated = BlurConfig::bionicActivatedDarker();
+    bionic.dirIntensityActivated = BlurConfig::bionicActivatedDirIntensity();
+    bionic.dirOppositeIntensityActivated = BlurConfig::bionicActivatedDirOppositeIntensity();
+    bionic.colorPowActivated = BlurConfig::bionicActivatedColorPow();
+    bionic.hsvvBoostActivated = BlurConfig::bionicActivatedHsvvBoost();
+    bionic.reflStrengthActivated = BlurConfig::bionicActivatedReflStrength();
+    bionic.refractActivated = BlurConfig::bionicActivatedRefract();
+
+    classic.enabled = BlurConfig::classicMode();
+    classic.dark0 = BlurConfig::classicDark0();
+    classic.dark1 = BlurConfig::classicDark1();
+    classic.dark2 = BlurConfig::classicDark2();
+    classic.light0 = BlurConfig::classicLight0();
+    classic.light1 = BlurConfig::classicLight1();
+    classic.light2 = BlurConfig::classicLight2();
+    classic.strokeSize = BlurConfig::classicStrokeSize();
+    classic.strokeStrength = BlurConfig::classicStrokeStrength();
+    classic.strokeDegree = BlurConfig::classicStrokeDegree();
+    classic.refractIOR = BlurConfig::classicRefractIOR();
+    classic.reflLighten = BlurConfig::classicReflLighten();
+    classic.reflStrength = BlurConfig::classicReflStrength();
+    classic.maskSoft = BlurConfig::classicMaskSoft();
 }
 
 }

--- a/vendor/kwin-effects-glass/src/settings.h
+++ b/vendor/kwin-effects-glass/src/settings.h
@@ -88,6 +88,69 @@ struct RefractionSettings
     bool physicallyBased;
 };
 
+struct BionicSettings
+{
+    bool enabled;
+    float lumValue0;
+    float lumValue1;
+    float lumValue2;
+    float lumValue3;
+    float lumAmount;
+    float brightness;
+    float darker;
+    float darkerRange0;
+    float darkerRange1;
+    float innerBottom;
+    float innerColorWhite;
+    float innerColorMix;
+    float colorPow;
+    float alpha;
+    float overallAlpha;
+    float shapeEdgePx;
+    float shapeEdgePow;
+    float shapeThicknessPx;
+    float shapeReflectOffsetPx;
+    float reflLighten;
+    float reflStrength;
+    float dirX;
+    float dirY;
+    float dirZ;
+    float dirIntensity;
+    float dirOppositeIntensity;
+    float dirAngleRange;
+    float dirEdgePow;
+    int blur;
+    float ior;
+    float bgColorSaturation;
+    float bgColorBrightness;
+    float hsvvBoost;
+    float darkerActivated;
+    float dirIntensityActivated;
+    float dirOppositeIntensityActivated;
+    float colorPowActivated;
+    float hsvvBoostActivated;
+    float reflStrengthActivated;
+    float refractActivated;
+};
+
+struct ClassicSettings
+{
+    bool enabled;
+    QString dark0;
+    QString dark1;
+    QString dark2;
+    QString light0;
+    QString light1;
+    QString light2;
+    float strokeSize;
+    float strokeStrength;
+    float strokeDegree;
+    float refractIOR;
+    float reflLighten;
+    float reflStrength;
+    float maskSoft;
+};
+
 class BlurSettings
 {
 public:
@@ -95,6 +158,8 @@ public:
     ForceBlurSettings forceBlur{};
     RoundedCornersSettings roundedCorners{};
     RefractionSettings refraction{};
+    BionicSettings bionic{};
+    ClassicSettings classic{};
 
     void read();
 };

--- a/vendor/kwin-effects-glass/src/shaders/glass.glsl
+++ b/vendor/kwin-effects-glass/src/shaders/glass.glsl
@@ -20,6 +20,65 @@ uniform float refractionOffsetStrength;
 uniform float refractionBevelIntensity;
 uniform int physicallyBasedRefraction;
 
+// ── Bionic light-field (HyperOS 4 soft-glass / MaterialMode$Bionics) ──
+// The 37-float DEFAULT_GLASS_TOKEN recipe from MiBackgroundStyle, now with
+// the field<->value alignment re-verified against three independent
+// sources: the BionicsToken constructor iput sequence, the
+// toBionicsParams() array order, and the sibling GlassToken.create()
+// parameter layout (luminanceValues / darkerRange / inner.color /
+// shape.edge / reflect.lighten / blurBg.*). Consumed by bionicGlass().
+uniform int bionicMode;
+uniform float bionicFlowTime;           // 流动时间（秒）
+uniform float bionicFlowAmp;            // 流动幅度（0=静止）
+uniform float bionicLumValue0;         // luminanceValue0   0.67
+uniform float bionicLumValue1;         // luminanceValue1   0.16
+uniform float bionicLumValue2;         // luminanceValue2   0.09
+uniform float bionicLumValue3;         // luminanceValue3   0.0
+uniform float bionicLumAmount;         // luminanceAmount   0.24
+uniform float bionicBrightness;        // brightness       -0.02
+uniform float bionicHsvvBoost;         // rou guang ti liang qiang du 1.0
+uniform float bionicDarker;            // darker            0.3
+uniform float bionicDarkerRange0;      // darkerRange[0]    0.6
+uniform float bionicDarkerRange1;      // darkerRange[1]    1.0
+uniform float bionicInnerBottom;       // inner.bottom      0.03
+uniform float bionicInnerColorWhite;   // inner.colorWhite  0.2
+uniform float bionicInnerColorMix;     // inner.colorMix    0.3
+uniform float bionicColorPow;          // inner.colorPow    1.0
+uniform float bionicAlpha;             // inner.color alpha 0.1
+uniform float bionicOverallAlpha;      // overallAlpha      1.0
+uniform float bionicShapeEdgePx;       // shape.edge        72.0
+uniform float bionicShapeEdgePow;      // shape.edgePow     3.8
+uniform float bionicShapeThicknessPx;  // shape.thicknessPx 80.0
+uniform float bionicShapeReflectOffsetPx; // shape.reflectOffsetPx 800.0
+uniform float bionicReflLighten;       // reflect.lighten   1.2
+uniform float bionicReflStrength;      // reflect.strength  1.0
+uniform float bionicDirX;              // directionalLight x -0.4
+uniform float bionicDirY;              // directionalLight y  0.6
+uniform float bionicDirZ;              // directionalLight z -0.8
+uniform float bionicDirIntensity;      // directionalLight intensity 1.4
+uniform float bionicDirOppositeIntensity; // oppositeIntensity 0.7
+uniform float bionicDirAngleRange;     // angleRange        0.8
+uniform float bionicDirEdgePow;        // edgePow           1.15
+uniform float bionicIOR;               // refract.ior (visual calibration kept at 1.2)
+uniform float bionicBgColorSaturation; // blurBg.saturation 2.0
+uniform float bionicBgColorBrightness; // blurBg.brightness 0.0
+
+// ── Classic (HyperOS "light frosted glass") ───────────────────────────
+// Model: blur + stacked colour-blend layers + bloom stroke, from the
+// miuix ColorBlendToken / BloomStrokeToken tables (see apply_classic.py).
+uniform int classicMode;
+uniform vec4 classicDark0;    // rgba layer 0 (dark scene)
+uniform vec4 classicDark1;
+uniform vec4 classicDark2;
+uniform vec4 classicLight0;   // rgba layer 0 (light scene)
+uniform vec4 classicLight1;
+uniform vec4 classicLight2;
+uniform vec4 classicStroke;   // x=size(24) y=strength(0.1) z=w unused w unused
+uniform float classicRefractIOR;     // GlassToken$Refract.ior 1.5
+uniform float classicReflLighten;    // GlassToken$Reflect.lighten 2.0
+uniform float classicReflStrength;   // GlassToken$Reflect.strength 0.6
+uniform float classicMaskSoft;       // shape mask feather px (native setMaskBlur 20)
+
 float roundedRectangleDist(vec2 p, vec2 b, vec4 cornerRadius)
 {
     float r = p.x > 0.0
@@ -291,8 +350,274 @@ vec3 applyLiquidGlints(vec3 rgb, vec2 position, vec2 halfBlurSize,
     return rgb;
 }
 
+vec4 bionicGlass(vec4 sum, vec4 cornerRadius)
+{
+    vec2 halfBlurSize = blurSize * 0.5;
+    float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
+
+    vec2 position = uv * blurSize - halfBlurSize.xy;
+    float dist = roundedRectangleDist(position, halfBlurSize, cornerRadius);
+    if (dist >= 0.0) {
+        return sum;
+    }
+
+    // Rim normals (shared by refraction and rim lighting).
+    float minR = min(min(cornerRadius.x, cornerRadius.y), min(cornerRadius.z, cornerRadius.w));
+    float gradRadius = min(minR * 1.5, minHalfSize);
+    vec2 gradient = gradSdRoundedBox(position, halfBlurSize, gradRadius);
+    vec2 n2d = length(gradient) > 1e-5 ? -normalize(gradient) : vec2(0.0, 1.0);
+
+    float interiorDist = -dist;   // 0 at the rim, grows inward
+    const vec3 lumaW = vec3(0.299, 0.587, 0.114);
+
+    // 1) Refraction — IOR-driven gentle lens inside the edge band.
+    //    shapeThicknessPx drives the band width (native thicknessPx, the
+    //    *30 scaling was the value-domain of the previous alignment).
+    float refractAmp = clamp((bionicIOR - 1.0) * 0.15, 0.0, 0.4);
+    float bandW = clamp(bionicShapeThicknessPx * 0.3, 8.0, 60.0);
+    float bandT = 1.0 - clamp(interiorDist / bandW, 0.0, 1.0);
+    float lens = circleMap(bandT);
+    vec2 refrUv = clamp(uv + n2d * (refractAmp * lens), 0.0, 1.0);
+
+    // 1.5) Liquid edge lens — 边缘带内的"液态拉伸"（原生折射域：IOR + edgeScale）：
+    //      在靠近边缘的区域，背景 UV 以边缘权重做缩放变形——模拟液体的
+    //      边缘透镜拉伸感（中心区域不变，避免整体模糊化）。
+    //      edgeScale 系数对齐原生参数（refract 域 = 2.0 时的量级）。
+    // 1.4) Liquid flow — 时间驱动的背景微流动（液态感）
+    if (bionicFlowAmp > 0.0001) {
+        float ft = bionicFlowTime;
+        vec2 flow = vec2(
+            sin(ft * 1.1 + refrUv.y * 7.0),
+            cos(ft * 0.9 + refrUv.x * 7.0));
+        refrUv = clamp(refrUv + flow * bionicFlowAmp, 0.0, 1.0);
+    }
+    {
+        float edgeRefract = clamp((bionicIOR - 1.0) * 0.06, 0.0, 0.24);
+        float edgeLensW = clamp(bionicShapeThicknessPx * 0.5, 6.0, 60.0);
+        float lensT = 1.0 - clamp(interiorDist / edgeLensW, 0.0, 1.0);
+        // 平滑的边缘权重（平方衰减，越靠边越强）
+        float lensW = lensT * lensT;
+        vec2 centered = refrUv - 0.5;
+        refrUv = clamp(0.5 + centered * (1.0 - edgeRefract * lensW), 0.0, 1.0);
+    }
+    vec3 base = texture(texUnit, refrUv).rgb;
+
+    // 2) Backdrop treatment — NATIVE ONLY.
+    //    The single backdrop transform with a native formula is `darker`
+    //    (verbatim from bloom_stroke.sksl):
+    //      mix(col, vec3(0.07874,0.02848,0.09278),
+    //          mix(0., darker, smoothstep(range.x, range.y, luma)))
+    //    Saturation / brightness / luminance-step passes were OUR
+    //    approximations and are removed — the native pipeline owns its own
+    //    chroma & luma handling; we must not double-apply or invent one.
+    const vec3 kBionicDarkTint = vec3(0.07874, 0.02848, 0.09278);
+    float darkW = smoothstep(bionicDarkerRange0, bionicDarkerRange1, dot(base, lumaW));
+    base = mix(base, kBionicDarkTint, mix(0.0, bionicDarker, darkW));
+
+    vec3 rgb = base;
+
+    // 3) Rim lighting — ported from bloom_stroke.sksl (calculateLighting /
+    //    dynamicAdd / processLighting / hsvv).
+    //    IMPORTANT: edgeK (rim-band mask) multiplies rawLight — the native
+    //    processLighting only runs OUTSIDE the inner box; applying the lift
+    //    across the whole surface floods the glass (overexposed + flat).
+    float zR = clamp(bionicShapeThicknessPx * 0.15, 2.5, 12.0);
+    float edgeK = 1.0 - clamp(interiorDist / zR, 0.0, 1.0);
+    vec3 dirL = normalize(vec3(bionicDirX, bionicDirY, bionicDirZ));
+    vec3 n3 = vec3(n2d.x, -n2d.y, sqrt(max(0.0, 1.0 - dot(n2d, n2d))));
+    float ndl1 = max(dot(n3, dirL), 0.0);
+    float light1 = ndl1 * max(1.0 - acos(clamp(ndl1, -1.0, 1.0))
+                    / (3.14159 * max(bionicDirAngleRange, 0.05)), 0.0) * bionicDirIntensity;
+    vec3 dirL2 = dirL * vec3(-1.0, -1.0, 1.0);
+    float ndl2 = max(dot(n3, dirL2), 0.0);
+    float light2 = ndl2 * max(1.0 - acos(clamp(ndl2, -1.0, 1.0))
+                    / (3.14159 * max(bionicDirAngleRange, 0.05)), 0.0) * bionicDirOppositeIntensity;
+
+    // dynamicAdd(color) + rawLight + knee -> lightenParam (verbatim chain,
+    // restricted to the rim band so the interior stays untouched).
+    float whiteDis = distance(vec3(1.0), rgb);
+    whiteDis = smoothstep(0.2, 1.0, whiteDis);
+    whiteDis = mix(0.2, 1.0, whiteDis);
+    float lumin0 = dot(rgb, lumaW);
+    float lightRatio = mix(0.8, whiteDis, lumin0);
+    float rawLight = (light1 + light2) * lightRatio * edgeK;
+    rawLight = pow(clamp(rawLight, 0.0, 1.0), 0.85);
+    float knee = mix(1.0, 0.7, smoothstep(0.0, 0.5, lumin0));
+    float lightenParam = rawLight / (rawLight + knee);
+
+    // hsvv(col, lighten): centre-gain lift (native soft-light)
+    {
+        float v = dot(rgb, lumaW);
+        float w = smoothstep(0.0, 0.5, v);
+        float k = mix(1.0 - v, v, w);
+        float g = 1.0 + smoothstep(0.0, 1.0, lightenParam) * mix(0.75, 0.4, w) * max(bionicHsvvBoost, 0.0);
+        rgb = (rgb + vec3(k)) * g - vec3(k);
+    }
+    // clamp (native renderGlassShape does clamp(col, 0, 1) after colorPow)
+    rgb = clamp(rgb, 0.0, 1.0);
+
+
+    // Reflection pair / inner-surface passes removed — they were OUR
+    // approximations (no native formula available); keeping them made the
+    // material diverge from OS4.
+
+    // 4) colorPow — native `pow(color, uColorPow)` (bloom_stroke.sksl).
+    rgb = pow(max(rgb, vec3(0.0)), vec3(max(bionicColorPow, 0.05)));
+
+    // 5) transparency (BionicOverallAlpha) — glass-layer opacity multiplier:
+    //    lower = more see-through (background shows); no longer darkens rgb.
+    float alphaScale = clamp(bionicOverallAlpha, 0.0, 1.0);
+
+    // 6) shape.edge — soft edge transition width, clamped to 25 as in the
+    //    native renderer. Applied at a reduced scale (0.2) so the Qt-side
+    //    surfaces keep a crisp inner edge.
+    // Soft edge width: edgePx maps to pixels at 1:5 scale, clamped to the
+    // native 25px ceiling (72 -> 14.4px... too soft; 25 -> 5px; 125 -> 25px).
+    float edgeSoft = clamp(bionicShapeEdgePx / 5.0, 0.1, 25.0);
+    float edgeT = clamp(-dist / max(edgeSoft, 0.1), 0.0, 1.0);
+    return vec4(rgb, smoothstep(0.0, 1.0, edgeT) * alphaScale);
+}
+
+// ── HyperOS light-frosted (Classic) render path ───────────────────────
+// Native composition: the three colour layers are composited with the
+// *blend modes* from the miuix ColorBlendToken tables instead of plain
+// alpha stacking (the alpha stack read as a grey film).
+//   Pured_Thin_Glass Dark : [PLUS_DARKER, LUMINOSITY, OVERLAY]
+//   Pured_Thin_Glass Light: [PLUS_DARKER, SOFT_LIGHT, HARD_LIGHT]
+float blendSoftLight(float a, float b)
+{
+    return (1.0 - 2.0 * b) * a * a + 2.0 * b * a;
+}
+vec3 blendSoftLight(vec3 a, vec3 b)
+{
+    return vec3(blendSoftLight(a.r, b.r), blendSoftLight(a.g, b.g), blendSoftLight(a.b, b.b));
+}
+vec3 blendOverlay(vec3 a, vec3 b)
+{
+    return mix(2.0 * a * b, 1.0 - 2.0 * (1.0 - a) * (1.0 - b), step(0.5, a));
+}
+vec3 blendHardLight(vec3 a, vec3 b)
+{
+    return blendOverlay(b, a);
+}
+vec3 blendPlusDarker(vec3 a, vec3 b)
+{
+    return max(vec3(0.0), a + b - 1.0);
+}
+vec3 blendLuminosity(vec3 a, vec3 b)
+{
+    // Keep the backdrop's chroma, take the layer's luminance.
+    float lb = dot(b, vec3(0.299, 0.587, 0.114));
+    float la = dot(a, vec3(0.299, 0.587, 0.114));
+    return clamp(a + (lb - la), 0.0, 1.0);
+}
+
+vec3 classicDarkLayers(vec3 c, vec4 l0, vec4 l1, vec4 l2)
+{
+    c = mix(c, blendPlusDarker(c, l0.rgb), l0.a);
+    c = mix(c, blendLuminosity(c, l1.rgb), l1.a);
+    c = mix(c, blendOverlay(c, l2.rgb), l2.a);
+    return c;
+}
+vec3 classicLightLayers(vec3 c, vec4 l0, vec4 l1, vec4 l2)
+{
+    c = mix(c, blendPlusDarker(c, l0.rgb), l0.a);
+    c = mix(c, blendSoftLight(c, l1.rgb), l1.a);
+    c = mix(c, blendHardLight(c, l2.rgb), l2.a);
+    return c;
+}
+
+vec4 classicGlass(vec4 sum, vec4 cornerRadius)
+{
+    vec2 halfBlurSize = blurSize * 0.5;
+    float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
+
+    vec2 position = uv * blurSize - halfBlurSize.xy;
+    float dist = roundedRectangleDist(position, halfBlurSize, cornerRadius);
+    if (dist >= 0.0) {
+        return sum;
+    }
+
+    float interiorDist = -dist;
+
+    // Rim normal (used by refraction and the bloom-stroke gradient).
+    float minR = min(min(cornerRadius.x, cornerRadius.y), min(cornerRadius.z, cornerRadius.w));
+    float gradRadius = min(minR * 1.5, minHalfSize);
+    vec2 gradient2 = gradSdRoundedBox(position, halfBlurSize, gradRadius);
+    vec2 n2d = length(gradient2) > 1e-5 ? -normalize(gradient2) : vec2(0.0, 1.0);
+
+    // 1) Refraction — GlassToken$Refract.ior (1.5, thin-glass family):
+    //    gentle lens inside the edge band (band ~= shape.thickness 60 * 0.3).
+    float clRefAmp = clamp((classicRefractIOR - 1.0) * 0.15, 0.0, 0.4);
+    float clBandW = 18.0;
+    float clBandT = 1.0 - clamp(interiorDist / clBandW, 0.0, 1.0);
+    float clLens = circleMap(clBandT);
+    vec2 clRefrUv = clamp(uv + n2d * (clRefAmp * clLens), 0.0, 1.0);
+    vec3 base = texture(texUnit, clRefrUv).rgb;
+
+    // Scene-dependent layer stack (dark scene vs light scene).
+    float bgLum = dot(base, vec3(0.299, 0.587, 0.114));
+    vec3 darkSide = classicDarkLayers(base, classicDark0, classicDark1, classicDark2);
+    vec3 lightSide = classicLightLayers(base, classicLight0, classicLight1, classicLight2);
+    vec3 rgb = mix(darkSide, lightSide, smoothstep(0.25, 0.55, bgLum));
+
+    // ── Bloom stroke (Glass_Stroke_Middle_Light / _Dark, native recipe) ──
+    //   line: width 0.8dp (~2px), colour white @ 10%, 24-degree gradient.
+    //   The previous build mistook the gradient angle (24) for the width,
+    //   which painted a 24px white band -> the halo.
+    float strokePx = max(classicStroke.x, 0.5);
+    float lineT = 1.0 - clamp(interiorDist / strokePx, 0.0, 1.0);
+    float line = lineT * lineT;                       // crisp, thin falloff
+    float gradA = radians(classicStroke.z);
+    vec2 gradDir = normalize(vec2(cos(gradA), -sin(gradA)));
+    float gradFace = 0.5 + 0.5 * dot(-n2d, gradDir);  // 0..1 along rim
+    float grad = mix(0.35, 1.0, gradFace);
+    rgb += vec3(1.0) * line * grad * classicStroke.y;
+
+    // ── Double light sources (BloomStrokeToken native values) ───────────
+    // Light preset:  src1 rgb(1.0,0.5,0.7) a0.8 @(0.2,0.5,0)
+    //                src2 rgb(1,1,1)      a0.3 @(0,1,1)
+    // Dark preset:   src1 rgb(1.0,0.4,0.7) a0.8
+    //                src2 rgb(1,1,1)      a0.2
+    // Scene blend mirrors the colour-layer stack above; positions are the
+    // native XY (screen y down), raking the stroke from the upper side.
+    float srcScene = smoothstep(0.25, 0.55, bgLum);
+    vec3 src1Col = mix(vec3(1.0, 0.4, 0.7), vec3(1.0, 0.5, 0.7), srcScene);
+    float src1A = 0.8;
+    vec3 src2Col = vec3(1.0);
+    float src2A = mix(0.2, 0.3, srcScene);
+    vec2 src1Dir = normalize(vec2(0.2, -0.5));   // native position (0.2, 0.5)
+    vec2 src2Dir = normalize(vec2(0.0, -1.0));   // native position (0.0, 1.0)
+    float beam1 = pow(clamp(dot(-n2d, src1Dir), 0.0, 1.0), 2.0);
+    float beam2 = pow(clamp(dot(-n2d, src2Dir), 0.0, 1.0), 2.0);
+    rgb += (src1Col * (beam1 * src1A) + src2Col * (beam2 * src2A)) * line * 0.35;
+
+    // 2) Reflection — GlassToken$Reflect (lighten 2.0 / strength 0.6):
+    //    the rim brightens where it faces the light.
+    float clFace = max(n2d.y, 0.0) + max(-n2d.y, 0.0) * 0.35;
+    // Gate the reflection to the stroke band: n2d is only meaningful near the
+    // rim; in the flat interior it carries SDF-gradient quantization that the
+    // ×lighten boost amplified into raster lines.
+    float clReflK = clamp(clFace * classicReflStrength * 0.24, 0.0, 1.0) * line;
+    rgb = mix(rgb, rgb * max(classicReflLighten, 0.0), clReflK);
+
+    // ── maskBlur (native setMaskBlur(0x14 = 20)): feather the shape mask ─
+    float maskSoft = max(classicMaskSoft, 0.1);
+    float maskT = clamp(-dist / maskSoft, 0.0, 1.0);
+    return vec4(rgb, smoothstep(0.0, 1.0, maskT));
+}
+
 vec4 glass(vec4 sum, vec4 cornerRadius)
 {
+    if (bionicMode == 1) {
+        // Soft glass (HyperOS): fully independent of the KOS material.
+        return bionicGlass(sum, cornerRadius);
+    }
+    if (classicMode == 1) {
+        // Light frosted (HyperOS Classic): blur + colour layers + stroke.
+        return classicGlass(sum, cornerRadius);
+    }
+
     vec2 halfBlurSize = blurSize * 0.5;
     float minHalfSize = min(halfBlurSize.x, halfBlurSize.y);
 


### PR DESCRIPTION
## 新增内容

在最新 main 基础上新增两套玻璃材质风格（来自澎湃OS 4 的材质设计参考）：

- **柔光玻璃**：高通透、带边缘光与光影流动效果
- **轻透磨砂**：经典磨砂质感、沉稳内敛

### 设置选项（外观页）

- **材质风格**三选一：液态玻璃 / 柔光玻璃 / 轻透磨砂
  - Material Design 界面形态下自动隐藏该区域（该形态下玻璃参数不生效）
- **材质微调**（各材质独立生效）：
  - 柔光玻璃：折射强度、边缘光、柔光强度、边缘软边、透明度
  - 轻透磨砂：折射、反射、边缘光、边缘软边
  - 液态玻璃：模糊强度、液态强度

### 说明

- **液态玻璃的渲染与行为保持主线原样**
- 材质切换通过 KWin 玻璃特效的 BionicMode/ClassicMode 渲染路径实现
- 切回液态时完整恢复用户滑条值（模糊/折射/透明 tint）
- 改动文件：
  - `vendor/kwin-effects-glass/`：材质渲染
  - `apps/settings/`：设置界面与桥接
  - `shell/desktop/`：配置服务

### 测试

- 三种材质切换正常（1 秒内生效）
- 各微调实时写入 KWin 配置
- Material Design 形态下材质区自动隐藏
