### PR TITLE
fix(dock): adapt running dot indicator to dark and light themes

### DIFF
--- a/shared/qml/test_visual_contract.mjs
+++ b/shared/qml/test_visual_contract.mjs
@@ -81,13 +81,19 @@ for (const mode of ["dark", "light"]) {
     const primary = rgbaProperty(shellThemeSource, `${mode}Fg`);
     const secondary = rgbaProperty(shellThemeSource, `${mode}SecondaryFg`);
     const tertiary = rgbaProperty(shellThemeSource, `${mode}TertiaryFg`);
+    const indicator = rgbaProperty(shellThemeSource, `${mode}Indicator`);
     assert.ok(contrast(primary, background) >= 7,
         `${mode} primary shell text reaches enhanced contrast`);
     assert.ok(contrast(composite(secondary, background), background) >= 4.5,
         `${mode} secondary shell text reaches AA contrast`);
     assert.ok(contrast(composite(tertiary, background), background) >= 4.5,
         `${mode} tertiary shell text remains readable at small sizes`);
+    assert.ok(contrast(composite(indicator, background), background) >= 4.5,
+        `${mode} dock indicator reaches AA contrast against dock background`);
 }
+const dockIconSource = read("../../shell/desktop/modules/dock/DockIcon.qml");
+assert.match(dockIconSource, /color:\s*ThemeService\.indicatorColor/,
+    "dock running dots adapt dynamically to theme indicator color");
 const glassTextSource = read("../../shell/desktop/modules/common/GlassText.qml");
 assert.match(glassTextSource,
     /inkLuminance[\s\S]*styleColor:[\s\S]*inkLuminance\s*>=\s*0\.55/,

--- a/shell/desktop/modules/dock/DockIcon.qml
+++ b/shell/desktop/modules/dock/DockIcon.qml
@@ -599,7 +599,11 @@ Item {
                     width: runningIndicator.dotSize
                     height: width
                     radius: width / 2
-                    color: Qt.rgba(1, 1, 1, 0.95)
+                    color: ThemeService.indicatorColor
+
+                    Behavior on color {
+                        ColorAnimation { duration: 150; easing.type: Easing.OutCubic }
+                    }
                 }
             }
         }
@@ -609,6 +613,10 @@ Item {
             visible: !icon.dotIndicator
             radius: width / 2
             color: ThemeService.accentColor
+
+            Behavior on color {
+                ColorAnimation { duration: 150; easing.type: Easing.OutCubic }
+            }
         }
     }
 

--- a/shell/desktop/modules/dock/DockThemeService.qml
+++ b/shell/desktop/modules/dock/DockThemeService.qml
@@ -28,7 +28,7 @@ QtObject {
     readonly property color darkAccent: Qt.rgba(0.20, 0.60, 1.0, 1.0)
     readonly property color darkDivider: Qt.rgba(1.0, 1.0, 1.0, 0.18)
     readonly property color darkTooltipBg: Qt.rgba(0.18, 0.18, 0.20, 0.95)
-    readonly property color darkIndicator: Qt.rgba(0.20, 0.60, 1.0, 0.85)
+    readonly property color darkIndicator: Qt.rgba(0.985, 0.990, 1.000, 0.90)
     readonly property color darkBorder: Qt.rgba(1.0, 1.0, 1.0, 0.16)
     readonly property color darkHighlight: Qt.rgba(1.0, 1.0, 1.0, 0.28)
 
@@ -42,7 +42,7 @@ QtObject {
     readonly property color lightAccent: Qt.rgba(0.0, 0.50, 0.90, 1.0)
     readonly property color lightDivider: Qt.rgba(0.055, 0.065, 0.085, 0.16)
     readonly property color lightTooltipBg: Qt.rgba(0.92, 0.92, 0.94, 0.95)
-    readonly property color lightIndicator: Qt.rgba(0.0, 0.50, 0.90, 0.75)
+    readonly property color lightIndicator: Qt.rgba(0.055, 0.065, 0.085, 0.85)
     readonly property color lightBorder: Qt.rgba(0.055, 0.065, 0.085, 0.14)
     readonly property color lightHighlight: Qt.rgba(1.0, 1.0, 1.0, 0.55)
 


### PR DESCRIPTION
### 变更说明

- **问题**：在浅色模式下，Dock 图标下方运行中/激活状态的小圆点被硬编码为白色（`Qt.rgba(1, 1, 1, 0.95)`），导致浅色半透明背景与白色点缺乏对比度，无法清晰辨别窗口运行状态。
- **改动**：
  1. 在 `DockThemeService.qml` 中将 `darkIndicator` 与 `lightIndicator` 规范为与深/浅色墨水层次一致的高对比色（深色模式为白墨 `rgba(0.985, 0.990, 1.0, 0.90)`，浅色模式为深黑墨 `rgba(0.055, 0.065, 0.085, 0.85)`），均超过 11:1 对比度（远超 AA / AAA 标准）。
  2. 将 `DockIcon.qml` 中小圆点颜色绑定至 `ThemeService.indicatorColor`，并增加 `Behavior on color` 平滑颜色过渡。
  3. 在 `shared/qml/test_visual_contract.mjs` 视觉契约测试中加入深浅色 Dock 指示器对比度断言与 QML 属性绑定断言。