### PR TITLE
fix(kwin): 修复 CSD / Electron 窗口在水滴动画中的向下跳变缺陷

### DIFF
--- a/integrations/kwin/dock-window-animation/dockwindowanimationeffect.cpp
+++ b/integrations/kwin/dock-window-animation/dockwindowanimationeffect.cpp
@@ -435,6 +435,20 @@ void DockWindowAnimationEffect::startAnimation(EffectWindow *window,
     }
     animation.target = target;
     animation.transition = transition;
+    // 固化记录 CSD 阴影缓冲区相对偏移量（用于 Wayland 客户端最小化几何补偿）
+    if (m_csdOffsets.contains(window)) {
+        animation.csdOffset = m_csdOffsets.value(window);
+    } else if (window && !window->isMinimized()) {
+        const QRectF frame = window->frameGeometry();
+        const QRectF buffer = window->bufferGeometry();
+        if (frame.isValid() && buffer.isValid()) {
+            const QPointF offset = buffer.topLeft() - frame.topLeft();
+            if (offset.x() < -1.0 || offset.y() < -1.0) {
+                animation.csdOffset = offset;
+                m_csdOffsets.insert(window, offset);
+            }
+        }
+    }
 
     QString action;
     switch (transition) {
@@ -469,7 +483,8 @@ void DockWindowAnimationEffect::startAnimation(EffectWindow *window,
     qCInfo(KWIN_KOS_DOCK_ANIMATION)
         << action << target.appId
         << "window" << window->internalId()
-        << "from/to Dock rect" << target.geometry;
+        << "from/to Dock rect" << target.geometry
+        << "csdOffset" << animation.csdOffset;
 
     redirect(window);
     effects->addRepaintFull();
@@ -484,19 +499,24 @@ void DockWindowAnimationEffect::drawWindow(
 
     if (it != m_animations.end()
         && it->transition != Transition::Open) {
-        // Cover the real-surface/offscreen-texture seam at progress zero.
-        // This is exactly where minimize begins and restore finishes. Keep a
-        // normally painted copy underneath for about 40ms so a late client
-        // buffer or first redirected snapshot cannot expose the wallpaper.
-        // The redirected copy is still painted below and remains fully opaque;
-        // this is not an opacity animation.
-        const int duration = it->transition == Transition::Minimize
-            ? m_minimizeDuration : m_restoreDuration;
-        const qreal seamSpan = std::clamp(40.0 / duration, 0.0, 1.0);
-        if (it->timeLine.value() <= seamSpan) {
-            WindowPaintData backingData = data;
-            effects->drawWindow(renderTarget, viewport, window, mask,
-                                deviceRegion, backingData);
+        // 对于存在 CSD 阴影缓冲区跳变的窗口，若其底层缓冲区在最小化瞬间已发生重置，
+        // 绘制底层未重定向表面会透出向下偏移的未补偿画面；因此带有 CSD 偏移的窗口直接跳过底层绘制
+        const bool hasCsdJump = (it->csdOffset.x() < -1.0 || it->csdOffset.y() < -1.0);
+        if (!hasCsdJump) {
+            // Cover the real-surface/offscreen-texture seam at progress zero.
+            // This is exactly where minimize begins and restore finishes. Keep a
+            // normally painted copy underneath for about 40ms so a late client
+            // buffer or first redirected snapshot cannot expose the wallpaper.
+            // The redirected copy is still painted below and remains fully opaque;
+            // this is not an opacity animation.
+            const int duration = it->transition == Transition::Minimize
+                ? m_minimizeDuration : m_restoreDuration;
+            const qreal seamSpan = std::clamp(40.0 / duration, 0.0, 1.0);
+            if (it->timeLine.value() <= seamSpan) {
+                WindowPaintData backingData = data;
+                effects->drawWindow(renderTarget, viewport, window, mask,
+                                    deviceRegion, backingData);
+            }
         }
     }
 
@@ -628,6 +648,21 @@ void DockWindowAnimationEffect::apply(EffectWindow *window, int mask,
     const auto it = m_animations.constFind(window);
     if (it == m_animations.cend())
         return;
+
+    // 补偿 Wayland 下 Electron/CSD 窗口因最小化导致阴影缓冲区原点重置丢失的偏移量
+    // 当检测到网格原点因最小化退场而退化为 (0, 0) 时，通过加上 csdOffset 还原真实的物理对齐原点
+    if (!quads.isEmpty() && (it->csdOffset.x() < -1.0 || it->csdOffset.y() < -1.0)) {
+        const QPointF currentTopLeft(quads[0][0].x(), quads[0][0].y());
+        if (std::abs(currentTopLeft.x()) < 2.0 && std::abs(currentTopLeft.y()) < 2.0) {
+            for (WindowQuad &quad : quads) {
+                for (int i = 0; i < 4; ++i) {
+                    quad[i].setX(quad[i].x() + it->csdOffset.x());
+                    quad[i].setY(quad[i].y() + it->csdOffset.y());
+                }
+            }
+        }
+    }
+
     // The window remains the only flying texture and simply disappears on
     // the final approach. Restore/open run the same curve in reverse.
     const qreal fadeProgress = smoothStep(
@@ -724,6 +759,26 @@ void DockWindowAnimationEffect::watchWindow(EffectWindow *window)
     connect(window, &EffectWindow::minimizedChanged,
             this, &DockWindowAnimationEffect::handleMinimizedChanged,
             Qt::UniqueConnection);
+    // Qt6 中 Lambda 仿函数不支持 Qt::UniqueConnection（会导致断言崩溃），指定上下文 this 已具备安全性
+    connect(window, &EffectWindow::windowFrameGeometryChanged,
+            this, [this, window]() {
+                updateWindowGeometryTracking(window);
+            });
+    updateWindowGeometryTracking(window);
+}
+
+void DockWindowAnimationEffect::updateWindowGeometryTracking(EffectWindow *window)
+{
+    if (!window || window->isMinimized())
+        return;
+    const QRectF frame = window->frameGeometry();
+    const QRectF buffer = window->bufferGeometry();
+    if (frame.isValid() && buffer.isValid() && frame.width() > 1 && frame.height() > 1) {
+        const QPointF offset = buffer.topLeft() - frame.topLeft();
+        if (offset.x() < -1.0 || offset.y() < -1.0) {
+            m_csdOffsets.insert(window, offset);
+        }
+    }
 }
 
 void DockWindowAnimationEffect::tryStartTicketedOpenAnimation(
@@ -767,6 +822,7 @@ void DockWindowAnimationEffect::handleMinimizedChanged(EffectWindow *window)
 
 void DockWindowAnimationEffect::handleWindowDeleted(EffectWindow *window)
 {
+    m_csdOffsets.remove(window);
     m_animations.remove(window);
     m_claimedRoles.remove(window);
 }

--- a/integrations/kwin/dock-window-animation/dockwindowanimationeffect.h
+++ b/integrations/kwin/dock-window-animation/dockwindowanimationeffect.h
@@ -83,6 +83,8 @@ private:
         TimeLine timeLine;
         Target target;
         Transition transition = Transition::Minimize;
+        // CSD 客户端自绘阴影缓冲区相对于窗口 frameGeometry 的物理偏移量
+        QPointF csdOffset = QPointF(0, 0);
     };
 
     struct PendingLaunch {
@@ -93,6 +95,7 @@ private:
 
     void handleWindowAdded(EffectWindow *window);
     void watchWindow(EffectWindow *window);
+    void updateWindowGeometryTracking(EffectWindow *window);
     void tryStartTicketedOpenAnimation(EffectWindow *window,
                                        int remainingAttempts);
     void handleMinimizedChanged(EffectWindow *window);
@@ -117,6 +120,8 @@ private:
     QList<PendingLaunch> m_pendingLaunches;
     QHash<EffectWindow *, WindowAnimation> m_animations;
     QHash<EffectWindow *, int> m_claimedRoles;
+    // 跟踪各窗口在未最小化状态下的真实 CSD 阴影缓冲区偏移量
+    QHash<EffectWindow *, QPointF> m_csdOffsets;
 
     int m_openDuration = 300;
     int m_minimizeDuration = 300;


### PR DESCRIPTION
### 📌 Summary / 概述
- **EN**: This PR resolves a visual jump glitch where windows using Client-Side Decorations (CSD, e.g. VS Code, Obsidian, and various Electron/GTK Wayland apps) jump downward by the shadow margin offset before shrinking into the dock during minimization.
- **ZH**: 本 PR 修复了在 Wayland 环境下，使用客户端自绘装饰（CSD，如 VS Code、Obsidian 等各类 Electron/GTK 应用）的窗口在执行最小化水滴动画时，会先因阴影外扩偏移坍塌而突兀“向下跳变再收缩”的视觉缺陷。

---

### 🔍 Root Cause Analysis / 根因分析
- **EN**: Under Wayland, CSD clients allocate an expanded buffer with transparent shadow margins (typically ~39px) and declare logical geometry via `xdg_surface.set_window_geometry`. When minimized, the viewport surface offset can reset, causing offscreen quads in KWin effects to momentarily drift from the genuine client origin.
- **ZH**: 在 Wayland 协议下，使用客户端自绘边框（CSD）的应用分配了包含透明阴影边缘的缓冲区，并通过 `set_window_geometry` 声明逻辑窗口。当窗口最小化时，视口边缘计算发生坍塌重置，导致离屏渲染四边形网格在首帧出现坐标跳变。

---

### 🛠 Solution / 解决方案
- **Real-time Viewport Tracking**: Dynamically track and cache genuine `csdOffset = buffer.topLeft() - frame.topLeft()` in `m_csdOffsets`.
- **Animation Lifecycle Solidification**: Solidify genuine `csdOffset` at `startAnimation` to prevent geometry collapse during animation timeline.
- **Mesh & Viewport Alignment**: Compensate target quad vertices during paint pass, ensuring completely smooth fluid dock motion.

---

### 🧪 Verification & Testing / 测试与验证
- [x] **Electron / CSD Apps (VS Code, Obsidian, etc.)**: Verified smooth minimization into dock with zero downward jump;
- [x] **Server-Side Decorated (SSD) Apps (Kate, Dolphin, Konsole)**: Verified zero regression for classic desktop windows;
- [x] **Maximized & Fullscreen Windows**: Smooth transitions and correct quad mapping retained;
- [x] **Multi-monitor Setup**: Verified across mixed DPI and multi-display environments.
